### PR TITLE
build(android): Pin AAR minCompileSdk to minSdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Pin the published Sentry Android SDK's AAR metadata `minCompileSdk` to our `minSdk` (`21`) instead of AGP 9's new default of the SDK's own `compileSdk` (`37`), so apps that depend on the SDK aren't forced to raise their `compileSdk` ([#5823](https://github.com/getsentry/sentry-java/pull/5823))
+
 ### Performance
 
 - Reduce the number of SDK threads: `LifecycleWatcher` now schedules the session-end task on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5819](https://github.com/getsentry/sentry-java/pull/5819))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,6 +177,13 @@ subprojects {
                     sourceCompatibility = JavaVersion.VERSION_1_8
                     targetCompatibility = JavaVersion.VERSION_1_8
                 }
+
+                // AGP 9 defaults the AAR metadata minCompileSdk to the library's compileSdk,
+                // which would force every consumer onto that compile SDK. Pin it to our minSdk
+                // so consumers remain free to compile against any SDK we support, as before.
+                defaultConfig {
+                    aarMetadata { minCompileSdk = libs.versions.minSdk.get().toInt() }
+                }
             }
         }
 


### PR DESCRIPTION
## :scroll: Description

Pin the AAR metadata `minCompileSdk` to our `minSdk` for all published Android library modules, set centrally in the shared `com.android.library` configuration in the root `build.gradle.kts`.

## :bulb: Motivation and Context

[AGP 9.0 changed the default](https://developer.android.com/build/releases/agp-9-0-0-release-notes#android-gradle-plugin-behavior-changes) so that a published library's AAR metadata `minCompileSdk` mirrors its `compileSdk`, requiring consumers to compile against the same or higher SDK. Since we recently bumped `compileSdk` to 37, this default would force every consumer of the Android SDK onto `compileSdk 37`.

Pinning `minCompileSdk` to our `minSdk` keeps consumers free to compile against any SDK we support, preserving the pre-AGP-9 behavior.

## :green_heart: How did you test it?

Verified that `writeReleaseAarMetadata` now emits `minCompileSdk=21` for the published Android library modules (`sentry-android-core`, `sentry-android-ndk`, `sentry-android-replay`, `sentry-compose`).

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
