### PR TITLE
fix(replay): Prevent concurrent PixelCopy frame access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Prevent concurrent PixelCopy access during Session Replay masking and bitmap cleanup ([#5808](https://github.com/getsentry/sentry-java/pull/5808))
 - Release `MediaMuxer` when the replay video encoder fails to start to avoid a resource leak ([#5607](https://github.com/getsentry/sentry-java/pull/5607))
 
 ### Performance

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -376,7 +376,11 @@ internal class PixelCopyStrategy(
 
   private fun finishFrame() {
     frameInFlight.set(false)
-    if (isClosed.get()) {
+    // Only clean up if we're closed AND can re-take the gate. If a new capture slipped in after we
+    // released it (its CAS won), that frame now owns the shared screenshot; its own finishFrame
+    // will
+    // clean up. Backing off here avoids recycling the bitmap while that capture is still using it.
+    if (isClosed.get() && frameInFlight.compareAndSet(false, true)) {
       scheduleCleanup()
     }
   }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -59,6 +59,8 @@ internal class PixelCopyStrategy(
   private val contentChanged = AtomicBoolean(false)
   private val unstableCaptures = AtomicInteger(0)
   private val isClosed = AtomicBoolean(false)
+  private val frameInFlight = AtomicBoolean(false)
+  private val cleanupScheduled = AtomicBoolean(false)
   private val dstOverPaint by
     lazy(NONE) { Paint().apply { xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OVER) } }
   private val screenshotCanvas by lazy(NONE) { Canvas(screenshot) }
@@ -77,8 +79,14 @@ internal class PixelCopyStrategy(
       return
     }
 
+    if (!frameInFlight.compareAndSet(false, true)) {
+      options.logger.log(DEBUG, "PixelCopyStrategy capture is already in flight, skipping")
+      return
+    }
+
     if (isClosed.get()) {
       options.logger.log(DEBUG, "PixelCopyStrategy is closed, not capturing screenshot")
+      finishFrame()
       return
     }
 
@@ -90,6 +98,7 @@ internal class PixelCopyStrategy(
         { copyResult: Int ->
           if (isClosed.get()) {
             options.logger.log(DEBUG, "PixelCopyStrategy is closed, ignoring capture result")
+            finishFrame()
             return@request
           }
 
@@ -97,11 +106,13 @@ internal class PixelCopyStrategy(
             options.logger.log(INFO, "Failed to capture replay recording: %d", copyResult)
             unstableCaptures.set(0)
             lastCaptureSuccessful.set(false)
+            finishFrame()
             return@request
           }
 
           val changedDuringCapture = contentChanged.get()
           if (changedDuringCapture && shouldSkipUnstableCapture()) {
+            finishFrame()
             return@request
           }
 
@@ -116,15 +127,23 @@ internal class PixelCopyStrategy(
           root.traverse(viewHierarchy, options.sessionReplay, options.logger, surfaceViewNodes)
 
           if (surfaceViewNodes.isNullOrEmpty()) {
-            executor.submit(
-              ReplayRunnable("screenshot_recorder.mask") {
-                applyMaskingAndNotify(
-                  root,
-                  viewHierarchy,
-                  resetUnstableCaptures = !changedDuringCapture,
-                )
-              }
-            )
+            val submitted =
+              executor.submit(
+                ReplayRunnable("screenshot_recorder.mask") {
+                  try {
+                    applyMaskingAndNotify(
+                      root,
+                      viewHierarchy,
+                      resetUnstableCaptures = !changedDuringCapture,
+                    )
+                  } finally {
+                    finishFrame()
+                  }
+                }
+              )
+            if (submitted == null) {
+              finishFrame()
+            }
           } else {
             // Re-arm the recorder's contentChanged gate; SurfaceView redraws don't trigger
             // ViewTreeObserver.OnDrawListener, so we'd otherwise emit the same frame forever.
@@ -143,6 +162,7 @@ internal class PixelCopyStrategy(
       options.logger.log(WARNING, "Failed to capture replay recording", e)
       unstableCaptures.set(0)
       lastCaptureSuccessful.set(false)
+      finishFrame()
     }
   }
 
@@ -272,37 +292,46 @@ internal class PixelCopyStrategy(
     windowY: Int,
     resetUnstableCaptures: Boolean,
   ) {
-    executor.submit(
-      ReplayRunnable("screenshot_recorder.composite") {
-        if (isClosed.get() || screenshot.isRecycled) {
-          options.logger.log(DEBUG, "PixelCopyStrategy is closed, skipping compositing")
-          recycleCaptures(captures)
-          return@ReplayRunnable
+    val submitted =
+      executor.submit(
+        ReplayRunnable("screenshot_recorder.composite") {
+          try {
+            if (isClosed.get() || screenshot.isRecycled) {
+              options.logger.log(DEBUG, "PixelCopyStrategy is closed, skipping compositing")
+              recycleCaptures(captures)
+              return@ReplayRunnable
+            }
+
+            for (capture in captures) {
+              if (capture == null) continue
+              if (capture.bitmap.isRecycled) continue
+
+              compositeSurfaceViewInto(
+                screenshotCanvas,
+                dstOverPaint,
+                tmpSrcRect,
+                tmpDstRect,
+                capture.bitmap,
+                capture.x,
+                capture.y,
+                windowX,
+                windowY,
+                config.scaleFactorX,
+                config.scaleFactorY,
+              )
+              capture.bitmap.recycle()
+            }
+
+            applyMaskingAndNotify(root, viewHierarchy, resetUnstableCaptures)
+          } finally {
+            finishFrame()
+          }
         }
-
-        for (capture in captures) {
-          if (capture == null) continue
-          if (capture.bitmap.isRecycled) continue
-
-          compositeSurfaceViewInto(
-            screenshotCanvas,
-            dstOverPaint,
-            tmpSrcRect,
-            tmpDstRect,
-            capture.bitmap,
-            capture.x,
-            capture.y,
-            windowX,
-            windowY,
-            config.scaleFactorX,
-            config.scaleFactorY,
-          )
-          capture.bitmap.recycle()
-        }
-
-        applyMaskingAndNotify(root, viewHierarchy, resetUnstableCaptures)
-      }
-    )
+      )
+    if (submitted == null) {
+      recycleCaptures(captures)
+      finishFrame()
+    }
   }
 
   private fun recycleCaptures(captures: Array<SurfaceViewCapture?>) {
@@ -322,7 +351,7 @@ internal class PixelCopyStrategy(
   }
 
   override fun emitLastScreenshot() {
-    if (lastCaptureSuccessful() && !screenshot.isRecycled) {
+    if (!frameInFlight.get() && lastCaptureSuccessful() && !screenshot.isRecycled) {
       screenshotRecorderCallback?.onScreenshotRecorded(screenshot)
     }
   }
@@ -330,6 +359,22 @@ internal class PixelCopyStrategy(
   override fun close() {
     isClosed.set(true)
     unstableCaptures.set(0)
+    if (!frameInFlight.get()) {
+      scheduleCleanup()
+    }
+  }
+
+  private fun finishFrame() {
+    frameInFlight.set(false)
+    if (isClosed.get()) {
+      scheduleCleanup()
+    }
+  }
+
+  private fun scheduleCleanup() {
+    if (!cleanupScheduled.compareAndSet(false, true)) {
+      return
+    }
     executor.submit(
       ReplayRunnable(
         "PixelCopyStrategy.close",

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -60,7 +60,6 @@ internal class PixelCopyStrategy(
   private val unstableCaptures = AtomicInteger(0)
   private val isClosed = AtomicBoolean(false)
   private val frameInFlight = AtomicBoolean(false)
-  private val cleanupScheduled = AtomicBoolean(false)
   private val dstOverPaint by
     lazy(NONE) { Paint().apply { xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OVER) } }
   private val screenshotCanvas by lazy(NONE) { Canvas(screenshot) }
@@ -383,9 +382,6 @@ internal class PixelCopyStrategy(
   }
 
   private fun scheduleCleanup() {
-    if (!cleanupScheduled.compareAndSet(false, true)) {
-      return
-    }
     val cleanup =
       ReplayRunnable(
         "PixelCopyStrategy.close",

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -117,9 +117,8 @@ internal class PixelCopyStrategy(
             return@request
           }
 
-          // Ensure the frame gate is always released if anything below throws before we hand
-          // work off to the executor — otherwise a single failure wedges captures forever.
-          var handedOff = false
+          // Release the frame gate if anything below throws before we hand work off to the
+          // executor — otherwise a single failure wedges captures forever.
           try {
             // TODO: disableAllMasking here and dont traverse?
             val viewHierarchy = ViewHierarchyNode.fromView(root, null, 0, options.sessionReplay)
@@ -146,8 +145,8 @@ internal class PixelCopyStrategy(
                     }
                   }
                 )
-              if (submitted != null) {
-                handedOff = true
+              if (submitted == null) {
+                finishFrame()
               }
             } else {
               // Re-arm the recorder's contentChanged gate; SurfaceView redraws don't trigger
@@ -159,14 +158,10 @@ internal class PixelCopyStrategy(
                 viewHierarchy,
                 resetUnstableCaptures = !changedDuringCapture,
               )
-              handedOff = true
             }
           } catch (e: Throwable) {
             options.logger.log(WARNING, "Failed to process replay frame", e)
-          } finally {
-            if (!handedOff) {
-              finishFrame()
-            }
+            finishFrame()
           }
         },
         mainLooperHandler.handler,

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -81,6 +81,7 @@ internal class PixelCopyStrategy(
 
     if (!frameInFlight.compareAndSet(false, true)) {
       options.logger.log(DEBUG, "PixelCopyStrategy capture is already in flight, skipping")
+      markContentChanged()
       return
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -361,8 +361,27 @@ internal class PixelCopyStrategy(
   }
 
   override fun emitLastScreenshot() {
-    if (!frameInFlight.get() && lastCaptureSuccessful() && !screenshot.isRecycled) {
-      screenshotRecorderCallback?.onScreenshotRecorded(screenshot)
+    if (!frameInFlight.compareAndSet(false, true)) {
+      return
+    }
+    if (!lastCaptureSuccessful() || screenshot.isRecycled) {
+      finishFrame()
+      return
+    }
+    // Submit to the executor so the downstream consumer's bitmap read (JPEG compress) runs inline
+    // on the worker thread while the gate is held, same as the masked capture path.
+    val submitted =
+      executor.submit(
+        ReplayRunnable("PixelCopyStrategy.emit") {
+          try {
+            screenshotRecorderCallback?.onScreenshotRecorded(screenshot)
+          } finally {
+            finishFrame()
+          }
+        }
+      )
+    if (submitted == null) {
+      finishFrame()
     }
   }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -117,44 +117,56 @@ internal class PixelCopyStrategy(
             return@request
           }
 
-          // TODO: disableAllMasking here and dont traverse?
-          val viewHierarchy = ViewHierarchyNode.fromView(root, null, 0, options.sessionReplay)
-          val surfaceViewNodes =
-            if (options.sessionReplay.isCaptureSurfaceViews) {
-              mutableListOf<ViewHierarchyNode.SurfaceViewHierarchyNode>()
-            } else {
-              null
-            }
-          root.traverse(viewHierarchy, options.sessionReplay, options.logger, surfaceViewNodes)
+          // Ensure the frame gate is always released if anything below throws before we hand
+          // work off to the executor — otherwise a single failure wedges captures forever.
+          var handedOff = false
+          try {
+            // TODO: disableAllMasking here and dont traverse?
+            val viewHierarchy = ViewHierarchyNode.fromView(root, null, 0, options.sessionReplay)
+            val surfaceViewNodes =
+              if (options.sessionReplay.isCaptureSurfaceViews) {
+                mutableListOf<ViewHierarchyNode.SurfaceViewHierarchyNode>()
+              } else {
+                null
+              }
+            root.traverse(viewHierarchy, options.sessionReplay, options.logger, surfaceViewNodes)
 
-          if (surfaceViewNodes.isNullOrEmpty()) {
-            val submitted =
-              executor.submit(
-                ReplayRunnable("screenshot_recorder.mask") {
-                  try {
-                    applyMaskingAndNotify(
-                      root,
-                      viewHierarchy,
-                      resetUnstableCaptures = !changedDuringCapture,
-                    )
-                  } finally {
-                    finishFrame()
+            if (surfaceViewNodes.isNullOrEmpty()) {
+              val submitted =
+                executor.submit(
+                  ReplayRunnable("screenshot_recorder.mask") {
+                    try {
+                      applyMaskingAndNotify(
+                        root,
+                        viewHierarchy,
+                        resetUnstableCaptures = !changedDuringCapture,
+                      )
+                    } finally {
+                      finishFrame()
+                    }
                   }
-                }
+                )
+              if (submitted != null) {
+                handedOff = true
+              }
+            } else {
+              // Re-arm the recorder's contentChanged gate; SurfaceView redraws don't trigger
+              // ViewTreeObserver.OnDrawListener, so we'd otherwise emit the same frame forever.
+              markContentChanged()
+              captureSurfaceViews(
+                root,
+                surfaceViewNodes,
+                viewHierarchy,
+                resetUnstableCaptures = !changedDuringCapture,
               )
-            if (submitted == null) {
+              handedOff = true
+            }
+          } catch (e: Throwable) {
+            options.logger.log(WARNING, "Failed to process replay frame", e)
+          } finally {
+            if (!handedOff) {
               finishFrame()
             }
-          } else {
-            // Re-arm the recorder's contentChanged gate; SurfaceView redraws don't trigger
-            // ViewTreeObserver.OnDrawListener, so we'd otherwise emit the same frame forever.
-            markContentChanged()
-            captureSurfaceViews(
-              root,
-              surfaceViewNodes,
-              viewHierarchy,
-              resetUnstableCaptures = !changedDuringCapture,
-            )
           }
         },
         mainLooperHandler.handler,
@@ -376,7 +388,7 @@ internal class PixelCopyStrategy(
     if (!cleanupScheduled.compareAndSet(false, true)) {
       return
     }
-    executor.submit(
+    val cleanup =
       ReplayRunnable(
         "PixelCopyStrategy.close",
         {
@@ -390,7 +402,11 @@ internal class PixelCopyStrategy(
           maskRenderer.close()
         },
       )
-    )
+    // close() typically runs after ReplayIntegration has shut down the executor, so submit may
+    // return null. Fall back to running cleanup inline so the bitmap + mask renderer are freed.
+    if (executor.submit(cleanup) == null) {
+      cleanup.run()
+    }
   }
 }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -369,18 +369,24 @@ internal class PixelCopyStrategy(
   override fun close() {
     isClosed.set(true)
     unstableCaptures.set(0)
-    if (!frameInFlight.get()) {
-      scheduleCleanup()
-    }
+    cleanUpIfIdle()
   }
 
   private fun finishFrame() {
     frameInFlight.set(false)
-    // Only clean up if we're closed AND can re-take the gate. If a new capture slipped in after we
-    // released it (its CAS won), that frame now owns the shared screenshot; its own finishFrame
-    // will
-    // clean up. Backing off here avoids recycling the bitmap while that capture is still using it.
-    if (isClosed.get() && frameInFlight.compareAndSet(false, true)) {
+    if (isClosed.get()) {
+      cleanUpIfIdle()
+    }
+  }
+
+  /**
+   * Schedules cleanup only for the caller that owns the gate. Whoever wins [frameInFlight]'s CAS
+   * (close when no frame is running, or the finishFrame of the last in-flight frame after close)
+   * runs cleanup exactly once; a racing capture that took the gate loses the CAS and backs off, so
+   * we never recycle the shared screenshot while that capture is still using it.
+   */
+  private fun cleanUpIfIdle() {
+    if (frameInFlight.compareAndSet(false, true)) {
       scheduleCleanup()
     }
   }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/screenshot/PixelCopyStrategy.kt
@@ -159,7 +159,10 @@ internal class PixelCopyStrategy(
                 resetUnstableCaptures = !changedDuringCapture,
               )
             }
-          } catch (e: Throwable) {
+          } catch (e: RuntimeException) {
+            // OEM View subclasses have been observed throwing during hierarchy traversal
+            // (e.g. Redmi's TextView NPE). Release the frame gate so a single bad frame
+            // doesn't wedge the recorder. Errors (OOM, LinkageError) intentionally propagate.
             options.logger.log(WARNING, "Failed to process replay frame", e)
             finishFrame()
           }
@@ -397,8 +400,9 @@ internal class PixelCopyStrategy(
           maskRenderer.close()
         },
       )
-    // close() typically runs after ReplayIntegration has shut down the executor, so submit may
-    // return null. Fall back to running cleanup inline so the bitmap + mask renderer are freed.
+    // ReplayExecutorService.submit returns null only on genuine rejection (post-shutdown);
+    // inline execution on the worker thread returns a completed future. Fall back to running
+    // cleanup here so the bitmap + mask renderer are freed even when the executor is dead.
     if (executor.submit(cleanup) == null) {
       cleanup.run()
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/ReplayExecutorService.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/ReplayExecutorService.kt
@@ -4,6 +4,7 @@ import io.sentry.SentryLevel.ERROR
 import io.sentry.SentryOptions
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
@@ -14,11 +15,20 @@ internal class ReplayExecutorService(
   private val delegate: ScheduledExecutorService,
   private val options: SentryOptions,
 ) : ScheduledExecutorService by delegate {
+  /**
+   * Submits [task] for execution and returns a [Future] describing what happened. The return value
+   * has three distinct outcomes callers can rely on:
+   * - [CompletedFuture] — the caller is already on the replay worker thread, so the task was run
+   *   inline before this method returned. Skips the queue.
+   * - A regular [Future] from the underlying [ScheduledExecutorService] — the task was queued and
+   *   will run asynchronously.
+   * - `null` — the underlying executor rejected the submission (typically because it has been shut
+   *   down). The task did NOT run; callers that need cleanup must handle it themselves.
+   */
   override fun submit(task: Runnable): Future<*>? {
     if (Thread.currentThread().name.startsWith("SentryReplayIntegration")) {
-      // we're already on the worker thread, no need to submit
       task.run()
-      return null
+      return CompletedFuture
     }
     return try {
       delegate.submit {
@@ -68,3 +78,16 @@ internal class ReplayExecutorService(
 }
 
 internal class ReplayRunnable(val taskName: String, delegate: Runnable) : Runnable by delegate
+
+/** A Future that represents an already-completed inline execution — never used as null. */
+internal object CompletedFuture : Future<Unit> {
+  override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+
+  override fun isCancelled(): Boolean = false
+
+  override fun isDone(): Boolean = true
+
+  override fun get() {}
+
+  override fun get(timeout: Long, unit: TimeUnit) {}
+}

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -27,6 +27,7 @@ import io.sentry.android.replay.ScreenshotRecorderCallback
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.util.DebugOverlayDrawable
 import io.sentry.android.replay.util.MainLooperHandler
+import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -138,6 +139,98 @@ class PixelCopyStrategyTest {
     shadowOf(Looper.getMainLooper()).idle()
 
     if (failure.get() != null) throw failure.get()
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `capture drops frame while PixelCopy is in flight`() {
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val strategy = fixture.getSut(executor = fixture.inlineExecutor())
+
+    strategy.capture(root)
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(fixture.callback).onScreenshotRecorded(any<Bitmap>())
+
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(fixture.callback, times(2)).onScreenshotRecorded(any<Bitmap>())
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `capture drops frame while masking is in flight`() {
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val tasks = mutableListOf<Runnable>()
+    val executor = mock<ScheduledExecutorService>()
+    whenever(executor.submit(any<Runnable>())).doAnswer {
+      tasks += it.getArgument<Runnable>(0)
+      mock<Future<*>>()
+    }
+    val strategy = fixture.getSut(executor)
+
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertEquals(1, tasks.size)
+    tasks.removeAt(0).run()
+
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertEquals(1, tasks.size)
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `emitLastScreenshot skips while frame is in flight`() {
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val strategy = fixture.getSut(executor = fixture.inlineExecutor())
+    captureStableFrame(strategy, root)
+
+    strategy.capture(root)
+    strategy.emitLastScreenshot()
+
+    verify(fixture.callback).onScreenshotRecorded(any<Bitmap>())
+
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(fixture.callback, times(2)).onScreenshotRecorded(any<Bitmap>())
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `close defers cleanup until PixelCopy completes`() {
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val executor = mock<ScheduledExecutorService>()
+    val strategy = fixture.getSut(executor)
+
+    strategy.capture(root)
+    strategy.close()
+
+    verify(executor, never()).submit(any<Runnable>())
+
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(executor).submit(any<Runnable>())
   }
 
   @Test

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -25,6 +25,7 @@ import io.sentry.SentryOptions
 import io.sentry.android.replay.ExecutorProvider
 import io.sentry.android.replay.ScreenshotRecorderCallback
 import io.sentry.android.replay.ScreenshotRecorderConfig
+import io.sentry.android.replay.util.CompletedFuture
 import io.sentry.android.replay.util.DebugOverlayDrawable
 import io.sentry.android.replay.util.MainLooperHandler
 import io.sentry.android.replay.util.ReplayRunnable
@@ -87,7 +88,10 @@ class PixelCopyStrategyTest {
       return mock {
         doAnswer {
             (it.arguments[0] as Runnable).run()
-            null // submit(Runnable) returns Future<?>; returning Unit breaks the cast
+            // Mirror ReplayExecutorService's inline contract: a completed future, not null. Null
+            // means "rejected" and would make capture() run its null-fallback finishFrame on top of
+            // the task's own, a double-release production never does on the inline path.
+            CompletedFuture
           }
           .whenever(mock)
           .submit(any<Runnable>())

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -281,6 +281,30 @@ class PixelCopyStrategyTest {
 
   @Test
   @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `idle close claims the gate so a racing capture cannot schedule a second cleanup`() {
+    // Mirror of the finishFrame guard, but for close()'s idle path (no frame in flight). close()
+    // must atomically claim the gate before scheduling cleanup; otherwise a capture racing in right
+    // after the check can take the gate, see isClosed, run finishFrame and schedule cleanup a
+    // second
+    // time. Both cleanups are idempotent, but a single submit is the invariant we keep uniform.
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val executor = mock<ScheduledExecutorService>()
+    whenever(executor.submit(any<Runnable>())).thenReturn(mock<Future<*>>())
+    val strategy = fixture.getSut(executor)
+
+    strategy.close() // idle -> claims gate, schedules the one cleanup
+    // A capture landing after close must be dropped (gate held), not schedule cleanup again.
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(executor, times(1)).submit(any<Runnable>())
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
   fun `frame gate is released when masking submit is rejected`() {
     val activity = buildActivity(SimpleActivity::class.java).setup()
     shadowOf(Looper.getMainLooper()).idle()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -247,6 +247,40 @@ class PixelCopyStrategyTest {
 
   @Test
   @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `close-triggered cleanup keeps the frame gate so a racing capture cannot double-clean up`() {
+    // Guards the CAS handoff in finishFrame(). The real race is a 3-thread interleave (a new
+    // capture takes the gate the instant finishFrame releases it, then the old finishFrame recycles
+    // the bitmap the new capture is writing) and isn't deterministically reproducible single-
+    // threaded. This exercises its observable invariant instead: when finishFrame cleans up on
+    // close, it must re-take the gate (frameInFlight stays held), so any later capture is dropped
+    // rather than sneaking through to schedule a *second* cleanup on the shared screenshot.
+    // Without the CAS (plain frameInFlight.set(false)) the gate is left free and the follow-up
+    // capture reaches the isClosed guard and schedules cleanup again -> 2 submits.
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val executor = mock<ScheduledExecutorService>()
+    whenever(executor.submit(any<Runnable>())).thenReturn(mock<Future<*>>())
+    val strategy = fixture.getSut(executor)
+
+    strategy.capture(root)
+    strategy.close() // in-flight -> cleanup deferred, no submit yet
+
+    // PixelCopy completes; the callback sees isClosed and runs finishFrame -> the one cleanup.
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // A capture racing in after close must be dropped (gate still held), not schedule cleanup
+    // again.
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(executor, times(1)).submit(any<Runnable>())
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
   fun `frame gate is released when masking submit is rejected`() {
     val activity = buildActivity(SimpleActivity::class.java).setup()
     shadowOf(Looper.getMainLooper()).idle()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -141,7 +141,7 @@ class PixelCopyStrategyTest {
         // PixelCopyStrategy swallows the exception, so we have to capture it here and rethrow later
         failure.set(e)
       }
-      null
+      CompletedFuture
     }
 
     strategy = fixture.getSut(executor = executorThatClosesFirst)
@@ -227,6 +227,59 @@ class PixelCopyStrategyTest {
     DeferredWindowPixelCopyShadow.flush()
     shadowOf(Looper.getMainLooper()).idle()
     verify(fixture.callback, times(2)).onScreenshotRecorded(any<Bitmap>())
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `emitLastScreenshot holds the frame gate until the emit task drains`() {
+    // emit submits the consumer call to the executor so the bitmap read (JPEG compress) runs
+    // inline on the worker thread while the gate is held — same pattern as the masked capture path.
+    // Invariant: while the emit task is still queued (gate held), a racing capture is dropped.
+    // Without the gate (old `if (!frameInFlight.get())`) that capture proceeds -> extra frame.
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    val tasks = mutableListOf<Runnable>()
+    val executor = mock<ScheduledExecutorService>()
+    whenever(executor.submit(any<Runnable>())).doAnswer {
+      tasks.add(it.arguments[0] as Runnable)
+      mock<Future<*>>()
+    }
+    val strategy = fixture.getSut(executor)
+
+    // Set up a successful last capture: capture -> queued mask task -> drain releases the gate.
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+    tasks.removeAll {
+      it.run()
+      true
+    }
+    verify(fixture.callback, times(1)).onScreenshotRecorded(any<Bitmap>())
+
+    // Emit takes the gate and queues the consumer task (still pending).
+    strategy.emitLastScreenshot()
+    // Callback hasn't fired yet — the task is queued, not drained.
+    verify(fixture.callback, times(1)).onScreenshotRecorded(any<Bitmap>())
+
+    // A capture racing in before the emit task drains must be dropped (gate held).
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(fixture.callback, times(1)).onScreenshotRecorded(any<Bitmap>())
+
+    // Drain the emit task -> callback fires, gate released -> captures resume.
+    tasks.removeAll {
+      it.run()
+      true
+    }
+    verify(fixture.callback, times(2)).onScreenshotRecorded(any<Bitmap>())
+    captureStableFrame(strategy, root)
+    tasks.removeAll {
+      it.run()
+      true
+    }
+    verify(fixture.callback, times(3)).onScreenshotRecorded(any<Bitmap>())
   }
 
   @Test

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -238,6 +238,42 @@ class PixelCopyStrategyTest {
 
   @Test
   @Config(shadows = [DeferredWindowPixelCopyShadow::class])
+  fun `frame gate is released when masking submit is rejected`() {
+    val activity = buildActivity(SimpleActivity::class.java).setup()
+    shadowOf(Looper.getMainLooper()).idle()
+    val root = activity.get().findViewById<View>(android.R.id.content)
+    // Simulate an already-shutdown executor: submit returns null.
+    val executor = mock<ScheduledExecutorService>()
+    whenever(executor.submit(any<Runnable>())).thenReturn(null)
+    val strategy = fixture.getSut(executor)
+
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Gate must have been released; a follow-up capture should proceed rather than being dropped.
+    strategy.capture(root)
+    DeferredWindowPixelCopyShadow.flush()
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(executor, times(2)).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `close cleans up inline when executor is already shut down`() {
+    // submit returns null → previously the bitmap + maskRenderer would leak.
+    val executor = mock<ScheduledExecutorService>()
+    whenever(executor.submit(any<Runnable>())).thenReturn(null)
+    val strategy = fixture.getSut(executor)
+
+    strategy.close()
+
+    // No crash and the submit was attempted exactly once (cleanup ran inline as fallback).
+    verify(executor).submit(any<Runnable>())
+  }
+
+  @Test
+  @Config(shadows = [DeferredWindowPixelCopyShadow::class])
   fun `capture skips the first unstable PixelCopy result`() {
     val activity = buildActivity(SimpleActivity::class.java).setup()
     shadowOf(Looper.getMainLooper()).idle()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -151,6 +151,9 @@ class PixelCopyStrategyTest {
 
     strategy.capture(root)
     strategy.capture(root)
+
+    assertTrue(fixture.contentChangedMarked.get())
+
     DeferredWindowPixelCopyShadow.flush()
     shadowOf(Looper.getMainLooper()).idle()
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/screenshot/PixelCopyStrategyTest.kt
@@ -27,6 +27,7 @@ import io.sentry.android.replay.ScreenshotRecorderCallback
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.util.DebugOverlayDrawable
 import io.sentry.android.replay.util.MainLooperHandler
+import io.sentry.android.replay.util.ReplayRunnable
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
@@ -113,18 +114,23 @@ class PixelCopyStrategyTest {
   }
 
   @Test
-  fun `when close is called while executor task is running, does not crash with recycled bitmap`() {
+  fun `when close races the mask task, masking is skipped and no screenshot is emitted`() {
     val activity = buildActivity(SimpleActivity::class.java).setup()
     shadowOf(Looper.getMainLooper()).idle()
 
     var strategy: PixelCopyStrategy? = null
 
     val failure = AtomicReference<Throwable>()
-    // Custom executor that closes the strategy before executing tasks
+    // Custom executor that closes the strategy right before running the mask task, to simulate
+    // close() racing an in-flight mask task. We key off the mask task specifically (not "the first
+    // submit") because close() itself submits the cleanup task — closing again when that runs would
+    // recurse via close() -> scheduleCleanup() -> submit(), a loop no real code path can produce.
     val executorThatClosesFirst = mock<ScheduledExecutorService>()
     whenever(executorThatClosesFirst.submit(any<Runnable>())).doAnswer {
       val task = it.getArgument<Runnable>(0)
-      strategy?.close()
+      if ((task as? ReplayRunnable)?.taskName == "screenshot_recorder.mask") {
+        strategy?.close()
+      }
       try {
         task.run()
       } catch (e: Throwable) {
@@ -139,6 +145,9 @@ class PixelCopyStrategyTest {
     shadowOf(Looper.getMainLooper()).idle()
 
     if (failure.get() != null) throw failure.get()
+    // close() landed before masking ran, so applyMaskingAndNotify must bail out early and never
+    // hand a screenshot to the callback after the strategy is closed.
+    verify(fixture.callback, never()).onScreenshotRecorded(any<Bitmap>())
   }
 
   @Test


### PR DESCRIPTION
## 📜 Description

Prevent concurrent access to the bitmap shared by PixelCopy and replay processing.

The strategy now drops a capture while another frame is in flight, keeps the gate held through<br>masking and SurfaceView compositing, suppresses last-frame emission during that work, and defers<br>bitmap cleanup until the outstanding PixelCopy callback completes.

## 💡 Motivation and Context

`PixelCopy.request()` returns before RenderThread finishes writing its destination. The replay<br>executor could therefore draw masks or SurfaceView content into the same bitmap, while `close()`<br>could recycle it before the asynchronous request completed. This could produce torn or improperly<br>masked frames and may contribute to native `libhwui` crashes.

Dropping an overlapping frame avoids blocking the main thread or allocating a second recording<br>bitmap. Replay time remains continuous; the previous frame is displayed longer when a capture is<br>dropped. This should be rare at the default 1 FPS, while sustained overload at higher frame rates<br>may reduce visual smoothness rather than emit a corrupt or improperly masked frame.

Fixes getsentry/sentry-java#5340<br>Refs getsentry/sentry-java#5340

## 💚 How did you test it?

* `./gradlew ':sentry-android-replay:testDebugUnitTest' --tests='*PixelCopyStrategyTest*' --info`
* `./gradlew spotlessApply apiDump`

Added regression coverage for requests overlapping PixelCopy, queued masking, last-frame emission,<br>and cleanup during an outstanding request.

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.

## 🔮 Next steps

* Harden capture submission around Window and SurfaceView lifecycle transitions separately.
* Consider restoring `RGB_565` when SurfaceView capture is disabled in a separate change.