### PR TITLE
build: Disable Android debug variants outside the sample app

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -40,9 +40,9 @@ Determine the Gradle test task:
 
 | Module Pattern | Test Task |
 |---------------|-----------|
-| `sentry-android-*` | `testDebugUnitTest` |
-| `sentry-compose*` | `testDebugUnitTest` |
-| `*-android` | `testDebugUnitTest` |
+| `sentry-android-*` | `testReleaseUnitTest` |
+| `sentry-compose*` | `testReleaseUnitTest` |
+| `*-android` | `testReleaseUnitTest` |
 | Everything else | `test` |
 
 **Interactive mode:** Before running, read the test class file and use AskUserQuestion to ask:

--- a/.cursor/rules/coding.mdc
+++ b/.cursor/rules/coding.mdc
@@ -24,7 +24,7 @@ sentry-java is the Java and Android SDK for Sentry. This repository contains the
 ./gradlew check
 
 # Run unit tests for a specific file
-./gradlew ':<module>:testDebugUnitTest' --tests="*<file name>*" --info
+./gradlew ':<module>:testReleaseUnitTest' --tests="*<file name>*" --info
 ```
 
 ## Contributing Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,13 +44,13 @@ The project uses **Gradle** with Kotlin DSL. Key build files:
 ### Testing
 ```bash
 # Run unit tests for a specific file
-./gradlew ':<module>:testDebugUnitTest' --tests="*<file name>*" --info
+./gradlew ':<module>:testReleaseUnitTest' --tests="*<file name>*" --info
 
 # Run system tests (requires Python virtual env)
 make systemTest
 
 # Run specific test suites
-./gradlew :sentry-android-core:testDebugUnitTest
+./gradlew :sentry-android-core:testReleaseUnitTest
 ./gradlew :sentry:test
 ```
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -12,8 +12,10 @@ object Config {
     object Android {
         val abiFilters = listOf("x86", "armeabi-v7a", "x86_64", "arm64-v8a")
 
+        // Debug variants are disabled everywhere. Unit tests run against the release
+        // variant, so building the debug variant would only add overhead.
         fun shouldSkipDebugVariant(name: String?): Boolean {
-            return System.getenv("CI")?.toBoolean() ?: false && name == "debug"
+            return name == "debug"
         }
     }
 

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -34,8 +34,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin { compilerOptions.jvmTarget = JVM_1_8 }
@@ -83,7 +83,7 @@ tasks.withType<JavaCompile>().configureEach {
 // outputs so Gradle's build cache restores them on cache hits (otherwise the CLI upload step
 // finds an empty directory).
 tasks
-  .matching { it.name == "testDebugUnitTest" || it.name == "testReleaseUnitTest" }
+  .matching { it.name == "testReleaseUnitTest" }
   .configureEach { outputs.dir(layout.buildDirectory.dir("test-snapshots")) }
 
 dependencies {

--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -13,8 +13,8 @@ android {
   defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
   buildFeatures { buildConfig = false }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   testOptions {

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -25,8 +25,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin {

--- a/sentry-android-navigation/build.gradle.kts
+++ b/sentry-android-navigation/build.gradle.kts
@@ -25,8 +25,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin {

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -26,8 +26,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -34,8 +34,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin {

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -25,8 +25,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin {

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -32,8 +32,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin {

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -92,8 +92,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   testOptions {

--- a/sentry-launchdarkly-android/build.gradle.kts
+++ b/sentry-launchdarkly-android/build.gradle.kts
@@ -27,8 +27,8 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
-  // variant, so unit tests must target release to run at all.
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
   testBuildType = "release"
 
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -133,10 +133,6 @@ android {
 
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11 }
 
-  androidComponents.beforeVariants {
-    it.enable = !Config.Android.shouldSkipDebugVariant(it.buildType)
-  }
-
   androidComponents.onVariants { variant ->
     variant.buildConfigFields?.put(
       "USE_SAGP",


### PR DESCRIPTION
## :scroll: Description

Unit tests already run against the `release` variant (`testBuildType = "release"`), and CI already disabled the Android `debug` variant. This makes the same thing happen locally:

- `Config.Android.shouldSkipDebugVariant` now skips the `debug` variant everywhere (not just in CI), so local builds of the libraries and integration-test apps match CI and no longer configure/build the unused `debug` variant.
- The sample app (`sentry-samples-android`) keeps **both** `debug` and `release` variants locally and in CI, so manual runs and btrace profiling (`installDebug`) still work.
- Updated the contributor docs (`AGENTS.md`, `.cursor/rules/coding.mdc`) and the `test` skill to reference `testReleaseUnitTest` instead of `testDebugUnitTest`.
- Refreshed the now-stale "CI disables the debug variant" comments in the Android module build files and simplified the snapshot-outputs task matcher in `sentry-android-core` to the release task.

## :bulb: Motivation and Context

All unit tests use the release variant, so the debug variant only added build/configuration overhead locally, and the docs pointed contributors (and agents) at a `testDebugUnitTest` task that no longer runs.

## :green_heart: How did you test it?

- `./gradlew :sentry-android-core:tasks --all` — only `testReleaseUnitTest` is present; no `assembleDebug`/`testDebugUnitTest`.
- `./gradlew :sentry-samples:sentry-samples-android:tasks --all` — both `installDebug`/`assembleDebug` and their release counterparts remain.
- `./gradlew spotlessApply apiDump` — passes with no API changes.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
