### PR TITLE
perf: Schedule rate-limit notifications on shared executor (JAVA-653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Performance
 
 - Reduce the number of SDK threads: `LifecycleWatcher` now schedules the session-end task on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5819](https://github.com/getsentry/sentry-java/pull/5819))
+- Reduce the number of SDK threads: `RateLimiter` now schedules its rate-limit-lifted notifications on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5814](https://github.com/getsentry/sentry-java/pull/5814))
 - Speed up deserialization of arbitrary JSON objects by typing numbers without throwing exceptions ([#5783](https://github.com/getsentry/sentry-java/pull/5783))
 
 ### Dependencies

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -23,12 +23,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,8 +43,9 @@ public final class RateLimiter implements Closeable {
   private final @NotNull Map<DataCategory, @NotNull Date> sentryRetryAfterLimit =
       new ConcurrentHashMap<>();
   private final @NotNull List<IRateLimitObserver> rateLimitObservers = new CopyOnWriteArrayList<>();
-  private @Nullable Timer timer = null;
-  private final @NotNull AutoClosableReentrantLock timerLock = new AutoClosableReentrantLock();
+  private final @NotNull List<Future<?>> notifyObserversFutures = new ArrayList<>();
+  private final @NotNull AutoClosableReentrantLock notifyFuturesLock =
+      new AutoClosableReentrantLock();
 
   public RateLimiter(
       final @NotNull ICurrentDateProvider currentDateProvider,
@@ -278,11 +280,11 @@ public final class RateLimiter implements Closeable {
                   continue;
                 }
 
-                applyRetryAfterOnlyIfLonger(dataCategory, date);
+                applyRetryAfterOnlyIfLonger(dataCategory, date, retryAfterMillis);
               }
             } else {
               // if categories are empty, we should apply to "all" categories.
-              applyRetryAfterOnlyIfLonger(DataCategory.All, date);
+              applyRetryAfterOnlyIfLonger(DataCategory.All, date, retryAfterMillis);
             }
           }
         }
@@ -291,7 +293,7 @@ public final class RateLimiter implements Closeable {
       final long retryAfterMillis = parseRetryAfterOrDefault(retryAfterHeader);
       // we dont care if Date is UTC as we just add the relative seconds
       final Date date = new Date(currentDateProvider.getCurrentTimeMillis() + retryAfterMillis);
-      applyRetryAfterOnlyIfLonger(DataCategory.All, date);
+      applyRetryAfterOnlyIfLonger(DataCategory.All, date, retryAfterMillis);
     }
   }
 
@@ -300,10 +302,11 @@ public final class RateLimiter implements Closeable {
    *
    * @param dataCategory the DataCategory
    * @param date the Date to be applied
+   * @param delayMillis the millis until the rate limit is lifted
    */
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
   private void applyRetryAfterOnlyIfLonger(
-      final @NotNull DataCategory dataCategory, final @NotNull Date date) {
+      final @NotNull DataCategory dataCategory, final @NotNull Date date, final long delayMillis) {
     final Date oldDate = sentryRetryAfterLimit.get(dataCategory);
 
     // only overwrite its previous date if the limit is even longer
@@ -312,19 +315,25 @@ public final class RateLimiter implements Closeable {
 
       notifyRateLimitObservers();
 
-      try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
-        if (timer == null) {
-          timer = new Timer(true);
+      // notify observers again once the rate limit is lifted, using the shared timer executor
+      // instead of a dedicated Timer thread
+      try (final @NotNull ISentryLifecycleToken ignored = notifyFuturesLock.acquire()) {
+        final @NotNull Iterator<Future<?>> iterator = notifyObserversFutures.iterator();
+        while (iterator.hasNext()) {
+          if (iterator.next().isDone()) {
+            iterator.remove();
+          }
         }
-
-        timer.schedule(
-            new TimerTask() {
-              @Override
-              public void run() {
-                notifyRateLimitObservers();
-              }
-            },
-            date);
+        try {
+          notifyObserversFutures.add(
+              options
+                  .getTimerExecutorService()
+                  .schedule(() -> notifyRateLimitObservers(), delayMillis));
+        } catch (RejectedExecutionException e) {
+          options
+              .getLogger()
+              .log(SentryLevel.WARNING, "Failed to schedule rate limit lifted notification.", e);
+        }
       }
     }
   }
@@ -364,11 +373,11 @@ public final class RateLimiter implements Closeable {
 
   @Override
   public void close() throws IOException {
-    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
-      if (timer != null) {
-        timer.cancel();
-        timer = null;
+    try (final @NotNull ISentryLifecycleToken ignored = notifyFuturesLock.acquire()) {
+      for (Future<?> future : notifyObserversFutures) {
+        future.cancel(false);
       }
+      notifyObserversFutures.clear();
     }
     rateLimitObservers.clear();
   }

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -328,7 +328,7 @@ public final class RateLimiter implements Closeable {
           notifyObserversFutures.add(
               options
                   .getTimerExecutorService()
-                  .schedule(() -> notifyRateLimitObservers(), delayMillis));
+                  .schedule(this::notifyRateLimitObservers, delayMillis));
         } catch (RejectedExecutionException e) {
           options
               .getLogger()

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -18,6 +18,7 @@ import io.sentry.SentryEnvelope
 import io.sentry.SentryEnvelopeHeader
 import io.sentry.SentryEnvelopeItem
 import io.sentry.SentryEvent
+import io.sentry.SentryExecutorService
 import io.sentry.SentryLogEvent
 import io.sentry.SentryLogEvents
 import io.sentry.SentryLogLevel
@@ -37,11 +38,10 @@ import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.test.getProperty
-import io.sentry.test.injectForField
 import io.sentry.util.HintUtils
 import java.io.File
-import java.util.Timer
 import java.util.UUID
+import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -66,6 +66,8 @@ class RateLimiterTest {
 
     fun getSUT(): RateLimiter {
       val options = SentryOptions().apply { setLogger(NoOpLogger.getInstance()) }
+      // a real executor so scheduled rate-limit-lifted notifications actually run
+      options.setTimerExecutorService(SentryExecutorService(options))
 
       SentryOptionsManipulator.setClientReportRecorder(options, clientReportRecorder)
 
@@ -654,7 +656,7 @@ class RateLimiterTest {
   }
 
   @Test
-  fun `apply rate limits schedules a timer to notify observers of lifted limits`() {
+  fun `apply rate limits schedules a task to notify observers of lifted limits`() {
     val rateLimiter = fixture.getSUT()
     whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 1, 2001)
 
@@ -667,18 +669,19 @@ class RateLimiterTest {
   }
 
   @Test
-  fun `close cancels the timer`() {
+  fun `close cancels pending notify tasks`() {
     val rateLimiter = fixture.getSUT()
-    val timer = mock<Timer>()
-    rateLimiter.injectForField("timer", timer)
+    rateLimiter.updateRetryAfterLimits("60:replay:key", null, 1)
+
+    val futures = rateLimiter.getProperty<List<Future<*>>>("notifyObserversFutures")
+    assertEquals(1, futures.size)
+    val future = futures.first()
 
     // When the rate limiter is closed
     rateLimiter.close()
 
-    // Then the timer is cancelled
-    verify(timer).cancel()
-
-    // And is removed by the rateLimiter
-    assertNull(rateLimiter.getProperty("timer"))
+    // Then the pending notify task is cancelled and dropped
+    assertTrue(future.isCancelled)
+    assertTrue(rateLimiter.getProperty<List<Future<*>>>("notifyObserversFutures").isEmpty())
   }
 }

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -43,6 +43,7 @@ import java.io.File
 import java.util.UUID
 import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -63,11 +64,14 @@ class RateLimiterTest {
     val currentDateProvider = mock<ICurrentDateProvider>()
     val clientReportRecorder = mock<IClientReportRecorder>()
     val serializer = mock<ISerializer>()
+    var executorService: SentryExecutorService? = null
 
     fun getSUT(): RateLimiter {
       val options = SentryOptions().apply { setLogger(NoOpLogger.getInstance()) }
       // a real executor so scheduled rate-limit-lifted notifications actually run
-      options.setTimerExecutorService(SentryExecutorService(options))
+      val timerExecutorService = SentryExecutorService(options)
+      executorService = timerExecutorService
+      options.setTimerExecutorService(timerExecutorService)
 
       SentryOptionsManipulator.setClientReportRecorder(options, clientReportRecorder)
 
@@ -76,6 +80,12 @@ class RateLimiterTest {
   }
 
   private val fixture = Fixture()
+
+  @AfterTest
+  fun `tear down`() {
+    // the executor's core thread never times out, so it would stay parked for the whole test JVM
+    fixture.executorService?.close(0)
+  }
 
   @Test
   fun `uses X-Sentry-Rate-Limit and allows sending if time has passed`() {


### PR DESCRIPTION
## :scroll: Description

`RateLimiter` created a `java.util.Timer` (a dedicated thread) whose thread stayed alive for the rest of the process once the SDK got rate limited. The "rate limit lifted" observer notification now runs on the shared timer executor (`SentryOptions#getTimerExecutorService`), already used for transaction timeouts, whose single worker thread is reused and self-terminates when idle.

- The notification is scheduled with the delay until the limit expires; to avoid an extra `getCurrentTimeMillis()` call the already-computed `retryAfterMillis` is passed through as the delay.
- Pending notification futures are tracked (completed ones pruned on each schedule) and cancelled on `close()`, preserving the old `Timer#cancel()` semantics.

## :bulb: Motivation and Context

Part of reducing the number of threads created by the SDK: [JAVA-653](https://linear.app/getsentry/issue/JAVA-653/reduce-number-of-threads-created-and-used-by-the-sdk).

Once an app got rate limited, this timer thread lived forever. The shared timer executor's worker is reused and idles out.

## :green_heart: How did you test it?

Existing `RateLimiterTest`, adapted from the Timer-mock verification to the executor/future model, plus `AsyncHttpTransportTest`.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Related PRs in this effort: LifecycleWatcher (#5819), performance collector (#5816), HostnameCache (#5817), batch processors (#5818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
