### PR TITLE
fix(replay): Dispatch session-deadline stop off the replay worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix background ANR when a session replay reaches its duration deadline: the resulting `stop()` (and its segment encoding) no longer runs on the replay worker thread while holding the replay lifecycle lock, which could block a foreground `start()` on the main thread ([#5826](https://github.com/getsentry/sentry-java/pull/5826))
 - Pin the published Sentry Android SDK's AAR metadata `minCompileSdk` to our `minSdk` (`21`) instead of AGP 9's new default of the SDK's own `compileSdk` (`37`), so apps that depend on the SDK aren't forced to raise their `compileSdk` ([#5823](https://github.com/getsentry/sentry-java/pull/5823))
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Fixes
 
 - Fix background ANR when a session replay reaches its duration deadline: the resulting `stop()` (and its segment encoding) no longer runs on the replay worker thread while holding the replay lifecycle lock, which could block a foreground `start()` on the main thread ([#5826](https://github.com/getsentry/sentry-java/pull/5826))
-- Pin the published Sentry Android SDK's AAR metadata `minCompileSdk` to our `minSdk` (`21`) instead of AGP 9's new default of the SDK's own `compileSdk` (`37`), so apps that depend on the SDK aren't forced to raise their `compileSdk` ([#5823](https://github.com/getsentry/sentry-java/pull/5823))
 - Release `MediaMuxer` when the replay video encoder fails to start to avoid a resource leak ([#5607](https://github.com/getsentry/sentry-java/pull/5607))
 
 ### Performance

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -10,6 +10,7 @@ import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
 import io.sentry.android.replay.util.ReplayRunnable
+import io.sentry.android.replay.util.submitSafely
 import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.FileUtils
@@ -134,8 +135,13 @@ internal class SessionCaptureStrategy(
         }
 
         if ((now - replayStartTimestamp.get() >= options.sessionReplay.sessionDuration)) {
-          options.replayController.stop()
           options.logger.log(INFO, "Session replay deadline exceeded (1h), stopping recording")
+          // dispatch off the replay worker thread, otherwise stop() would run the final segment
+          // encoding synchronously while holding the replay lifecycle lock, blocking a foreground
+          // start() on the main thread (ANR)
+          options.executorService.submitSafely(options, "$TAG.stop") {
+            options.replayController.stop()
+          }
         }
       }
     )

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -29,6 +29,8 @@ import io.sentry.protocol.SentryId
 import io.sentry.rrweb.RRWebBreadcrumbEvent
 import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebOptionsEvent
+import io.sentry.test.DeferredExecutorService
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
 import java.io.File
@@ -66,6 +68,7 @@ class SessionCaptureStrategyTest {
         setReplayController(
           mock { on { breadcrumbConverter }.thenReturn(DefaultReplayBreadcrumbConverter()) }
         )
+        executorService = ImmediateExecutorService()
       }
     val scope = Scope(options)
     val scopes =
@@ -287,6 +290,35 @@ class SessionCaptureStrategyTest {
     strategy.onConfigurationChanged(mock<ScreenshotRecorderConfig>())
 
     strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+    verify(fixture.options.replayController).stop()
+  }
+
+  @Test
+  fun `onScreenshotRecorded dispatches deadline stop off the calling thread`() {
+    val deferredExecutor = DeferredExecutorService()
+    fixture.options.executorService = deferredExecutor
+    var count = 0
+    val strategy =
+      fixture.getSut(
+        dateProvider = {
+          if (count++ == 2) {
+            System.currentTimeMillis() + (fixture.options.sessionReplay.sessionDuration * 2)
+          } else {
+            System.currentTimeMillis()
+          }
+        }
+      )
+    strategy.start()
+    strategy.onConfigurationChanged(mock<ScreenshotRecorderConfig>())
+
+    strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+    // stop must not run inline on the caller (replay worker) thread, otherwise it would encode the
+    // final segment while holding the lifecycle lock and block a foreground start() (ANR)
+    verify(fixture.options.replayController, never()).stop()
+
+    deferredExecutor.runAll()
 
     verify(fixture.options.replayController).stop()
   }


### PR DESCRIPTION
## :scroll: Description

When a session replay reaches its duration deadline (default 1h), the resulting `stop()` was invoked inline from the replay worker thread, inside the `add_frame` task in `SessionCaptureStrategy.onScreenshotRecorded`. Because `ReplayExecutorService.submit()` runs tasks synchronously when the caller is already on a `SentryReplayIntegration-*` thread, `stop()` encoded the final video segment and recursively deleted the replay cache **while holding the replay lifecycle lock** (`AutoClosableReentrantLock`).

A foreground `start()` (`LifecycleWatcher.onForeground` → `startSession`) runs on the **main thread** and must acquire that same lock, so it parked long enough to trigger a background ANR.

This change dispatches the deadline `stop()` through `options.executorService` (a non-worker thread). `stop()` then submits the segment encoding **asynchronously** onto the single-threaded replay executor (preserving ordering), and the lifecycle lock is held only for the fast state transition — matching the existing timer-executor `endSession` stop path.

## :bulb: Motivation and Context

Fixes the background ANR reported in getsentry/sentry-dart#3556 (Linear: DART-323), whose stack shows the main thread parked on the replay lifecycle lock in `ReplayIntegration.start()` on foreground. The deadline stop re-entering the lifecycle lock from the worker thread is the only path where the segment encode runs synchronously under the lock; every other `start`/`stop`/`pause`/`resume` caller already submits the encode asynchronously.

- GH Issue: getsentry/sentry-dart#3556
- Linear: DART-323

## :green_heart: How did you test it?

Added a regression test in `SessionCaptureStrategyTest` using a deferred executor that asserts the deadline `stop()` is dispatched off the calling thread (not run inline) and only runs once the executor drains. Updated the existing deadline test's fixture to use an immediate executor so it still exercises the dispatched stop.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
