### PR TITLE
docs(changelog): Add dedicated Android 17 support section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Android 17 support
+
+- We've put Android 17 through a set of rigorous tests. We're now officially giving it the Sentry stamp of compatibility .([#5796](https://github.com/getsentry/sentry-java/pull/5796))
+
 ### Fixes
 
 - Reduce main-thread work during `Sentry.init` by resolving the shake-detector accelerometer off the main thread (~1.75ms on a Pixel 10) ([#5784](https://github.com/getsentry/sentry-java/pull/5784))
@@ -17,7 +21,6 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0154)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.15.3...0.15.4)
 - The SDK is now compiled with Android Gradle Plugin 9.2.1 ([#5779](https://github.com/getsentry/sentry-java/pull/5779))
-- The SDK has been fully tested for compatibility with Android 17 and platform 37; it is now compiled and tested against it ([#5796](https://github.com/getsentry/sentry-java/pull/5796))
 
 ## 8.49.0
 


### PR DESCRIPTION
## :scroll: Description

Promote the Android 17 compatibility note out of the `### Dependencies` subsection into its own dedicated `### Android 17 support` section under `## Unreleased`, and reword it as a user-facing highlight.

## :bulb: Motivation and Context

Android 17 / platform 37 support is a notable milestone for users, but it was buried in the Dependencies subsection alongside routine bumps. A dedicated section makes the officially supported platform easy to spot in the changelog.

## :green_heart: How did you test it?

Changelog-only (Markdown) change — verified the diff renders correctly.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
