### PR TITLE
feat(apollo): [Data Collection 8] Apply outgoing request body policy

### DIFF
--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
@@ -365,16 +365,18 @@ constructor(
           request.body?.let {
             bodySize = it.contentLength
 
-            val buffer = Buffer()
+            if (scopes.options.dataCollectionResolver.isOutgoingRequestBody) {
+              val buffer = Buffer()
 
-            try {
-              it.writeTo(buffer)
-              data = GraphqlUtils.filterRequestBody(buffer.readUtf8(), scopes.options)
-            } catch (e: Throwable) {
-              scopes.options.logger.log(SentryLevel.ERROR, "Error reading the request body.", e)
-              // continue because the response body alone can already give some insights
-            } finally {
-              buffer.close()
+              try {
+                it.writeTo(buffer)
+                data = GraphqlUtils.filterRequestBody(buffer.readUtf8(), scopes.options)
+              } catch (e: Throwable) {
+                scopes.options.logger.log(SentryLevel.ERROR, "Error reading the request body.", e)
+                // continue because the response body alone can already give some insights
+              } finally {
+                buffer.close()
+              }
             }
           }
         }

--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.exception.ApolloException
 import io.sentry.Hint
+import io.sentry.HttpBodyType
 import io.sentry.IScopes
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
@@ -263,6 +264,24 @@ class SentryApollo3InterceptorClientErrors {
           assertEquals(body, request.data)
           assertNull(request.cookies)
           assertNull(request.headers)
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable outgoing request body`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpBodies = setOf(HttpBodyType.INCOMING_RESPONSE)
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals(193L, it.request!!.bodySize)
+          assertNull(it.request!!.data)
         },
         any<Hint>(),
       )

--- a/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
+++ b/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
@@ -364,16 +364,18 @@ constructor(
           request.body?.let {
             bodySize = it.contentLength
 
-            val buffer = Buffer()
+            if (scopes.options.dataCollectionResolver.isOutgoingRequestBody) {
+              val buffer = Buffer()
 
-            try {
-              it.writeTo(buffer)
-              data = GraphqlUtils.filterRequestBody(buffer.readUtf8(), scopes.options)
-            } catch (e: Throwable) {
-              scopes.options.logger.log(SentryLevel.ERROR, "Error reading the request body.", e)
-              // continue because the response body alone can already give some insights
-            } finally {
-              buffer.close()
+              try {
+                it.writeTo(buffer)
+                data = GraphqlUtils.filterRequestBody(buffer.readUtf8(), scopes.options)
+              } catch (e: Throwable) {
+                scopes.options.logger.log(SentryLevel.ERROR, "Error reading the request body.", e)
+                // continue because the response body alone can already give some insights
+              } finally {
+                buffer.close()
+              }
             }
           }
         }

--- a/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
+++ b/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.http.HttpRequest
 import com.apollographql.apollo.api.http.HttpResponse
 import com.apollographql.apollo.exception.ApolloException
 import io.sentry.Hint
+import io.sentry.HttpBodyType
 import io.sentry.IScopes
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
@@ -277,6 +278,24 @@ abstract class SentryApollo4BuilderExtensionsClientErrorsTest(
           assertEquals(body, request.data)
           assertNull(request.cookies)
           assertNull(request.headers)
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable outgoing request body`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpBodies = setOf(HttpBodyType.INCOMING_RESPONSE)
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals(193L, it.request!!.bodySize)
+          assertNull(it.request!!.data)
         },
         any<Hint>(),
       )


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Apply the outgoing request body policy to Apollo 3 and Apollo 4 failed GraphQL events.

When body collection is enabled, GraphQL document and variable policies continue to filter their respective fields. Disabling body content retains request body size and other technical metadata. Existing always-collect behavior remains unchanged when Data Collection is absent.

## :bulb: Motivation and Context

Apollo’s serialized GraphQL request is outgoing HTTP body content and must honor both its directional body policy and its structured GraphQL controls.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- Apollo 3 and Apollo 4 failed-request tests

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Apply the outgoing server response body policy and HTTP header policies.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
