### PR TITLE
feat(apollo): [Data Collection 7] Apply incoming response body policy

### DIFF
--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
@@ -394,7 +394,9 @@ constructor(
           response.body?.buffer?.size?.ifHasValidLength { contentLength ->
             bodySize = contentLength
           }
-          data = body
+          if (scopes.options.dataCollectionResolver.isIncomingResponseBody) {
+            data = body
+          }
         }
 
       fingerprints.add(response.statusCode.toString())

--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
@@ -361,6 +361,26 @@ class SentryApollo3InterceptorClientErrors {
   }
 
   @Test
+  fun `data collection can disable incoming response body`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpBodies = emptySet()
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          val response = it.contexts.response!!
+          assertEquals(200, response.statusCode)
+          assertEquals(200, response.bodySize)
+          assertNull(response.data)
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `capture errors with more response context if sendDefaultPii is enabled`() {
     val sut = fixture.getSut(responseBody = fixture.responseBodyNotOk, sendDefaultPii = true)
     executeQuery(sut)

--- a/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
+++ b/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
@@ -393,7 +393,9 @@ constructor(
           response.body?.buffer?.size?.ifHasValidLength { contentLength ->
             bodySize = contentLength
           }
-          data = body
+          if (scopes.options.dataCollectionResolver.isIncomingResponseBody) {
+            data = body
+          }
         }
 
       fingerprints.add(response.statusCode.toString())

--- a/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
+++ b/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
@@ -374,6 +374,26 @@ abstract class SentryApollo4BuilderExtensionsClientErrorsTest(
   }
 
   @Test
+  fun `data collection can disable incoming response body`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpBodies = emptySet()
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          val response = it.contexts.response!!
+          assertEquals(200, response.statusCode)
+          assertEquals(200, response.bodySize)
+          assertNull(response.data)
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `capture errors with more response context if sendDefaultPii is enabled`() {
     val sut = fixture.getSut(responseBody = fixture.responseBodyNotOk, sendDefaultPii = true)
     executeQuery(sut)


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Apply the incoming response body policy to Apollo 3 and Apollo 4 failed GraphQL events.

When disabled, response body content is omitted while status code and body size remain attached. Existing always-collect behavior remains unchanged when Data Collection is absent.

## :bulb: Motivation and Context

Apollo operates as an HTTP client, so received GraphQL response content maps to the incoming response body direction and should be independently configurable.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- Apollo 3 and Apollo 4 failed-request tests

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Apply outgoing request and server response body policies.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
