### PR TITLE
fix(anr-profiling): Properly bill ANR profiling under UI Profile Hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Set the correct platform (`android` instead of `java`) on ANR profile chunks so they are billed as UI Profile Hours rather than Continuous Profile Hours ([#5836](https://github.com/getsentry/sentry-java/pull/5836))
 - Prevent concurrent PixelCopy access during Session Replay masking and bitmap cleanup ([#5808](https://github.com/getsentry/sentry-java/pull/5808))
 - Release `MediaMuxer` when the replay video encoder fails to start to avoid a resource leak ([#5607](https://github.com/getsentry/sentry-java/pull/5607))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoEventProcessor.java
@@ -1021,7 +1021,7 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
               null,
               new HashMap<>(0),
               anrTimestampMs / 1000.0d,
-              ProfileChunk.PLATFORM_JAVA,
+              ProfileChunk.PLATFORM_ANDROID,
               options);
       chunk.setSentryProfile(profile);
 


### PR DESCRIPTION
## :scroll: Description

Updates the platform used with ANR profiles from Java to Android so that we can properly bill ANR profiling under UI Profile Hours rather than Continuous Profile Hours.

Depends on the updates made in [Relay #6183](https://github.com/getsentry/relay/pull/6183), [getsentry #118849](https://github.com/getsentry/sentry/pull/118849), [vroomrs #93](https://github.com/getsentry/vroomrs/pull/93), and [vroom #672](https://github.com/getsentry/vroom/pull/672) – all of which have been deployed.

## :bulb: Motivation and Context

ANR profile chunks are currently (and wrongly) counted against customers' Continuous Profile Hours rather than UI Profile Hours. Relay attributes all "java" platform profile chunks to Continuous Profile Hours and "android" to UI Profile Hours. 

[JAVA-548](https://linear.app/getsentry/issue/JAVA-548/bill-anr-profiles-as-ui-profile-hours-instead-of-continuous-profile)

## :green_heart: How did you test it?

n/a

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps

- [x] Merge + deploy [Relay #6183](https://github.com/getsentry/relay/pull/6183) prior to merging this PR.
- [ ] Inform #team-se prior to publishing the changes in this PR, as it will have billing consequences for customers.
- [ ] Merge doc updates: [sentry-docs #18839](https://github.com/getsentry/sentry-docs/pull/18839)