### PR TITLE
fix(replay): Skip buffer-mode replay capture when rate-limited (DART-313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Skip encoding and capturing buffered session replay segments while rate-limited, so we don't waste resources on envelopes the transport will drop ([#5813](https://github.com/getsentry/sentry-java/pull/5813))
+  - These skipped replays are now reported as `ratelimit_backoff` discarded events in client reports, so they no longer disappear from drop statistics. One event is recorded per buffer flush rather than per segment.
 - Reduce main-thread work during `Sentry.init` by resolving the shake-detector accelerometer off the main thread (~1.75ms on a Pixel 10) ([#5784](https://github.com/getsentry/sentry-java/pull/5784))
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 - `SentryTagModifierNode.isImportantForBounds` now matches the default behavior and returns `true` ([#5789](https://github.com/getsentry/sentry-java/pull/5789))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Skip encoding and capturing buffered session replay segments while rate-limited, so we don't waste resources on envelopes the transport will drop ([#5813](https://github.com/getsentry/sentry-java/pull/5813))
   - These skipped replays are now reported as `ratelimit_backoff` discarded events in client reports, so they no longer disappear from drop statistics. One event is recorded per buffer flush rather than per segment.
+  - Buffer mode is also kept while rate-limited instead of switching to session mode, so the rolling buffer stays warm and the next error after the rate limit expires can send a complete replay.
 - Reduce main-thread work during `Sentry.init` by resolving the shake-detector accelerometer off the main thread (~1.75ms on a Pixel 10) ([#5784](https://github.com/getsentry/sentry-java/pull/5784))
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 - `SentryTagModifierNode.isImportantForBounds` now matches the default behavior and returns `true` ([#5789](https://github.com/getsentry/sentry-java/pull/5789))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Skip encoding and capturing buffered session replay segments while rate-limited, so we don't waste resources on envelopes the transport will drop ([#5813](https://github.com/getsentry/sentry-java/pull/5813))
 - Reduce main-thread work during `Sentry.init` by resolving the shake-detector accelerometer off the main thread (~1.75ms on a Pixel 10) ([#5784](https://github.com/getsentry/sentry-java/pull/5784))
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 - `SentryTagModifierNode.isImportantForBounds` now matches the default behavior and returns `true` ([#5789](https://github.com/getsentry/sentry-java/pull/5789))

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -19,6 +19,7 @@ import io.sentry.android.replay.capture.CaptureStrategy.Companion.rotateEvents
 import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
 import io.sentry.android.replay.util.ReplayRunnable
 import io.sentry.android.replay.util.sample
+import io.sentry.clientreport.DiscardReason.RATELIMIT_BACKOFF
 import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.FileUtils
@@ -78,13 +79,6 @@ internal class BufferCaptureStrategy(
   }
 
   override fun captureReplay(isTerminating: Boolean, onSegmentSent: (Date) -> Unit) {
-    if (isReplayRateLimited()) {
-      // the segment envelopes would be dropped by the transport anyway, so don't waste resources
-      // encoding videos that will only be discarded
-      options.logger.log(INFO, "Replay is rate-limited, not capturing for event")
-      return
-    }
-
     val sampled = random.sample(options.sessionReplay.onErrorSampleRate)
 
     if (!sampled) {
@@ -106,6 +100,18 @@ internal class BufferCaptureStrategy(
         DEBUG,
         "Not capturing replay for crashed event, will be captured on next launch",
       )
+      return
+    }
+
+    if (isReplayRateLimited()) {
+      // the segment envelopes would be dropped by the transport anyway, so don't waste resources
+      // encoding videos that will only be discarded
+      options.logger.log(INFO, "Replay is rate-limited, not capturing for event")
+      // one lost event per flush, not per segment: the transport would have counted the current
+      // segment plus every buffered one, but a flush only ever loses a single replay from the
+      // user's perspective. Under-reporting here is preferable to making replay look like it
+      // dropped data it never held.
+      options.clientReportRecorder.recordLostEvent(RATELIMIT_BACKOFF, Replay)
       return
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.graphics.Bitmap
 import android.view.MotionEvent
+import io.sentry.DataCategory.All
+import io.sentry.DataCategory.Replay
 import io.sentry.DateUtils
 import io.sentry.IScopes
 import io.sentry.SentryLevel.DEBUG
@@ -76,6 +78,13 @@ internal class BufferCaptureStrategy(
   }
 
   override fun captureReplay(isTerminating: Boolean, onSegmentSent: (Date) -> Unit) {
+    if (isReplayRateLimited()) {
+      // the segment envelopes would be dropped by the transport anyway, so don't waste resources
+      // encoding videos that will only be discarded
+      options.logger.log(INFO, "Replay is rate-limited, not capturing for event")
+      return
+    }
+
     val sampled = random.sample(options.sessionReplay.onErrorSampleRate)
 
     if (!sampled) {
@@ -169,6 +178,11 @@ internal class BufferCaptureStrategy(
     val bufferLimit = dateProvider.currentTimeMillis - options.sessionReplay.errorReplayDuration
     rotateEvents(currentEvents, bufferLimit)
   }
+
+  private fun isReplayRateLimited(): Boolean =
+    scopes?.rateLimiter?.let {
+      it.isActiveForCategory(All) || it.isActiveForCategory(Replay)
+    } == true
 
   private fun deleteFile(file: File?) {
     if (file == null) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -166,6 +166,13 @@ internal class BufferCaptureStrategy(
       )
       return this
     }
+    if (isReplayRateLimited()) {
+      // captureReplay skipped the flush, so there is nothing to continue in session mode. Staying
+      // in buffer mode keeps the rolling buffer warm, so the next error after the rate limit
+      // expires can send a complete replay starting at segment 0.
+      options.logger.log(DEBUG, "Not converting to session mode, because replay is rate-limited")
+      return this
+    }
     // we hand over replayExecutor and persistingExecutor to the new strategy to preserve order of
     // execution
     val captureStrategy =

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -2,9 +2,12 @@ package io.sentry.android.replay.capture
 
 import android.graphics.Bitmap
 import android.view.MotionEvent
+import io.sentry.DataCategory
 import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
+import io.sentry.SentryEnvelope
+import io.sentry.SentryEnvelopeHeader
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.DefaultReplayBreadcrumbConverter
@@ -17,6 +20,8 @@ import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_TIMESTAMP
 import io.sentry.android.replay.ReplayFrame
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.capture.BufferCaptureStrategyTest.Fixture.Companion.VIDEO_DURATION
+import io.sentry.clientreport.DiscardReason
+import io.sentry.clientreport.DiscardedEvent
 import io.sentry.protocol.SentryId
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
@@ -93,6 +98,16 @@ class BufferCaptureStrategyTest {
         frameRate = 1,
         bitRate = 20_000,
       )
+
+    // client report counts are only readable by draining them onto an envelope
+    fun discardedEvents(): List<DiscardedEvent> =
+      options.clientReportRecorder
+        .attachReportToEnvelope(SentryEnvelope(SentryEnvelopeHeader(), emptyList()))
+        .items
+        .firstOrNull()
+        ?.getClientReport(options.serializer)
+        ?.discardedEvents
+        .orEmpty()
 
     fun getSut(
       onErrorSampleRate: Double = 1.0,
@@ -338,7 +353,7 @@ class BufferCaptureStrategyTest {
   }
 
   @Test
-  fun `captureReplay does nothing when rate-limited`() {
+  fun `captureReplay does not capture segments when rate-limited`() {
     val rateLimiter = mock<RateLimiter> { on { isActiveForCategory(any()) }.thenReturn(true) }
     whenever(fixture.scopes.rateLimiter).thenReturn(rateLimiter)
     val strategy = fixture.getSut()
@@ -350,7 +365,37 @@ class BufferCaptureStrategyTest {
 
     // neither the current nor the buffered segment should be sent while rate-limited
     verify(fixture.scopes, never()).captureReplay(any(), any())
-    assertEquals(SentryId.EMPTY_ID, fixture.scope.replayId)
+    // the replayId is still set on the scope so the error that flushed the buffer stays linked to
+    // the replay that gets recorded once the rate limit lifts
+    assertEquals(strategy.currentReplayId, fixture.scope.replayId)
+  }
+
+  @Test
+  fun `captureReplay records a lost replay event when rate-limited`() {
+    val rateLimiter = mock<RateLimiter> { on { isActiveForCategory(any()) }.thenReturn(true) }
+    whenever(fixture.scopes.rateLimiter).thenReturn(rateLimiter)
+    val strategy = fixture.getSut()
+    strategy.start()
+    strategy.onConfigurationChanged(fixture.recorderConfig)
+    strategy.pause()
+
+    strategy.captureReplay(false) {}
+
+    val discarded = fixture.discardedEvents()
+    assertEquals(1, discarded.size)
+    assertEquals(DiscardReason.RATELIMIT_BACKOFF.reason, discarded.first().reason)
+    assertEquals(DataCategory.Replay.category, discarded.first().category)
+  }
+
+  @Test
+  fun `captureReplay does not record a lost replay event when not rate-limited`() {
+    val strategy = fixture.getSut()
+    strategy.start()
+    strategy.onConfigurationChanged(fixture.recorderConfig)
+
+    strategy.captureReplay(false) {}
+
+    assertTrue(fixture.discardedEvents().none { it.category == DataCategory.Replay.category })
   }
 
   @Test

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -20,6 +20,7 @@ import io.sentry.android.replay.capture.BufferCaptureStrategyTest.Fixture.Compan
 import io.sentry.protocol.SentryId
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
+import io.sentry.transport.RateLimiter
 import io.sentry.util.Random
 import java.io.File
 import kotlin.test.Test
@@ -333,6 +334,22 @@ class BufferCaptureStrategyTest {
 
     strategy.captureReplay(false) {}
 
+    assertEquals(SentryId.EMPTY_ID, fixture.scope.replayId)
+  }
+
+  @Test
+  fun `captureReplay does nothing when rate-limited`() {
+    val rateLimiter = mock<RateLimiter> { on { isActiveForCategory(any()) }.thenReturn(true) }
+    whenever(fixture.scopes.rateLimiter).thenReturn(rateLimiter)
+    val strategy = fixture.getSut()
+    strategy.start()
+    strategy.onConfigurationChanged(fixture.recorderConfig)
+    strategy.pause()
+
+    strategy.captureReplay(false) {}
+
+    // neither the current nor the buffered segment should be sent while rate-limited
+    verify(fixture.scopes, never()).captureReplay(any(), any())
     assertEquals(SentryId.EMPTY_ID, fixture.scope.replayId)
   }
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -256,6 +256,19 @@ class BufferCaptureStrategyTest {
   }
 
   @Test
+  fun `convert stays in buffer mode when rate-limited`() {
+    val rateLimiter = mock<RateLimiter> { on { isActiveForCategory(any()) }.thenReturn(true) }
+    whenever(fixture.scopes.rateLimiter).thenReturn(rateLimiter)
+    val strategy = fixture.getSut()
+    strategy.start()
+
+    strategy.captureReplay(false) {}
+
+    val converted = strategy.convert()
+    assertTrue(converted is BufferCaptureStrategy)
+  }
+
+  @Test
   fun `convert converts to session strategy and sets replayId to scope`() {
     val strategy = fixture.getSut()
     strategy.start()


### PR DESCRIPTION
## 📜 Description

In buffer (on-error) session replay mode, the recorder intentionally keeps running while the SDK is rate-limited so the rolling buffer stays warm. However, when an error triggered `captureReplay`, the strategy still encoded the current segment **and every buffered segment** and handed the resulting envelopes to the transport — which then discarded them because of the active rate limit. That wasted CPU, disk I/O, and `MediaMuxer` file descriptors on replays that could never be sent.

This adds a guard at the top of `BufferCaptureStrategy.captureReplay`: if the `Replay` (or `All`) data category is rate-limited, we skip encoding and capturing entirely. This mirrors the guard session mode already applies via `onRateLimitChanged`/`checkCanRecord`. The buffer keeps rolling cheaply in the background and captures normally once the rate limit expires.

## 💡 Motivation and Context

Follow-up to the session replay resource-leak work in getsentry/sentry-java#5583 and getsentry/sentry-java#5607. Those fixed the `MediaMuxer` FD leak during encoding; this closes the remaining item called out in [getsentry/sentry-dart#3528](<https://github.com/getsentry/sentry-dart/issues/3528>) (getsentry/sentry-dart#3528): while rate-limited, the Android SDK kept creating and encoding segments that were only going to be discarded.

## 💚 How did you test it?

Added a unit test (`captureReplay does nothing when rate-limited`) asserting that, even with a buffered segment present, no segment is sent to the transport and no `replayId` is written to the scope while rate-limited.

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps

Optionally extend the same guard to the `pause` and `onConfigurationChanged` encode paths in buffer mode if that churn proves significant.