### PR TITLE
feat(graphql): [Data Collection 9] Apply outgoing response body policy

### DIFF
--- a/sentry-graphql-core/src/main/java/io/sentry/graphql/ExceptionReporter.java
+++ b/sentry-graphql-core/src/main/java/io/sentry/graphql/ExceptionReporter.java
@@ -62,9 +62,10 @@ public final class ExceptionReporter {
   }
 
   private boolean isAllowedToAttachResponseBody(final @NotNull IScopes scopes) {
-    final @NotNull SentryOptions options = scopes.getOptions();
-    return options.isSendDefaultPii()
-        && !SentryOptions.RequestSize.NONE.equals(options.getMaxRequestBodySize());
+    return scopes
+        .getOptions()
+        .getDataCollectionResolver()
+        .isOutgoingResponseBodyWithLegacyBodyGate();
   }
 
   private void setRequestDetailsOnEvent(

--- a/sentry-graphql-core/src/test/kotlin/io/sentry/graphql/ExceptionReporterTest.kt
+++ b/sentry-graphql-core/src/test/kotlin/io/sentry/graphql/ExceptionReporterTest.kt
@@ -12,6 +12,7 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLSchema
 import io.sentry.Hint
+import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.KeyValueCollectionBehavior
@@ -249,6 +250,124 @@ class ExceptionReporterTest {
           assertEquals(fixture.query, data["query"])
           assertEquals(fixture.variables, data["variables"])
         },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `legacy options can disable outgoing response data`() {
+    val options = SentryOptions().also { it.maxRequestBodySize = SentryOptions.RequestSize.ALWAYS }
+    val exceptionReporter = fixture.getSut(options)
+
+    exceptionReporter.captureThrowable(
+      fixture.exception,
+      ExceptionReporter.ExceptionDetails(
+        fixture.scopes,
+        fixture.instrumentationExecutionParameters,
+        false,
+      ),
+      fixture.executionResult,
+    )
+
+    verify(fixture.scopes)
+      .captureEvent(
+        org.mockito.kotlin.check { assertNull(it.contexts.response) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `legacy request body size can disable outgoing response data`() {
+    val options = SentryOptions().also { it.isSendDefaultPii = true }
+    val exceptionReporter = fixture.getSut(options)
+
+    exceptionReporter.captureThrowable(
+      fixture.exception,
+      ExceptionReporter.ExceptionDetails(
+        fixture.scopes,
+        fixture.instrumentationExecutionParameters,
+        false,
+      ),
+      fixture.executionResult,
+    )
+
+    verify(fixture.scopes)
+      .captureEvent(
+        org.mockito.kotlin.check { assertNull(it.contexts.response) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection response ignores legacy request body options`() {
+    val options =
+      SentryOptions().also {
+        it.maxRequestBodySize = SentryOptions.RequestSize.NONE
+        it.dataCollection.httpBodies = setOf(HttpBodyType.OUTGOING_RESPONSE)
+      }
+    val exceptionReporter = fixture.getSut(options)
+
+    exceptionReporter.captureThrowable(
+      fixture.exception,
+      ExceptionReporter.ExceptionDetails(
+        fixture.scopes,
+        fixture.instrumentationExecutionParameters,
+        false,
+      ),
+      fixture.executionResult,
+    )
+
+    verify(fixture.scopes)
+      .captureEvent(
+        org.mockito.kotlin.check { assertNotNull(it.contexts.response?.data) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable outgoing response data`() {
+    val options = fixture.defaultOptions.also { it.dataCollection.httpBodies = emptySet() }
+    val exceptionReporter = fixture.getSut(options)
+
+    exceptionReporter.captureThrowable(
+      fixture.exception,
+      ExceptionReporter.ExceptionDetails(
+        fixture.scopes,
+        fixture.instrumentationExecutionParameters,
+        false,
+      ),
+      fixture.executionResult,
+    )
+
+    verify(fixture.scopes)
+      .captureEvent(
+        org.mockito.kotlin.check { assertNull(it.contexts.response) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection namespace default enables outgoing response data`() {
+    val options =
+      SentryOptions().also {
+        it.maxRequestBodySize = SentryOptions.RequestSize.NONE
+        it.dataCollection.cookies = KeyValueCollectionBehavior.off()
+      }
+    val exceptionReporter = fixture.getSut(options)
+
+    exceptionReporter.captureThrowable(
+      fixture.exception,
+      ExceptionReporter.ExceptionDetails(
+        fixture.scopes,
+        fixture.instrumentationExecutionParameters,
+        false,
+      ),
+      fixture.executionResult,
+    )
+
+    verify(fixture.scopes)
+      .captureEvent(
+        org.mockito.kotlin.check { assertNotNull(it.contexts.response?.data) },
         any<Hint>(),
       )
   }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -435,6 +435,7 @@ public final class io/sentry/DataCollectionResolver {
 	public fun isIncomingResponseBody ()Z
 	public fun isOutgoingRequestBody ()Z
 	public fun isOutgoingResponseBody ()Z
+	public fun isOutgoingResponseBodyWithLegacyBodyGate ()Z
 	public fun isUserInfo ()Z
 }
 

--- a/sentry/src/main/java/io/sentry/DataCollectionResolver.java
+++ b/sentry/src/main/java/io/sentry/DataCollectionResolver.java
@@ -104,6 +104,10 @@ public final class DataCollectionResolver {
     return isHttpBodyEnabled(HttpBodyType.OUTGOING_RESPONSE, options.isSendDefaultPii());
   }
 
+  public boolean isOutgoingResponseBodyWithLegacyBodyGate() {
+    return isHttpBodyEnabled(HttpBodyType.OUTGOING_RESPONSE, isLegacyGraphqlBodyEnabled());
+  }
+
   private boolean isLegacyGraphqlBodyEnabled() {
     return options.isSendDefaultPii()
         && !SentryOptions.RequestSize.NONE.equals(options.getMaxRequestBodySize());

--- a/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
@@ -129,6 +129,37 @@ class DataCollectionResolverTest {
   }
 
   @Test
+  fun `outgoing response legacy body variant preserves the legacy size gate`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = true
+        maxRequestBodySize = SentryOptions.RequestSize.NONE
+      }
+
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBodyWithLegacyBodyGate).isFalse()
+
+    options.maxRequestBodySize = SentryOptions.RequestSize.SMALL
+
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBodyWithLegacyBodyGate).isTrue()
+  }
+
+  @Test
+  fun `outgoing response legacy body variant uses data collection when namespace is explicit`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = false
+        maxRequestBodySize = SentryOptions.RequestSize.NONE
+        dataCollection.graphql.setDocument(true)
+      }
+
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBodyWithLegacyBodyGate).isTrue()
+
+    options.dataCollection.httpBodies = emptySet()
+
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBodyWithLegacyBodyGate).isFalse()
+  }
+
+  @Test
   fun `GraphQL legacy body variants ignore the size option when namespace is explicit`() {
     val options =
       SentryOptions().apply {


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Apply the outgoing response body policy to GraphQL Java execution results attached by `ExceptionReporter`.

Explicit Data Collection controls the serialized GraphQL response independently from the request document. When Data Collection is absent, the existing `sendDefaultPii` and `maxRequestBodySize` gate remains unchanged.

## :bulb: Motivation and Context

A server-side GraphQL execution result is outgoing response body content and can contain customer data. It requires a directional policy distinct from the incoming GraphQL document and variables.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `DataCollectionResolverTest`
- `ExceptionReporterTest`
- `./gradlew apiCheck`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Apply request and response header collection behavior across HTTP integrations.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
