### PR TITLE
feat(http): [Data Collection 10] Apply request header policy

### DIFF
--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
@@ -264,6 +264,21 @@ constructor(
   private fun getHeader(key: String, headers: List<HttpHeader>): String? =
     headers.firstOrNull { it.name.equals(key, true) }?.value
 
+  private fun getRequestHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val requestHeaders = mutableMapOf<String, String>()
+      for (header in headers) {
+        requestHeaders[header.name] = header.value
+      }
+      return HttpUtils.filterHeaders(
+          requestHeaders,
+          scopes.options.dataCollectionResolver.httpRequestHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(headers)
+  }
+
   private fun getHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
     // Headers are only sent if isSendDefaultPii is enabled due to PII
     if (!scopes.options.isSendDefaultPii) {
@@ -359,7 +374,7 @@ constructor(
           cookies =
             if (scopes.options.isSendDefaultPii) getHeader("Cookie", request.headers) else null
           method = request.method.name
-          headers = getHeaders(request.headers)
+          headers = getRequestHeaders(request.headers)
           apiTarget = "graphql"
 
           request.body?.let {

--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.exception.ApolloException
 import io.sentry.Hint
 import io.sentry.HttpBodyType
 import io.sentry.IScopes
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
 import io.sentry.SentryOptions.DEFAULT_PROPAGATION_TARGETS
@@ -337,6 +338,41 @@ class SentryApollo3InterceptorClientErrors {
     verify(fixture.scopes)
       .captureEvent(
         check { assertNull(it.request!!.data) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("operation-name")
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals(
+            "[Filtered]",
+            it.request!!.headers?.get("X-APOLLO-OPERATION-NAME"),
+          )
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable request headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check { assertTrue(it.request!!.headers!!.isEmpty()) },
         any<Hint>(),
       )
   }

--- a/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
+++ b/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
@@ -263,6 +263,21 @@ constructor(
   private fun getHeader(key: String, headers: List<HttpHeader>): String? =
     headers.firstOrNull { it.name.equals(key, true) }?.value
 
+  private fun getRequestHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val requestHeaders = mutableMapOf<String, String>()
+      for (header in headers) {
+        requestHeaders[header.name] = header.value
+      }
+      return HttpUtils.filterHeaders(
+          requestHeaders,
+          scopes.options.dataCollectionResolver.httpRequestHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(headers)
+  }
+
   private fun getHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
     // Headers are only sent if isSendDefaultPii is enabled due to PII
     if (!scopes.options.isSendDefaultPii) {
@@ -358,7 +373,7 @@ constructor(
           cookies =
             if (scopes.options.isSendDefaultPii) getHeader("Cookie", request.headers) else null
           method = request.method.name
-          headers = getHeaders(request.headers)
+          headers = getRequestHeaders(request.headers)
           apiTarget = "graphql"
 
           request.body?.let {

--- a/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
+++ b/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
@@ -10,6 +10,7 @@ import com.apollographql.apollo.exception.ApolloException
 import io.sentry.Hint
 import io.sentry.HttpBodyType
 import io.sentry.IScopes
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
 import io.sentry.SentryOptions.DEFAULT_PROPAGATION_TARGETS
@@ -351,6 +352,21 @@ abstract class SentryApollo4BuilderExtensionsClientErrorsTest(
     verify(fixture.scopes)
       .captureEvent(
         check { assertNull(it.request!!.data) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable request headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check { assertTrue(it.request!!.headers!!.isEmpty()) },
         any<Hint>(),
       )
   }

--- a/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
+++ b/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
@@ -357,6 +357,23 @@ abstract class SentryApollo4BuilderExtensionsClientErrorsTest(
   }
 
   @Test
+  fun `data collection filters request headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("accept")
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals("[Filtered]", it.request!!.headers?.get("Accept"))
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `data collection can disable request headers`() {
     val sut =
       fixture.getSut(responseBody = fixture.responseBodyNotOk) {

--- a/sentry-ktor-client/src/main/java/io/sentry/ktorClient/SentryKtorClientUtils.kt
+++ b/sentry-ktor-client/src/main/java/io/sentry/ktorClient/SentryKtorClientUtils.kt
@@ -40,7 +40,7 @@ internal object SentryKtorClientUtils {
         urlDetails.applyToRequest(this)
         cookies = if (scopes.options.isSendDefaultPii) request.headers["Cookie"] else null
         method = request.method.value
-        headers = getHeaders(scopes, request.headers)
+        headers = getRequestHeaders(scopes, request.headers)
         bodySize = request.content.contentLength
       }
 
@@ -65,6 +65,19 @@ internal object SentryKtorClientUtils {
       }
 
     scopes.captureEvent(event, hint)
+  }
+
+  private fun getRequestHeaders(scopes: IScopes, headers: Headers): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val requestHeaders =
+        headers.toMap().mapValues { (_, values) -> values.joinToString(",") }.toMutableMap()
+      return HttpUtils.filterHeaders(
+          requestHeaders,
+          scopes.options.dataCollectionResolver.httpRequestHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(scopes, headers)
   }
 
   private fun getHeaders(scopes: IScopes, headers: Headers): MutableMap<String, String>? {

--- a/sentry-ktor-client/src/test/java/io/sentry/ktorClient/SentryKtorClientPluginTest.kt
+++ b/sentry-ktor-client/src/test/java/io/sentry/ktorClient/SentryKtorClientPluginTest.kt
@@ -14,6 +14,7 @@ import io.sentry.Hint
 import io.sentry.HttpStatusCodeRange
 import io.sentry.IScope
 import io.sentry.IScopes
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.Sentry
@@ -253,6 +254,56 @@ class SentryKtorClientPluginTest {
     sut.get(fixture.server.url("/hello").toString())
 
     verify(fixture.scopes, never()).captureEvent(any(), any<Hint>())
+  }
+
+  @Test
+  fun `data collection filters request headers`(): Unit = runBlocking {
+    val sut =
+      fixture.getSut(
+        captureFailedRequests = true,
+        httpStatusCode = 500,
+        optionsConfiguration =
+          Sentry.OptionsConfiguration {
+            it.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("customer")
+          },
+      )
+
+    sut.get(fixture.server.url("/hello").toString()) {
+      headers["content-type"] = "application/json"
+      headers["authorization"] = "Bearer token"
+      headers["x-customer"] = "customer value"
+    }
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check<SentryEvent> {
+          assertEquals("application/json", it.request!!.headers!!["content-type"])
+          assertEquals("[Filtered]", it.request!!.headers!!["authorization"])
+          assertEquals("[Filtered]", it.request!!.headers!!["x-customer"])
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable request headers`(): Unit = runBlocking {
+    val sut =
+      fixture.getSut(
+        captureFailedRequests = true,
+        httpStatusCode = 500,
+        optionsConfiguration =
+          Sentry.OptionsConfiguration {
+            it.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+          },
+      )
+
+    sut.get(fixture.server.url("/hello").toString()) { headers["myHeader"] = "myValue" }
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check<SentryEvent> { assertTrue(it.request!!.headers!!.isEmpty()) },
+        any<Hint>(),
+      )
   }
 
   @Test

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpUtils.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpUtils.kt
@@ -40,7 +40,7 @@ internal object SentryOkHttpUtils {
         // Cookie is only sent if isSendDefaultPii is enabled
         cookies = if (scopes.options.isSendDefaultPii) request.headers["Cookie"] else null
         method = request.method
-        headers = getHeaders(scopes, request.headers)
+        headers = getRequestHeaders(scopes, request.headers)
 
         request.body?.contentLength().ifHasValidLength { bodySize = it }
       }
@@ -65,6 +65,24 @@ internal object SentryOkHttpUtils {
     if (this != null && this != -1L) {
       fn.invoke(this)
     }
+  }
+
+  private fun getRequestHeaders(
+    scopes: IScopes,
+    requestHeaders: Headers,
+  ): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val headers = mutableMapOf<String, String>()
+      for (i in 0 until requestHeaders.size) {
+        headers[requestHeaders.name(i)] = requestHeaders.value(i)
+      }
+      return HttpUtils.filterHeaders(
+          headers,
+          scopes.options.dataCollectionResolver.httpRequestHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(scopes, requestHeaders)
   }
 
   private fun getHeaders(scopes: IScopes, requestHeaders: Headers): MutableMap<String, String>? {

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpUtilsTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpUtilsTest.kt
@@ -2,6 +2,7 @@ package io.sentry.okhttp
 
 import io.sentry.Hint
 import io.sentry.IScopes
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.TransactionContext
@@ -36,12 +37,14 @@ class SentryOkHttpUtilsTest {
       responseBody: String = "success",
       socketPolicy: SocketPolicy = SocketPolicy.KEEP_OPEN,
       sendDefaultPii: Boolean = false,
+      configureOptions: SentryOptions.() -> Unit = {},
     ): OkHttpClient {
       val options =
         SentryOptions().apply {
           dsn = "https://key@sentry.io/proj"
           setTracePropagationTargets(listOf(server.hostName))
           isSendDefaultPii = sendDefaultPii
+          configureOptions()
         }
       whenever(scopes.options).thenReturn(options)
 
@@ -119,6 +122,40 @@ class SentryOkHttpUtilsTest {
         },
         any<Hint>(),
       )
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val sut = fixture.getSut {
+      dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("myheader")
+    }
+    val request = getRequest()
+    val response = sut.newCall(request).execute()
+
+    SentryOkHttpUtils.captureClientError(fixture.scopes, request, response)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals("[Filtered]", it.request!!.headers!!["myHeader"])
+          assertEquals("[Filtered]", it.request!!.headers!!["Cookie"])
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable request headers`() {
+    val sut = fixture.getSut {
+      dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+    }
+    val request = getRequest()
+    val response = sut.newCall(request).execute()
+
+    SentryOkHttpUtils.captureClientError(fixture.scopes, request, response)
+
+    verify(fixture.scopes)
+      .captureEvent(check { assertTrue(it.request!!.headers!!.isEmpty()) }, any<Hint>())
   }
 
   @Test

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryAttributesExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryAttributesExtractor.java
@@ -77,6 +77,8 @@ public final class OpenTelemetryAttributesExtractor {
   private static Map<String, String> collectHeaders(
       final @NotNull Attributes attributes, final @NotNull SentryOptions options) {
     Map<String, String> headers = new HashMap<>();
+    final boolean isDataCollectionConfigured =
+        options.getDataCollectionResolver().isDataCollectionConfigured();
 
     attributes.forEach(
         (key, value) -> {
@@ -84,7 +86,9 @@ public final class OpenTelemetryAttributesExtractor {
           if (attributeKeyAsString.startsWith(HTTP_REQUEST_HEADER_PREFIX)) {
             final @NotNull String headerName =
                 StringUtils.removePrefix(attributeKeyAsString, HTTP_REQUEST_HEADER_PREFIX);
-            if (options.isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
+            if (isDataCollectionConfigured
+                || options.isSendDefaultPii()
+                || !HttpUtils.containsSensitiveHeader(headerName)) {
               if (value instanceof List) {
                 try {
                   final @NotNull List<String> headerValues = (List<String>) value;
@@ -102,6 +106,10 @@ public final class OpenTelemetryAttributesExtractor {
             }
           }
         });
+    if (isDataCollectionConfigured) {
+      return HttpUtils.filterHeaders(
+          headers, options.getDataCollectionResolver().getHttpRequestHeaders());
+    }
     return headers;
   }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryAttributesExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryAttributesExtractor.java
@@ -77,8 +77,6 @@ public final class OpenTelemetryAttributesExtractor {
   private static Map<String, String> collectHeaders(
       final @NotNull Attributes attributes, final @NotNull SentryOptions options) {
     Map<String, String> headers = new HashMap<>();
-    final boolean isDataCollectionConfigured =
-        options.getDataCollectionResolver().isDataCollectionConfigured();
 
     attributes.forEach(
         (key, value) -> {
@@ -86,9 +84,7 @@ public final class OpenTelemetryAttributesExtractor {
           if (attributeKeyAsString.startsWith(HTTP_REQUEST_HEADER_PREFIX)) {
             final @NotNull String headerName =
                 StringUtils.removePrefix(attributeKeyAsString, HTTP_REQUEST_HEADER_PREFIX);
-            if (isDataCollectionConfigured
-                || options.isSendDefaultPii()
-                || !HttpUtils.containsSensitiveHeader(headerName)) {
+            if (options.isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
               if (value instanceof List) {
                 try {
                   final @NotNull List<String> headerValues = (List<String>) value;
@@ -106,10 +102,6 @@ public final class OpenTelemetryAttributesExtractor {
             }
           }
         });
-    if (isDataCollectionConfigured) {
-      return HttpUtils.filterHeaders(
-          headers, options.getDataCollectionResolver().getHttpRequestHeaders());
-    }
     return headers;
   }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OpenTelemetryAttributesExtractorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OpenTelemetryAttributesExtractorTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.ServerAttributes
 import io.opentelemetry.semconv.UrlAttributes
-import io.sentry.KeyValueCollectionBehavior
 import io.sentry.Scope
 import io.sentry.SentryOptions
 import io.sentry.protocol.Request
@@ -322,43 +321,6 @@ class OpenTelemetryAttributesExtractorTest {
       "f9118105af4a2d42b4124532cd176588-4542d085bb0b4de5",
     )
     thenHeaderIsNotPresentOnRequest("some-header")
-  }
-
-  @Test
-  fun `data collection filters request header attributes`() {
-    fixture.options.dataCollection.httpHeaders.request =
-      KeyValueCollectionBehavior.denyList("customer")
-    givenAttributes(
-      mapOf(
-        HttpAttributes.HTTP_REQUEST_METHOD to "GET",
-        AttributeKey.stringArrayKey("http.request.header.content-type") to
-          listOf("application/json"),
-        AttributeKey.stringArrayKey("http.request.header.authorization") to listOf("Bearer token"),
-        AttributeKey.stringArrayKey("http.request.header.x-customer") to listOf("customer value"),
-      )
-    )
-
-    whenExtractingAttributes()
-
-    thenHeaderIsPresentOnRequest("content-type", "application/json")
-    thenHeaderIsPresentOnRequest("authorization", "[Filtered]")
-    thenHeaderIsPresentOnRequest("x-customer", "[Filtered]")
-  }
-
-  @Test
-  fun `data collection can disable request header attributes`() {
-    fixture.options.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
-    givenAttributes(
-      mapOf(
-        HttpAttributes.HTTP_REQUEST_METHOD to "GET",
-        AttributeKey.stringArrayKey("http.request.header.content-type") to
-          listOf("application/json"),
-      )
-    )
-
-    whenExtractingAttributes()
-
-    assertNull(fixture.scope.request!!.headers)
   }
 
   @Test

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OpenTelemetryAttributesExtractorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OpenTelemetryAttributesExtractorTest.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.ServerAttributes
 import io.opentelemetry.semconv.UrlAttributes
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.Scope
 import io.sentry.SentryOptions
 import io.sentry.protocol.Request
@@ -321,6 +322,43 @@ class OpenTelemetryAttributesExtractorTest {
       "f9118105af4a2d42b4124532cd176588-4542d085bb0b4de5",
     )
     thenHeaderIsNotPresentOnRequest("some-header")
+  }
+
+  @Test
+  fun `data collection filters request header attributes`() {
+    fixture.options.dataCollection.httpHeaders.request =
+      KeyValueCollectionBehavior.denyList("customer")
+    givenAttributes(
+      mapOf(
+        HttpAttributes.HTTP_REQUEST_METHOD to "GET",
+        AttributeKey.stringArrayKey("http.request.header.content-type") to
+          listOf("application/json"),
+        AttributeKey.stringArrayKey("http.request.header.authorization") to listOf("Bearer token"),
+        AttributeKey.stringArrayKey("http.request.header.x-customer") to listOf("customer value"),
+      )
+    )
+
+    whenExtractingAttributes()
+
+    thenHeaderIsPresentOnRequest("content-type", "application/json")
+    thenHeaderIsPresentOnRequest("authorization", "[Filtered]")
+    thenHeaderIsPresentOnRequest("x-customer", "[Filtered]")
+  }
+
+  @Test
+  fun `data collection can disable request header attributes`() {
+    fixture.options.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+    givenAttributes(
+      mapOf(
+        HttpAttributes.HTTP_REQUEST_METHOD to "GET",
+        AttributeKey.stringArrayKey("http.request.header.content-type") to
+          listOf("application/json"),
+      )
+    )
+
+    whenExtractingAttributes()
+
+    assertNull(fixture.scope.request!!.headers)
   }
 
   @Test

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.servlet.jakarta;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
@@ -20,9 +21,12 @@ import org.jetbrains.annotations.Nullable;
 final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
 
   private final @NotNull HttpServletRequest httpRequest;
+  private final @NotNull SentryOptions options;
 
-  public SentryRequestHttpServletRequestProcessor(@NotNull HttpServletRequest httpRequest) {
+  public SentryRequestHttpServletRequestProcessor(
+      @NotNull HttpServletRequest httpRequest, @NotNull SentryOptions options) {
     this.httpRequest = Objects.requireNonNull(httpRequest, "httpRequest is required");
+    this.options = Objects.requireNonNull(options, "options are required");
   }
 
   // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
@@ -45,10 +49,14 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
       final @NotNull HttpServletRequest request) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
-      // do not copy personal information identifiable headers
-      if (!HttpUtils.containsSensitiveHeader(headerName.toUpperCase(Locale.ROOT))) {
+      if (options.getDataCollectionResolver().isDataCollectionConfigured()
+          || !HttpUtils.containsSensitiveHeader(headerName.toUpperCase(Locale.ROOT))) {
         headersMap.put(headerName, toString(request.getHeaders(headerName)));
       }
+    }
+    if (options.getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, options.getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletRequestListener.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletRequestListener.java
@@ -59,7 +59,8 @@ public class SentryServletRequestListener implements ServletRequestListener {
 
       scopes.configureScope(
           scope -> {
-            scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(httpRequest));
+            scope.addEventProcessor(
+                new SentryRequestHttpServletRequestProcessor(httpRequest, scopes.getOptions()));
           });
     }
   }

--- a/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.servlet.jakarta
 
 import io.sentry.Hint
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import jakarta.servlet.http.HttpServletRequest
@@ -24,7 +25,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         url = "http://example.com?param1=xyz",
         headers = mapOf("some-header" to "some-header value", "Accept" to "application/json"),
       )
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, SentryOptions())
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())
@@ -47,7 +48,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         url = "http://example.com?param1=xyz",
         headers = mapOf("another-header" to listOf("another value", "another value2")),
       )
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, SentryOptions())
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())
@@ -63,12 +64,57 @@ class SentryRequestHttpServletRequestProcessorTest {
       mockRequest(url = "http://example.com?param1=xyz", headers = mapOf("Cookie" to "name=value"))
     val sentryOptions = SentryOptions()
     sentryOptions.isSendDefaultPii = false
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, sentryOptions)
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())
 
     assertNotNull(event.request) { assertNull(it.cookies) }
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val request =
+      mockRequest(
+        url = "http://example.com",
+        headers =
+          mapOf(
+            "content-type" to "application/json",
+            "authorization" to "Bearer token",
+            "x-customer" to "customer value",
+          ),
+      )
+    val options =
+      SentryOptions().also {
+        it.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("customer")
+      }
+    val event = SentryEvent()
+
+    SentryRequestHttpServletRequestProcessor(request, options).process(event, Hint())
+
+    assertEquals(
+      mapOf(
+        "content-type" to "application/json",
+        "authorization" to "[Filtered]",
+        "x-customer" to "[Filtered]",
+      ),
+      event.request!!.headers,
+    )
+  }
+
+  @Test
+  fun `data collection can disable request headers`() {
+    val request =
+      mockRequest(url = "http://example.com", headers = mapOf("content-type" to "application/json"))
+    val options =
+      SentryOptions().also {
+        it.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+      }
+    val event = SentryEvent()
+
+    SentryRequestHttpServletRequestProcessor(request, options).process(event, Hint())
+
+    assertEquals(emptyMap(), event.request!!.headers)
   }
 
   @Test
@@ -87,7 +133,7 @@ class SentryRequestHttpServletRequestProcessorTest {
       )
     val sentryOptions = SentryOptions()
     sentryOptions.isSendDefaultPii = false
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, sentryOptions)
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.servlet;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
@@ -20,9 +21,12 @@ import org.jetbrains.annotations.Nullable;
 final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
 
   private final @NotNull HttpServletRequest httpRequest;
+  private final @NotNull SentryOptions options;
 
-  public SentryRequestHttpServletRequestProcessor(@NotNull HttpServletRequest httpRequest) {
+  public SentryRequestHttpServletRequestProcessor(
+      @NotNull HttpServletRequest httpRequest, @NotNull SentryOptions options) {
     this.httpRequest = Objects.requireNonNull(httpRequest, "httpRequest is required");
+    this.options = Objects.requireNonNull(options, "options are required");
   }
 
   // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
@@ -45,10 +49,14 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
       final @NotNull HttpServletRequest request) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
-      // do not copy personal information identifiable headers
-      if (!HttpUtils.containsSensitiveHeader(headerName.toUpperCase(Locale.ROOT))) {
+      if (options.getDataCollectionResolver().isDataCollectionConfigured()
+          || !HttpUtils.containsSensitiveHeader(headerName.toUpperCase(Locale.ROOT))) {
         headersMap.put(headerName, toString(request.getHeaders(headerName)));
       }
+    }
+    if (options.getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, options.getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
@@ -59,7 +59,8 @@ public class SentryServletRequestListener implements ServletRequestListener {
 
       scopes.configureScope(
           scope -> {
-            scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(httpRequest));
+            scope.addEventProcessor(
+                new SentryRequestHttpServletRequestProcessor(httpRequest, scopes.getOptions()));
           });
     }
   }

--- a/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.servlet
 
 import io.sentry.Hint
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import java.net.URI
@@ -21,7 +22,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         .header("some-header", "some-header value")
         .accept("application/json")
         .buildRequest(MockServletContext())
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, SentryOptions())
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())
@@ -44,7 +45,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         .header("another-header", "another value")
         .header("another-header", "another value2")
         .buildRequest(MockServletContext())
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, SentryOptions())
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())
@@ -62,12 +63,55 @@ class SentryRequestHttpServletRequestProcessorTest {
         .buildRequest(MockServletContext())
     val sentryOptions = SentryOptions()
     sentryOptions.isSendDefaultPii = false
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, sentryOptions)
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())
 
     assertNotNull(event.request) { assertNull(it.cookies) }
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val request =
+      MockMvcRequestBuilders.get(URI.create("http://example.com"))
+        .header("content-type", "application/json")
+        .header("authorization", "Bearer token")
+        .header("x-customer", "customer value")
+        .buildRequest(MockServletContext())
+    val options =
+      SentryOptions().also {
+        it.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("customer")
+      }
+    val event = SentryEvent()
+
+    SentryRequestHttpServletRequestProcessor(request, options).process(event, Hint())
+
+    assertEquals(
+      mapOf(
+        "Content-Type" to "application/json",
+        "authorization" to "[Filtered]",
+        "x-customer" to "[Filtered]",
+      ),
+      event.request!!.headers,
+    )
+  }
+
+  @Test
+  fun `data collection can disable request headers`() {
+    val request =
+      MockMvcRequestBuilders.get(URI.create("http://example.com"))
+        .header("content-type", "application/json")
+        .buildRequest(MockServletContext())
+    val options =
+      SentryOptions().also {
+        it.dataCollection.httpHeaders.request = KeyValueCollectionBehavior.off()
+      }
+    val event = SentryEvent()
+
+    SentryRequestHttpServletRequestProcessor(request, options).process(event, Hint())
+
+    assertEquals(emptyMap(), event.request!!.headers)
   }
 
   @Test
@@ -82,7 +126,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         .buildRequest(MockServletContext())
     val sentryOptions = SentryOptions()
     sentryOptions.isSendDefaultPii = false
-    val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+    val eventProcessor = SentryRequestHttpServletRequestProcessor(request, sentryOptions)
     val event = SentryEvent()
 
     eventProcessor.process(event, Hint())

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/SentryRequestResolver.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/SentryRequestResolver.java
@@ -60,14 +60,18 @@ public class SentryRequestResolver {
       final @NotNull List<String> additionalSecurityCookieNames) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
-      // do not copy personal information identifiable headers
-      if (scopes.getOptions().isSendDefaultPii()
+      if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()
+          || scopes.getOptions().isSendDefaultPii()
           || !HttpUtils.containsSensitiveHeader(headerName)) {
         final @Nullable List<String> filteredHeaders =
             HttpUtils.filterOutSecurityCookiesFromHeader(
                 request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
         headersMap.put(headerName, toString(filteredHeaders));
       }
+    }
+    if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, scopes.getOptions().getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/webflux/SentryRequestResolver.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/webflux/SentryRequestResolver.java
@@ -50,9 +50,9 @@ public class SentryRequestResolver {
   Map<String, String> resolveHeadersMap(final HttpHeaders request) {
     final Map<String, String> headersMap = new HashMap<>();
     for (Map.Entry<String, List<String>> entry : request.headerSet()) {
-      // do not copy personal information identifiable headers
       String headerName = entry.getKey();
-      if (scopes.getOptions().isSendDefaultPii()
+      if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()
+          || scopes.getOptions().isSendDefaultPii()
           || !HttpUtils.containsSensitiveHeader(headerName)) {
         headersMap.put(
             headerName,
@@ -60,6 +60,10 @@ public class SentryRequestResolver {
                 HttpUtils.filterOutSecurityCookiesFromHeader(
                     entry.getValue(), headerName, Collections.emptyList())));
       }
+    }
+    if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, scopes.getOptions().getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/SentrySpringFilterTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/SentrySpringFilterTest.kt
@@ -5,6 +5,7 @@ import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -202,6 +203,30 @@ class SentrySpringFilterTest {
     listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
     assertNotNull(fixture.scope.request) { assertNull(it.cookies) }
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val sentryOptions =
+      SentryOptions().apply {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("customer")
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.get(URI.create("http://example.com"))
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer token")
+            .header("x-customer", "customer value")
+            .buildRequest(MockServletContext()),
+        options = sentryOptions,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    assertEquals("application/json", fixture.scope.request!!.headers!!["Content-Type"])
+    assertEquals("[Filtered]", fixture.scope.request!!.headers!!["authorization"])
+    assertEquals("[Filtered]", fixture.scope.request!!.headers!!["x-customer"])
   }
 
   @Test

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
@@ -60,14 +60,18 @@ public class SentryRequestResolver {
       final @NotNull List<String> additionalSecurityCookieNames) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
-      // do not copy personal information identifiable headers
-      if (scopes.getOptions().isSendDefaultPii()
+      if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()
+          || scopes.getOptions().isSendDefaultPii()
           || !HttpUtils.containsSensitiveHeader(headerName)) {
         final @Nullable List<String> filteredHeaders =
             HttpUtils.filterOutSecurityCookiesFromHeader(
                 request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
         headersMap.put(headerName, toString(filteredHeaders));
       }
+    }
+    if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, scopes.getOptions().getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryRequestResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryRequestResolver.java
@@ -50,9 +50,9 @@ public class SentryRequestResolver {
   Map<String, String> resolveHeadersMap(final HttpHeaders request) {
     final Map<String, String> headersMap = new HashMap<>();
     for (Map.Entry<String, List<String>> entry : request.entrySet()) {
-      // do not copy personal information identifiable headers
       String headerName = entry.getKey();
-      if (scopes.getOptions().isSendDefaultPii()
+      if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()
+          || scopes.getOptions().isSendDefaultPii()
           || !HttpUtils.containsSensitiveHeader(headerName)) {
         headersMap.put(
             headerName,
@@ -60,6 +60,10 @@ public class SentryRequestResolver {
                 HttpUtils.filterOutSecurityCookiesFromHeader(
                     entry.getValue(), headerName, Collections.emptyList())));
       }
+    }
+    if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, scopes.getOptions().getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentrySpringFilterTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentrySpringFilterTest.kt
@@ -5,6 +5,7 @@ import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -202,6 +203,30 @@ class SentrySpringFilterTest {
     listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
     assertNotNull(fixture.scope.request) { assertNull(it.cookies) }
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val sentryOptions =
+      SentryOptions().apply {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("customer")
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.get(URI.create("http://example.com"))
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer token")
+            .header("x-customer", "customer value")
+            .buildRequest(MockServletContext()),
+        options = sentryOptions,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    assertEquals("application/json", fixture.scope.request!!.headers!!["Content-Type"])
+    assertEquals("[Filtered]", fixture.scope.request!!.headers!!["authorization"])
+    assertEquals("[Filtered]", fixture.scope.request!!.headers!!["x-customer"])
   }
 
   @Test

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestResolver.java
@@ -60,14 +60,18 @@ public class SentryRequestResolver {
       final @NotNull List<String> additionalSecurityCookieNames) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
-      // do not copy personal information identifiable headers
-      if (scopes.getOptions().isSendDefaultPii()
+      if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()
+          || scopes.getOptions().isSendDefaultPii()
           || !HttpUtils.containsSensitiveHeader(headerName)) {
         final @Nullable List<String> filteredHeaders =
             HttpUtils.filterOutSecurityCookiesFromHeader(
                 request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
         headersMap.put(headerName, toString(filteredHeaders));
       }
+    }
+    if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, scopes.getOptions().getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryRequestResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryRequestResolver.java
@@ -50,9 +50,9 @@ public class SentryRequestResolver {
   Map<String, String> resolveHeadersMap(final HttpHeaders request) {
     final Map<String, String> headersMap = new HashMap<>();
     for (Map.Entry<String, List<String>> entry : request.entrySet()) {
-      // do not copy personal information identifiable headers
       String headerName = entry.getKey();
-      if (scopes.getOptions().isSendDefaultPii()
+      if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()
+          || scopes.getOptions().isSendDefaultPii()
           || !HttpUtils.containsSensitiveHeader(headerName)) {
         headersMap.put(
             headerName,
@@ -60,6 +60,10 @@ public class SentryRequestResolver {
                 HttpUtils.filterOutSecurityCookiesFromHeader(
                     entry.getValue(), headerName, Collections.emptyList())));
       }
+    }
+    if (scopes.getOptions().getDataCollectionResolver().isDataCollectionConfigured()) {
+      return HttpUtils.filterHeaders(
+          headersMap, scopes.getOptions().getDataCollectionResolver().getHttpRequestHeaders());
     }
     return headersMap;
   }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
@@ -5,6 +5,7 @@ import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
+import io.sentry.KeyValueCollectionBehavior
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -202,6 +203,30 @@ class SentrySpringFilterTest {
     listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
     assertNotNull(fixture.scope.request) { assertNull(it.cookies) }
+  }
+
+  @Test
+  fun `data collection filters request headers`() {
+    val sentryOptions =
+      SentryOptions().apply {
+        dataCollection.httpHeaders.request = KeyValueCollectionBehavior.denyList("customer")
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.get(URI.create("http://example.com"))
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer token")
+            .header("x-customer", "customer value")
+            .buildRequest(MockServletContext()),
+        options = sentryOptions,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    assertEquals("application/json", fixture.scope.request!!.headers!!["Content-Type"])
+    assertEquals("[Filtered]", fixture.scope.request!!.headers!!["authorization"])
+    assertEquals("[Filtered]", fixture.scope.request!!.headers!!["x-customer"])
   }
 
   @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7807,6 +7807,7 @@ public final class io/sentry/util/HttpUtils {
 	public static final field COOKIE_HEADER_NAME Ljava/lang/String;
 	public fun <init> ()V
 	public static fun containsSensitiveHeader (Ljava/lang/String;)Z
+	public static fun filterHeaders (Ljava/util/Map;Lio/sentry/KeyValueCollectionBehavior;)Ljava/util/Map;
 	public static fun filterOutSecurityCookies (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 	public static fun filterOutSecurityCookiesFromHeader (Ljava/util/Enumeration;Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
 	public static fun filterOutSecurityCookiesFromHeader (Ljava/util/List;Ljava/lang/String;Ljava/util/List;)Ljava/util/List;

--- a/sentry/src/main/java/io/sentry/util/HttpUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HttpUtils.java
@@ -90,12 +90,16 @@ public final class HttpUtils {
           containsTerm(name, SENSITIVE_DATA_KEYS)
               || "Cookie".equalsIgnoreCase(name)
               || "Set-Cookie".equalsIgnoreCase(name);
-      final boolean matchesTerm = containsTerm(name, behavior.getTerms());
-      final boolean shouldFilter =
-          sensitive
-              || (behavior.getMode() == KeyValueCollectionBehavior.Mode.DENY_LIST && matchesTerm)
-              || (behavior.getMode() == KeyValueCollectionBehavior.Mode.ALLOW_LIST && !matchesTerm);
-      filteredHeaders.put(name, shouldFilter ? SENSITIVE_DATA_SUBSTITUTE : header.getValue());
+      if (sensitive) {
+        filteredHeaders.put(name, SENSITIVE_DATA_SUBSTITUTE);
+      } else {
+        final boolean matchesTerm = containsTerm(name, behavior.getTerms());
+        final boolean shouldFilter =
+            behavior.getMode() == KeyValueCollectionBehavior.Mode.DENY_LIST
+                ? matchesTerm
+                : !matchesTerm;
+        filteredHeaders.put(name, shouldFilter ? SENSITIVE_DATA_SUBSTITUTE : header.getValue());
+      }
     }
     return filteredHeaders;
   }

--- a/sentry/src/main/java/io/sentry/util/HttpUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HttpUtils.java
@@ -3,12 +3,15 @@ package io.sentry.util;
 import static io.sentry.util.UrlUtils.SENSITIVE_DATA_SUBSTITUTE;
 
 import io.sentry.HttpStatusCodeRange;
+import io.sentry.KeyValueCollectionBehavior;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -33,6 +36,26 @@ public final class HttpUtils {
           "X-CSRFTOKEN",
           "X-XSRF-TOKEN");
 
+  private static final List<String> SENSITIVE_DATA_KEYS =
+      Arrays.asList(
+          "auth",
+          "token",
+          "secret",
+          "password",
+          "passwd",
+          "pwd",
+          "key",
+          "jwt",
+          "bearer",
+          "sso",
+          "saml",
+          "csrf",
+          "xsrf",
+          "credentials",
+          "session",
+          "sid",
+          "identity");
+
   private static final List<String> SECURITY_COOKIES =
       Arrays.asList(
           "JSESSIONID",
@@ -51,6 +74,43 @@ public final class HttpUtils {
 
   public static boolean containsSensitiveHeader(final @NotNull String header) {
     return SENSITIVE_HEADERS.contains(header.toUpperCase(Locale.ROOT));
+  }
+
+  public static @NotNull Map<String, String> filterHeaders(
+      final @NotNull Map<String, String> headers,
+      final @NotNull KeyValueCollectionBehavior behavior) {
+    final @NotNull Map<String, String> filteredHeaders = new LinkedHashMap<>();
+    if (behavior.getMode() == KeyValueCollectionBehavior.Mode.OFF) {
+      return filteredHeaders;
+    }
+
+    for (final Map.Entry<String, String> header : headers.entrySet()) {
+      final @NotNull String name = header.getKey();
+      final boolean sensitive =
+          containsTerm(name, SENSITIVE_DATA_KEYS)
+              || "Cookie".equalsIgnoreCase(name)
+              || "Set-Cookie".equalsIgnoreCase(name);
+      final boolean matchesTerm = containsTerm(name, behavior.getTerms());
+      final boolean shouldFilter =
+          sensitive
+              || (behavior.getMode() == KeyValueCollectionBehavior.Mode.DENY_LIST && matchesTerm)
+              || (behavior.getMode() == KeyValueCollectionBehavior.Mode.ALLOW_LIST && !matchesTerm);
+      filteredHeaders.put(name, shouldFilter ? SENSITIVE_DATA_SUBSTITUTE : header.getValue());
+    }
+    return filteredHeaders;
+  }
+
+  private static boolean containsTerm(
+      final @NotNull String key, final @NotNull List<String> terms) {
+    final @NotNull String normalizedKey = key.toLowerCase(Locale.ROOT);
+    for (final String term : terms) {
+      if (term != null
+          && !term.isEmpty()
+          && normalizedKey.contains(term.toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static @Nullable List<String> filterOutSecurityCookiesFromHeader(

--- a/sentry/src/test/java/io/sentry/util/HttpUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/HttpUtilsTest.kt
@@ -1,5 +1,7 @@
 package io.sentry.util
 
+import com.google.common.truth.Truth.assertThat
+import io.sentry.KeyValueCollectionBehavior
 import java.util.Enumeration
 import java.util.StringTokenizer
 import kotlin.test.Test
@@ -8,6 +10,66 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class HttpUtilsTest {
+  @Test
+  fun `header filter disables collection in off mode`() {
+    val filtered =
+      HttpUtils.filterHeaders(
+        mapOf("content-type" to "application/json"),
+        KeyValueCollectionBehavior.off(),
+      )
+
+    assertThat(filtered).isEmpty()
+  }
+
+  @Test
+  fun `header deny list filters built-in sensitive and configured terms`() {
+    val filtered =
+      HttpUtils.filterHeaders(
+        mapOf(
+          "content-type" to "application/json",
+          "authorization" to "Bearer token",
+          "x-customer" to "customer value",
+          "Cookie" to "name=value",
+        ),
+        KeyValueCollectionBehavior.denyList("customer"),
+      )
+
+    assertThat(filtered)
+      .containsExactly(
+        "content-type",
+        "application/json",
+        "authorization",
+        "[Filtered]",
+        "x-customer",
+        "[Filtered]",
+        "Cookie",
+        "[Filtered]",
+      )
+  }
+
+  @Test
+  fun `header allow list only retains allowed non-sensitive values`() {
+    val filtered =
+      HttpUtils.filterHeaders(
+        mapOf(
+          "content-type" to "application/json",
+          "authorization" to "Bearer token",
+          "x-customer" to "customer value",
+        ),
+        KeyValueCollectionBehavior.allowList("content", "authorization"),
+      )
+
+    assertThat(filtered)
+      .containsExactly(
+        "content-type",
+        "application/json",
+        "authorization",
+        "[Filtered]",
+        "x-customer",
+        "[Filtered]",
+      )
+  }
+
   @Test
   fun `null enumeration returns null when filtering security cookies from headers`() {
     val enumeration: Enumeration<String>? = null


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Apply the request-header Data Collection policy across Servlet, Spring MVC and WebFlux, OkHttp, Ktor, and Apollo 3/4 automatic instrumentation.

Explicit Data Collection supports off, deny-list, and allow-list behavior with canonical sensitive-key filtering. When Data Collection is absent, each integration retains its previous `sendDefaultPii` and legacy sensitive-header behavior.

Completed OpenTelemetry attributes retain their existing behavior because the exporter cannot distinguish manually supplied attributes from values added by auto-instrumentation.

## :bulb: Motivation and Context

Request header collection historically differs by integration. A shared filter provides specification behavior for opted-in applications without changing existing applications that continue to use legacy configuration.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- Full relevant core, Servlet, Spring, OkHttp, Ktor, Apollo 3, and Apollo 4 tests
- `./gradlew :sentry-opentelemetry:sentry-opentelemetry-core:test --tests '*OpenTelemetryAttributesExtractorTest'`
- `./gradlew apiCheck`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Apply the response-header policy and migrate cookies separately.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
