### PR TITLE
perf: Share one executor between log and metrics batch processors (JAVA-653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Reduce the number of SDK threads: the log and metrics batch processors now share a single executor instead of each creating its own ([#5818](https://github.com/getsentry/sentry-java/pull/5818))
+
 ## 8.50.0
 
 ### Android 17 support

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3018,6 +3018,7 @@ public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun close ()V
 	public fun close (Z)V
 	public fun flush (J)V
+	public fun getBatchProcessorExecutorService ()Lio/sentry/ISentryExecutorService;
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun isEnabled ()Z
 	public fun isHealthy ()Z
@@ -5475,6 +5476,7 @@ public class io/sentry/metrics/MetricsBatchProcessor : io/sentry/metrics/IMetric
 	public static final field MAX_QUEUE_SIZE I
 	protected final field options Lio/sentry/SentryOptions;
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;)V
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;Lio/sentry/ISentryExecutorService;)V
 	public fun add (Lio/sentry/SentryMetricsEvent;)V
 	public fun close (Z)V
 	public fun flush (J)V

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -45,6 +45,10 @@ public final class SentryClient implements ISentryClient {
   private final @NotNull ILoggerBatchProcessor loggerBatchProcessor;
   private final @NotNull IMetricsBatchProcessor metricsBatchProcessor;
 
+  // Single executor shared by the log and metrics batch processors, so they don't spawn a thread
+  // each. Created only when logs or metrics are enabled, and closed when those processors close.
+  private final @Nullable ISentryExecutorService batchProcessorExecutorService;
+
   @Override
   public boolean isEnabled() {
     return enabled;
@@ -62,6 +66,14 @@ public final class SentryClient implements ISentryClient {
 
     final RequestDetailsResolver requestDetailsResolver = new RequestDetailsResolver(options);
     transport = transportFactory.create(options, requestDetailsResolver.resolve());
+
+    // must be set before the batch processors are created, as they read it from this client
+    if (options.getLogs().isEnabled() || options.getMetrics().isEnabled()) {
+      batchProcessorExecutorService = new SentryExecutorService(options);
+    } else {
+      batchProcessorExecutorService = null;
+    }
+
     if (options.getLogs().isEnabled()) {
       loggerBatchProcessor =
           options.getLogs().getLoggerBatchProcessorFactory().create(options, this);
@@ -74,6 +86,16 @@ public final class SentryClient implements ISentryClient {
     } else {
       metricsBatchProcessor = NoOpMetricsBatchProcessor.getInstance();
     }
+  }
+
+  /**
+   * The executor shared by the log and metrics batch processors. Only present (non-null) when logs
+   * or metrics are enabled, which is the only time the batch processors request it.
+   */
+  @ApiStatus.Internal
+  public @NotNull ISentryExecutorService getBatchProcessorExecutorService() {
+    return Objects.requireNonNull(
+        batchProcessorExecutorService, "batch processor executor service is not available");
   }
 
   private boolean shouldApplyScopeData(

--- a/sentry/src/main/java/io/sentry/logger/DefaultLoggerBatchProcessorFactory.java
+++ b/sentry/src/main/java/io/sentry/logger/DefaultLoggerBatchProcessorFactory.java
@@ -8,6 +8,6 @@ public final class DefaultLoggerBatchProcessorFactory implements ILoggerBatchPro
   @Override
   public @NotNull ILoggerBatchProcessor create(
       @NotNull SentryOptions options, @NotNull SentryClient client) {
-    return new LoggerBatchProcessor(options, client);
+    return new LoggerBatchProcessor(options, client, client.getBatchProcessorExecutorService());
   }
 }

--- a/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
@@ -84,7 +84,13 @@ public class LoggerBatchProcessor implements ILoggerBatchProcessor {
     isShuttingDown = true;
     if (isRestarting) {
       maybeSchedule(true);
-      executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
+      try {
+        executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
+      } catch (RejectedExecutionException e) {
+        // the shared executor may already be shutting down (e.g. closed by the metrics batch
+        // processor); close it directly instead
+        executorService.close(options.getShutdownTimeoutMillis());
+      }
     } else {
       executorService.close(options.getShutdownTimeoutMillis());
       while (!queue.isEmpty()) {

--- a/sentry/src/main/java/io/sentry/metrics/DefaultMetricsBatchProcessorFactory.java
+++ b/sentry/src/main/java/io/sentry/metrics/DefaultMetricsBatchProcessorFactory.java
@@ -8,6 +8,6 @@ public final class DefaultMetricsBatchProcessorFactory implements IMetricsBatchP
   @Override
   public @NotNull IMetricsBatchProcessor create(
       final @NotNull SentryOptions options, final @NotNull SentryClient client) {
-    return new MetricsBatchProcessor(options, client);
+    return new MetricsBatchProcessor(options, client, client.getBatchProcessorExecutorService());
   }
 }

--- a/sentry/src/main/java/io/sentry/metrics/MetricsBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsBatchProcessor.java
@@ -19,8 +19,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 @Open
 public class MetricsBatchProcessor implements IMetricsBatchProcessor {
@@ -40,10 +42,19 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
 
   public MetricsBatchProcessor(
       final @NotNull SentryOptions options, final @NotNull ISentryClient client) {
+    this(options, client, new SentryExecutorService(options));
+  }
+
+  @ApiStatus.Internal
+  @TestOnly
+  public MetricsBatchProcessor(
+      final @NotNull SentryOptions options,
+      final @NotNull ISentryClient client,
+      final @NotNull ISentryExecutorService executorService) {
     this.options = options;
     this.client = client;
     this.queue = new ConcurrentLinkedQueue<>();
-    this.executorService = new SentryExecutorService(options);
+    this.executorService = executorService;
   }
 
   @Override
@@ -74,7 +85,13 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
     isShuttingDown = true;
     if (isRestarting) {
       maybeSchedule(true);
-      executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
+      try {
+        executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
+      } catch (RejectedExecutionException e) {
+        // the shared executor may already be shutting down (e.g. closed by the log batch
+        // processor); close it directly instead
+        executorService.close(options.getShutdownTimeoutMillis());
+      }
     } else {
       executorService.close(options.getShutdownTimeoutMillis());
       while (!queue.isEmpty()) {

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -29,6 +29,7 @@ import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.protocol.ViewHierarchy
 import io.sentry.test.callMethod
+import io.sentry.test.getProperty
 import io.sentry.test.injectForField
 import io.sentry.transport.ITransport
 import io.sentry.transport.ITransportGate
@@ -175,6 +176,33 @@ class SentryClientTest {
     fixture.sentryOptions.dsn = dsnStringLegacy
     val sut = fixture.getSut()
     assertTrue(sut.isEnabled)
+  }
+
+  @Test
+  fun `log and metrics batch processors share a single executor`() {
+    // real default factories (not the fixture mocks) so the shared executor is actually wired
+    val options =
+      SentryOptions().apply {
+        dsn = dsnString
+        logs.isEnabled = true
+        metrics.isEnabled = true
+      }
+    val client = SentryClient(options)
+    try {
+      val loggerExecutor =
+        client
+          .getProperty<ILoggerBatchProcessor>("loggerBatchProcessor")
+          .getProperty<ISentryExecutorService>("executorService")
+      val metricsExecutor =
+        client
+          .getProperty<IMetricsBatchProcessor>("metricsBatchProcessor")
+          .getProperty<ISentryExecutorService>("executorService")
+
+      assertSame(client.batchProcessorExecutorService, loggerExecutor)
+      assertSame(loggerExecutor, metricsExecutor)
+    } finally {
+      client.close()
+    }
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

`LoggerBatchProcessor` and `MetricsBatchProcessor` each constructed their own `SentryExecutorService`, so an app with both logs and metrics enabled ran two dedicated threads for structurally identical work (a 5-second flush loop that batches events and hands them to the transport).

`SentryClient` now owns a single `SentryExecutorService`, created only when logs or metrics are enabled, and exposes it via `getBatchProcessorExecutorService()`. The default factories inject it into both processors (through the existing 3-arg `LoggerBatchProcessor` constructor and a new matching one on `MetricsBatchProcessor`). The pluggable factory interfaces are unchanged.

The shutdown paths already close the executor from each processor's `close()`; since the executor is now shared, the second close is a safe no-op, and the restart branch's `submit(...)` is guarded with the same `RejectedExecutionException` fallback already used in `Scopes.close()` for the main executor.

## :bulb: Motivation and Context

Part of reducing the number of threads created by the SDK: [JAVA-653](https://linear.app/getsentry/issue/JAVA-653/reduce-number-of-threads-created-and-used-by-the-sdk).

Saves one thread for every app that has both logs and metrics enabled. The executor is created only when at least one of logs or metrics is enabled, and its worker thread is spawned only when the first flush is scheduled.

### Note for reviewers

Custom `ILoggerBatchProcessorFactory` / `IMetricsBatchProcessorFactory` implementations that call the public 2-arg processor constructors still get an independent executor (unchanged behavior). Only the default factories opt into the shared one.

## :green_heart: How did you test it?

New `SentryClientTest` case asserting both processors receive the same executor instance (and that it is the client's shared one), plus the existing `LoggerBatchProcessorTest`, `MetricsBatchProcessorTest`, `SentryClientTest`, `LoggerApiTest`, and `MetricsApiTest` suites.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Related PRs in this effort: RateLimiter (#5814), LifecycleWatcher (#5819), performance collector (#5816), HostnameCache (#5817).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
