### PR TITLE
perf: Schedule session end on shared executor (JAVA-653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Reduce the number of SDK threads: `LifecycleWatcher` now schedules the session-end task on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5819](https://github.com/getsentry/sentry-java/pull/5819))
+
 ## 8.50.0
 
 ### Android 17 support

--- a/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
@@ -8,9 +8,7 @@ import io.sentry.Session;
 import io.sentry.transport.CurrentDateProvider;
 import io.sentry.transport.ICurrentDateProvider;
 import io.sentry.util.AutoClosableReentrantLock;
-import io.sentry.util.LazyEvaluator;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,9 +20,8 @@ final class LifecycleWatcher implements AppState.AppStateListener {
 
   private final long sessionIntervalMillis;
 
-  private @Nullable TimerTask timerTask;
-  private final @NotNull LazyEvaluator<Timer> timer = new LazyEvaluator<>(() -> new Timer(true));
-  private final @NotNull AutoClosableReentrantLock timerLock = new AutoClosableReentrantLock();
+  private @Nullable Future<?> endSessionFuture;
+  private final @NotNull AutoClosableReentrantLock endSessionLock = new AutoClosableReentrantLock();
   private final @NotNull IScopes scopes;
   private final boolean enableSessionTracking;
   private final boolean enableAppLifecycleBreadcrumbs;
@@ -104,29 +101,40 @@ final class LifecycleWatcher implements AppState.AppStateListener {
   }
 
   private void scheduleEndSession() {
-    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
+    try (final @NotNull ISentryLifecycleToken ignored = endSessionLock.acquire()) {
       cancelTask();
-      timerTask =
-          new TimerTask() {
-            @Override
-            public void run() {
-              if (enableSessionTracking) {
-                scopes.endSession();
-              }
-              scopes.getOptions().getReplayController().stop();
-              scopes.getOptions().getContinuousProfiler().close(false);
+      final @NotNull Runnable endSession =
+          () -> {
+            if (enableSessionTracking) {
+              scopes.endSession();
             }
+            scopes.getOptions().getReplayController().stop();
+            scopes.getOptions().getContinuousProfiler().close(false);
           };
 
-      timer.getValue().schedule(timerTask, sessionIntervalMillis);
+      try {
+        endSessionFuture =
+            scopes
+                .getOptions()
+                .getTimerExecutorService()
+                .schedule(endSession, sessionIntervalMillis);
+      } catch (Throwable e) {
+        scopes
+            .getOptions()
+            .getLogger()
+            .log(SentryLevel.WARNING, "Failed to schedule end of session. Ending it now.", e);
+        // if we cannot re-check after the session interval, end the session right away instead of
+        // leaving it open forever
+        endSession.run();
+      }
     }
   }
 
   private void cancelTask() {
-    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
-      if (timerTask != null) {
-        timerTask.cancel();
-        timerTask = null;
+    try (final @NotNull ISentryLifecycleToken ignored = endSessionLock.acquire()) {
+      if (endSessionFuture != null) {
+        endSessionFuture.cancel(false);
+        endSessionFuture = null;
       }
     }
   }
@@ -144,13 +152,7 @@ final class LifecycleWatcher implements AppState.AppStateListener {
 
   @TestOnly
   @Nullable
-  TimerTask getTimerTask() {
-    return timerTask;
-  }
-
-  @TestOnly
-  @NotNull
-  Timer getTimer() {
-    return timer.getValue();
+  Future<?> getEndSessionFuture() {
+    return endSessionFuture;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/LifecycleWatcherTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/LifecycleWatcherTest.kt
@@ -7,6 +7,7 @@ import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ReplayController
 import io.sentry.ScopeCallback
+import io.sentry.SentryExecutorService
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.Session
@@ -32,7 +33,8 @@ class LifecycleWatcherTest {
   private class Fixture {
     val scopes = mock<IScopes>()
     val dateProvider = mock<ICurrentDateProvider>()
-    val options = SentryOptions()
+    // a real executor so scheduled end-session tasks actually run
+    val options = SentryOptions().apply { setTimerExecutorService(SentryExecutorService(this)) }
     val replayController = mock<ReplayController>()
     val continuousProfiler = mock<IContinuousProfiler>()
 
@@ -115,10 +117,10 @@ class LifecycleWatcherTest {
     watcher.onForeground()
 
     watcher.onBackground()
-    assertNotNull(watcher.timerTask)
+    assertNotNull(watcher.endSessionFuture)
 
     watcher.onForeground()
-    assertNull(watcher.timerTask)
+    assertNull(watcher.endSessionFuture)
 
     verify(fixture.scopes, never()).endSession()
     verify(fixture.replayController, never()).stop()
@@ -184,13 +186,6 @@ class LifecycleWatcherTest {
       fixture.getSUT(enableAutoSessionTracking = false, enableAppLifecycleBreadcrumbs = false)
     watcher.onBackground()
     verify(fixture.scopes, never()).addBreadcrumb(any<Breadcrumb>())
-  }
-
-  @Test
-  fun `timer is created if session tracking is enabled`() {
-    val watcher =
-      fixture.getSUT(enableAutoSessionTracking = true, enableAppLifecycleBreadcrumbs = false)
-    assertNotNull(watcher.timer)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

`LifecycleWatcher` created a `java.util.Timer` (a dedicated thread) on the first app-background transition, and that thread lived for the rest of the process. The session-end task now runs on the shared timer executor (`SentryOptions#getTimerExecutorService`), already used for transaction timeouts, whose single worker thread is reused and self-terminates when idle.

The task is scheduled/cancelled as the app moves between background and foreground via `Future#cancel(false)` (the same pattern `SentryTracer` uses for idle/deadline timeouts). If scheduling fails (executor already shut down), the session is ended immediately instead of being left open.

## :bulb: Motivation and Context

Part of reducing the number of threads created by the SDK: [JAVA-653](https://linear.app/getsentry/issue/JAVA-653/reduce-number-of-threads-created-and-used-by-the-sdk).

On Android this timer thread was created on the first background transition and never went away. Reusing the shared timer executor removes it.

## :green_heart: How did you test it?

Existing `LifecycleWatcherTest` (updated to assert on the scheduled `Future` instead of the removed `Timer`/`TimerTask` internals) and `SessionTrackingIntegrationTest`. Both fixtures now wire a real executor into options so scheduled tasks run.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Related PRs in this effort: RateLimiter (#5814), performance collector (#5816), HostnameCache (#5817), batch processors (#5818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
