### PR TITLE
feat(http): [Data Collection 11] Apply response header policy

### DIFF
--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
@@ -279,6 +279,21 @@ constructor(
     return getHeaders(headers)
   }
 
+  private fun getResponseHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val responseHeaders = mutableMapOf<String, String>()
+      for (header in headers) {
+        responseHeaders[header.name] = header.value
+      }
+      return HttpUtils.filterHeaders(
+          responseHeaders,
+          scopes.options.dataCollectionResolver.httpResponseHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(headers)
+  }
+
   private fun getHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
     // Headers are only sent if isSendDefaultPii is enabled due to PII
     if (!scopes.options.isSendDefaultPii) {
@@ -405,7 +420,7 @@ constructor(
             } else {
               null
             }
-          headers = getHeaders(response.headers)
+          headers = getResponseHeaders(response.headers)
           statusCode = response.statusCode
 
           response.body?.buffer?.size?.ifHasValidLength { contentLength ->

--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorClientErrors.kt
@@ -436,6 +436,38 @@ class SentryApollo3InterceptorClientErrors {
   }
 
   @Test
+  fun `data collection filters response headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.response = KeyValueCollectionBehavior.denyList("content-length")
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals("[Filtered]", it.contexts.response!!.headers?.get("Content-Length"))
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable response headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.response = KeyValueCollectionBehavior.off()
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check { assertTrue(it.contexts.response!!.headers!!.isEmpty()) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `capture errors with more response context if sendDefaultPii is enabled`() {
     val sut = fixture.getSut(responseBody = fixture.responseBodyNotOk, sendDefaultPii = true)
     executeQuery(sut)

--- a/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
+++ b/sentry-apollo-4/src/main/java/io/sentry/apollo4/SentryApollo4HttpInterceptor.kt
@@ -278,6 +278,21 @@ constructor(
     return getHeaders(headers)
   }
 
+  private fun getResponseHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val responseHeaders = mutableMapOf<String, String>()
+      for (header in headers) {
+        responseHeaders[header.name] = header.value
+      }
+      return HttpUtils.filterHeaders(
+          responseHeaders,
+          scopes.options.dataCollectionResolver.httpResponseHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(headers)
+  }
+
   private fun getHeaders(headers: List<HttpHeader>): MutableMap<String, String>? {
     // Headers are only sent if isSendDefaultPii is enabled due to PII
     if (!scopes.options.isSendDefaultPii) {
@@ -404,7 +419,7 @@ constructor(
             } else {
               null
             }
-          headers = getHeaders(response.headers)
+          headers = getResponseHeaders(response.headers)
           statusCode = response.statusCode
 
           response.body?.buffer?.size?.ifHasValidLength { contentLength ->

--- a/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
+++ b/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
@@ -429,6 +429,21 @@ abstract class SentryApollo4BuilderExtensionsClientErrorsTest(
   }
 
   @Test
+  fun `data collection can disable response headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.response = KeyValueCollectionBehavior.off()
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check { assertTrue(it.contexts.response!!.headers!!.isEmpty()) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `capture errors with more response context if sendDefaultPii is enabled`() {
     val sut = fixture.getSut(responseBody = fixture.responseBodyNotOk, sendDefaultPii = true)
     executeQuery(sut)

--- a/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
+++ b/sentry-apollo-4/src/test/java/io/sentry/apollo4/SentryApollo4BuilderExtensionsClientErrorsTest.kt
@@ -429,6 +429,23 @@ abstract class SentryApollo4BuilderExtensionsClientErrorsTest(
   }
 
   @Test
+  fun `data collection filters response headers`() {
+    val sut =
+      fixture.getSut(responseBody = fixture.responseBodyNotOk) {
+        dataCollection.httpHeaders.response = KeyValueCollectionBehavior.denyList("content-length")
+      }
+    executeQuery(sut)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals("[Filtered]", it.contexts.response!!.headers?.get("Content-Length"))
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `data collection can disable response headers`() {
     val sut =
       fixture.getSut(responseBody = fixture.responseBodyNotOk) {

--- a/sentry-ktor-client/src/main/java/io/sentry/ktorClient/SentryKtorClientUtils.kt
+++ b/sentry-ktor-client/src/main/java/io/sentry/ktorClient/SentryKtorClientUtils.kt
@@ -48,7 +48,7 @@ internal object SentryKtorClientUtils {
       io.sentry.protocol.Response().apply {
         // Set-Cookie is only sent if isSendDefaultPii is enabled due to PII
         cookies = if (scopes.options.isSendDefaultPii) response.headers["Set-Cookie"] else null
-        headers = getHeaders(scopes, response.headers)
+        headers = getResponseHeaders(scopes, response.headers)
         statusCode = response.status.value
         try {
           bodySize = response.bodyAsBytes().size.toLong()
@@ -74,6 +74,19 @@ internal object SentryKtorClientUtils {
       return HttpUtils.filterHeaders(
           requestHeaders,
           scopes.options.dataCollectionResolver.httpRequestHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(scopes, headers)
+  }
+
+  private fun getResponseHeaders(scopes: IScopes, headers: Headers): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val responseHeaders =
+        headers.toMap().mapValues { (_, values) -> values.joinToString(",") }.toMutableMap()
+      return HttpUtils.filterHeaders(
+          responseHeaders,
+          scopes.options.dataCollectionResolver.httpResponseHeaders,
         )
         .toMutableMap()
     }

--- a/sentry-ktor-client/src/test/java/io/sentry/ktorClient/SentryKtorClientPluginTest.kt
+++ b/sentry-ktor-client/src/test/java/io/sentry/ktorClient/SentryKtorClientPluginTest.kt
@@ -307,6 +307,59 @@ class SentryKtorClientPluginTest {
   }
 
   @Test
+  fun `data collection filters response headers`(): Unit = runBlocking {
+    val sut =
+      fixture.getSut(
+        captureFailedRequests = true,
+        httpStatusCode = 500,
+        optionsConfiguration =
+          Sentry.OptionsConfiguration {
+            it.dataCollection.httpHeaders.response = KeyValueCollectionBehavior.denyList("response")
+          },
+      )
+
+    sut.get(fixture.server.url("/hello").toString())
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check<SentryEvent> {
+          assertEquals(
+            "[Filtered]",
+            it.contexts.response!!
+              .headers!!
+              .entries
+              .firstOrNull { header ->
+                header.key.equals("myResponseHeader", ignoreCase = true)
+              }
+              ?.value,
+          )
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable response headers`(): Unit = runBlocking {
+    val sut =
+      fixture.getSut(
+        captureFailedRequests = true,
+        httpStatusCode = 500,
+        optionsConfiguration =
+          Sentry.OptionsConfiguration {
+            it.dataCollection.httpHeaders.response = KeyValueCollectionBehavior.off()
+          },
+      )
+
+    sut.get(fixture.server.url("/hello").toString())
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check<SentryEvent> { assertTrue(it.contexts.response!!.headers!!.isEmpty()) },
+        any<Hint>(),
+      )
+  }
+
+  @Test
   fun `does not capture headers when sendDefaultPii is disabled`(): Unit = runBlocking {
     val sut =
       fixture.getSut(captureFailedRequests = true, httpStatusCode = 500, sendDefaultPii = false)

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpUtils.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpUtils.kt
@@ -49,7 +49,7 @@ internal object SentryOkHttpUtils {
       io.sentry.protocol.Response().apply {
         // Set-Cookie is only sent if isSendDefaultPii is enabled due to PII
         cookies = if (scopes.options.isSendDefaultPii) response.headers["Set-Cookie"] else null
-        headers = getHeaders(scopes, response.headers)
+        headers = getResponseHeaders(scopes, response.headers)
         statusCode = response.code
 
         response.body?.contentLength().ifHasValidLength { bodySize = it }
@@ -83,6 +83,24 @@ internal object SentryOkHttpUtils {
         .toMutableMap()
     }
     return getHeaders(scopes, requestHeaders)
+  }
+
+  private fun getResponseHeaders(
+    scopes: IScopes,
+    responseHeaders: Headers,
+  ): MutableMap<String, String>? {
+    if (scopes.options.dataCollectionResolver.isDataCollectionConfigured) {
+      val headers = mutableMapOf<String, String>()
+      for (i in 0 until responseHeaders.size) {
+        headers[responseHeaders.name(i)] = responseHeaders.value(i)
+      }
+      return HttpUtils.filterHeaders(
+          headers,
+          scopes.options.dataCollectionResolver.httpResponseHeaders,
+        )
+        .toMutableMap()
+    }
+    return getHeaders(scopes, responseHeaders)
   }
 
   private fun getHeaders(scopes: IScopes, requestHeaders: Headers): MutableMap<String, String>? {

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpUtilsTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpUtilsTest.kt
@@ -159,6 +159,40 @@ class SentryOkHttpUtilsTest {
   }
 
   @Test
+  fun `data collection filters response headers`() {
+    val sut = fixture.getSut {
+      dataCollection.httpHeaders.response = KeyValueCollectionBehavior.denyList("response")
+    }
+    val request = getRequest()
+    val response = sut.newCall(request).execute()
+
+    SentryOkHttpUtils.captureClientError(fixture.scopes, request, response)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        check {
+          assertEquals("[Filtered]", it.contexts.response!!.headers!!["myResponseHeader"])
+          assertEquals("[Filtered]", it.contexts.response!!.headers!!["Set-Cookie"])
+        },
+        any<Hint>(),
+      )
+  }
+
+  @Test
+  fun `data collection can disable response headers`() {
+    val sut = fixture.getSut {
+      dataCollection.httpHeaders.response = KeyValueCollectionBehavior.off()
+    }
+    val request = getRequest()
+    val response = sut.newCall(request).execute()
+
+    SentryOkHttpUtils.captureClientError(fixture.scopes, request, response)
+
+    verify(fixture.scopes)
+      .captureEvent(check { assertTrue(it.contexts.response!!.headers!!.isEmpty()) }, any<Hint>())
+  }
+
+  @Test
   fun `captureClientError without sendDefaultPii does not send headers`() {
     val sut = fixture.getSut(sendDefaultPii = false)
     val request = getRequest()


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Apply the response-header Data Collection policy to OkHttp, Ktor, and Apollo 3/4 failed-request events.

Explicit Data Collection supports off, deny-list, and allow-list behavior with canonical sensitive-key filtering. When Data Collection is absent, `sendDefaultPii=false` continues to omit response headers and `sendDefaultPii=true` continues to collect headers while omitting legacy-sensitive names.

## :bulb: Motivation and Context

These are the current global response-header consumers. Central filtering provides granular response-header control while preserving historical behavior for applications that have not opted into Data Collection. Session Replay network headers remain governed by Replay-specific integration controls.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- Full OkHttp, Ktor, Apollo 3, and Apollo 4 tests
- `git diff --check`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Migrate cookie and query-parameter collection. Document that Session Replay remains governed by Replay-specific privacy controls.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
