### PR TITLE
perf: Let HostnameCache worker thread idle out (JAVA-653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Parse the app start profiling config with only the deserializer it needs instead of building a full `JsonSerializer` and `SentryOptions`, cutting 188 of 221 allocations on the main thread before `Application.onCreate` ([#5867](https://github.com/getsentry/sentry-java/pull/5867))
 - Batch and coalesce scope-persistence disk writes to reduce startup cost ([#5791](https://github.com/getsentry/sentry-java/pull/5791))
   - Scope mutations are now coalesced (latest value per field) and breadcrumbs are appended in batches behind a single fsync, instead of one synchronous disk write per mutation.
+- Reduce the number of SDK threads: the `HostnameCache` worker thread now times out while idle instead of staying alive for the whole process lifetime ([#5817](https://github.com/getsentry/sentry-java/pull/5817))
 
 ### Dependencies
 

--- a/sentry/src/main/java/io/sentry/HostnameCache.java
+++ b/sentry/src/main/java/io/sentry/HostnameCache.java
@@ -6,9 +6,10 @@ import java.net.InetAddress;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,6 +35,9 @@ public final class HostnameCache {
   /** Time before the get hostname operation times out (in ms). */
   private static final long GET_HOSTNAME_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
 
+  /** How long the worker thread may stay idle before it self-terminates. */
+  private static final long THREAD_KEEP_ALIVE_SECONDS = 30;
+
   private static volatile @Nullable HostnameCache INSTANCE;
   private static final @NotNull AutoClosableReentrantLock staticLock =
       new AutoClosableReentrantLock();
@@ -52,8 +56,7 @@ public final class HostnameCache {
 
   private final @NotNull Callable<InetAddress> getLocalhost;
 
-  private final @NotNull ExecutorService executorService =
-      Executors.newSingleThreadExecutor(new HostnameCacheThreadFactory());
+  private final @NotNull ExecutorService executorService;
 
   public static @NotNull HostnameCache getInstance() {
     if (INSTANCE == null) {
@@ -87,6 +90,18 @@ public final class HostnameCache {
   HostnameCache(long cacheDuration, final @NotNull Callable<InetAddress> getLocalhost) {
     this.cacheDuration = cacheDuration;
     this.getLocalhost = Objects.requireNonNull(getLocalhost, "getLocalhost is required");
+    // A single thread executor whose worker thread times out while idle, so no thread is kept
+    // alive between the infrequent cache refreshes.
+    final @NotNull ThreadPoolExecutor executor =
+        new ThreadPoolExecutor(
+            1,
+            1,
+            THREAD_KEEP_ALIVE_SECONDS,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            new HostnameCacheThreadFactory());
+    executor.allowCoreThreadTimeOut(true);
+    this.executorService = executor;
     updateCache();
   }
 

--- a/sentry/src/test/java/io/sentry/HostnameCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/HostnameCacheTest.kt
@@ -1,0 +1,41 @@
+package io.sentry
+
+import com.google.common.truth.Truth.assertThat
+import io.sentry.test.getProperty
+import java.net.InetAddress
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class HostnameCacheTest {
+
+  private fun getSut(): HostnameCache {
+    val address = mock<InetAddress>()
+    whenever(address.canonicalHostName).thenReturn("myhost")
+    return HostnameCache(TimeUnit.HOURS.toMillis(1)) { address }
+  }
+
+  @Test
+  fun `hostname is resolved and cached`() {
+    val cache = getSut()
+    assertThat(cache.hostname).isEqualTo("myhost")
+  }
+
+  @Test
+  fun `worker thread times out while idle instead of staying alive`() {
+    val cache = getSut()
+    val executorService = cache.getProperty<ThreadPoolExecutor>("executorService")
+    assertThat(executorService.allowsCoreThreadTimeOut()).isTrue()
+    assertThat(executorService.corePoolSize).isEqualTo(1)
+    assertThat(executorService.maximumPoolSize).isEqualTo(1)
+  }
+
+  @Test
+  fun `close shuts the executor down`() {
+    val cache = getSut()
+    cache.close()
+    assertThat(cache.isClosed).isTrue()
+  }
+}


### PR DESCRIPTION
## :scroll: Description

`HostnameCache`'s executor stays around for the entire process lifetime (that's how `ThreadPoolExecutors` work by default) even though the cache only refreshes once every 5 hours. It now uses a `ThreadPoolExecutor` (core = max = 1) with a 30s keep-alive and `allowCoreThreadTimeOut(true)`, so the worker thread self-terminates when idle and is recreated on the next refresh.

Alternatively, we can also use an existing executor for this but this is the smallest change here. Let me know if you think we should go that route.

## :bulb: Motivation and Context

Part of reducing the number of threads created by the SDK: [JAVA-653](https://linear.app/getsentry/issue/JAVA-653/reduce-number-of-threads-created-and-used-by-the-sdk).

## :green_heart: How did you test it?

There are some new unit tests, but otherwise relying on ART/JVM to do their thing correctly.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

