### PR TITLE
fix(replay): Don't let a wedged video encoder freeze the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))
 - Preserve custom `Throwable` identities when R8 optimizes Android apps ([#5881](https://github.com/getsentry/sentry-java/pull/5881))
 - Report the correct cpu usage for the first performance sample of a transaction, which was measured against the time since device boot ([#5926](https://github.com/getsentry/sentry-java/pull/5926))
+- Prevent an ANR when the Session Replay video encoder gets stuck ([#5842](https://github.com/getsentry/sentry-java/pull/5842))
+  - Some hardware encoders never signal end-of-stream, which made the replay worker spin forever while holding the encoder lock. The app's lifecycle callbacks then blocked on that lock and the app froze until the system killed it. The encoder now gives up instead of spinning, and closing the replay cache no longer waits indefinitely for a wedged encoder.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))
 - Preserve custom `Throwable` identities when R8 optimizes Android apps ([#5881](https://github.com/getsentry/sentry-java/pull/5881))
+- Prevent an ANR when the Session Replay video encoder gets stuck ([#5842](https://github.com/getsentry/sentry-java/pull/5842))
+  - Some hardware encoders never signal end-of-stream, which made the replay worker spin forever while holding the encoder lock. The app's lifecycle callbacks then blocked on that lock and the app froze until the system killed it. The encoder now gives up instead of spinning, and closing the replay cache no longer waits indefinitely for a wedged encoder.
 
 ### Dependencies
 

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
   testImplementation(libs.androidx.test.ext.junit)
   testImplementation(libs.androidx.test.runner)
   testImplementation(libs.awaitility.kotlin)
+  testImplementation(libs.google.truth)
   testImplementation(libs.mockito.kotlin)
   testImplementation(libs.mockito.inline)
   testImplementation(libs.androidx.compose.ui)

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -300,9 +300,10 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
       }
     } catch (e: InterruptedException) {
       Thread.currentThread().interrupt()
+    } finally {
+      // has to happen on all paths, callers rely on it to stop persisting segment values
+      isClosed.set(true)
     }
-    // has to happen on all paths, callers rely on it to stop persisting segment values
-    isClosed.set(true)
   }
 
   // TODO: it's awful, choose a better serialization format

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -22,6 +22,7 @@ import java.io.File
 import java.io.StringReader
 import java.util.Date
 import java.util.LinkedList
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -280,10 +281,27 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
   }
 
   override fun close() {
-    encoderLock.acquire().use {
-      encoder?.release()
-      encoder = null
+    // close() is called inline from the lifecycle path (ReplayIntegration.stop/close), which holds
+    // its own lock, so blocking here can freeze the main thread. If the encoder is wedged in a
+    // native MediaCodec call we'd never get the lock, so we give up instead: the already-dead codec
+    // is not released (leaking a native handle), which beats an ANR.
+    try {
+      val token = encoderLock.tryAcquire(ENCODER_RELEASE_TIMEOUT_MS, MILLISECONDS)
+      if (token == null) {
+        options.logger.log(
+          WARNING,
+          "Timed out waiting for the video encoder, skipping its release to not block the caller",
+        )
+      } else {
+        token.use {
+          encoder?.release()
+          encoder = null
+        }
+      }
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
     }
+    // has to happen on all paths, callers rely on it to stop persisting segment values
     isClosed.set(true)
   }
 
@@ -314,6 +332,13 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
   }
 
   internal companion object {
+    /**
+     * How long [close] waits for the video encoder to become available. Below Android's ~5s ANR
+     * budget, and above the encoder's own bail-out (see MAX_EOS_STALL_ITERATIONS), so an encoder
+     * that's merely slow is still awaited rather than abandoned.
+     */
+    private const val ENCODER_RELEASE_TIMEOUT_MS = 2000L
+
     internal const val ONGOING_SEGMENT = ".ongoing_segment"
 
     internal const val SEGMENT_KEY_HEIGHT = "config.height"

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -37,6 +37,7 @@ import android.media.MediaFormat
 import android.os.Build
 import android.view.Surface
 import io.sentry.SentryLevel.DEBUG
+import io.sentry.SentryLevel.WARNING
 import io.sentry.SentryOptions
 import io.sentry.android.replay.util.SystemProperties
 import java.io.File
@@ -301,7 +302,7 @@ internal class SimpleVideoEncoder(
 
       if (stalledIterations >= MAX_EOS_STALL_ITERATIONS) {
         options.logger.log(
-          DEBUG,
+          WARNING,
           "[Encoder]: encoder made no progress for $stalledIterations iterations, dropping the remaining frames",
         )
         break // out of while

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -45,6 +45,16 @@ import kotlin.LazyThreadSafetyMode.NONE
 
 private const val TIMEOUT_USEC = 100_000L
 
+/**
+ * How many consecutive [MediaCodec.dequeueOutputBuffer] calls may come back without producing
+ * anything before we give up on the encoder. At [TIMEOUT_USEC] per call that's ~1s.
+ *
+ * Some hardware encoders never emit [MediaCodec.BUFFER_FLAG_END_OF_STREAM] after
+ * [MediaCodec.signalEndOfInputStream], which used to spin the drain loop forever while holding the
+ * encoder lock, wedging the whole replay pipeline (and with it the app's lifecycle callbacks).
+ */
+private const val MAX_EOS_STALL_ITERATIONS = 10
+
 @SuppressLint("UseRequiresApi")
 @TargetApi(26)
 internal class SimpleVideoEncoder(
@@ -214,19 +224,26 @@ internal class SimpleVideoEncoder(
       mediaCodec.signalEndOfInputStream()
     }
     var encoderOutputBuffers: Array<ByteBuffer?>? = mediaCodec.outputBuffers
+    // counts consecutive iterations that made no progress, so a codec that never signals EOS can't
+    // spin us forever, see MAX_EOS_STALL_ITERATIONS
+    var stalledIterations = 0
     while (true) {
       val encoderStatus: Int = mediaCodec.dequeueOutputBuffer(bufferInfo, TIMEOUT_USEC)
       if (encoderStatus == MediaCodec.INFO_TRY_AGAIN_LATER) {
         // no output available yet
         if (!endOfStream) {
           break // out of while
-        } else if (options.sessionReplay.isDebug) {
+        }
+        stalledIterations++
+        if (options.sessionReplay.isDebug) {
           options.logger.log(DEBUG, "[Encoder]: no output available, spinning to await EOS")
         }
       } else if (encoderStatus == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
+        stalledIterations = 0
         // not expected for an encoder
         encoderOutputBuffers = mediaCodec.outputBuffers
       } else if (encoderStatus == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+        stalledIterations = 0
         // should happen before receiving buffers, and should only happen once
         if (frameMuxer.isStarted()) {
           throw RuntimeException("format changed twice")
@@ -245,8 +262,10 @@ internal class SimpleVideoEncoder(
             "[Encoder]: unexpected result from encoder.dequeueOutputBuffer: $encoderStatus",
           )
         }
-        // let's ignore it
+        // let's ignore it, but still count it as no progress so we can't loop on it forever
+        stalledIterations++
       } else {
+        stalledIterations = 0
         val encodedData =
           encoderOutputBuffers?.get(encoderStatus)
             ?: throw RuntimeException("encoderOutputBuffer $encoderStatus was null")
@@ -278,6 +297,14 @@ internal class SimpleVideoEncoder(
           }
           break // out of while
         }
+      }
+
+      if (stalledIterations >= MAX_EOS_STALL_ITERATIONS) {
+        options.logger.log(
+          DEBUG,
+          "[Encoder]: encoder made no progress for $stalledIterations iterations, dropping the remaining frames",
+        )
+        break // out of while
       }
     }
   }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -66,6 +66,7 @@ class ReplayCacheTest {
     ReplayShadowMediaCodec.neverSignalEos = false
     ReplayShadowMediaCodec.blockOnDequeue = null
     ReplayShadowMediaCodec.blockedOnDequeue = CountDownLatch(1)
+    ReplayShadowMediaCodec.released = false
     ShadowBitmapFactory.setAllowInvalidImageData(true)
   }
 
@@ -720,9 +721,29 @@ class ReplayCacheTest {
       // giving up on the lock still counts as closed, otherwise we'd keep persisting segments
       replayCache.persistSegmentValues(SEGMENT_KEY_ID, "0")
       assertThat(File(replayCache.replayCacheDir, ONGOING_SEGMENT).exists()).isFalse()
+
+      assertWithMessage("encoder should not be released when the lock times out")
+        .that(ReplayShadowMediaCodec.released)
+        .isFalse()
     } finally {
       wedge.countDown()
       encoder.join(SECONDS.toMillis(10))
     }
+  }
+
+  @Test
+  fun `close releases the encoder when the lock is available`() {
+    ReplayShadowMediaCodec.neverSignalEos = true
+    val replayCache = fixture.getSut(tmpDir)
+
+    val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
+    replayCache.addFrame(bitmap, 1)
+
+    // createVideoOf bails out via the stall bound, but still releases the encoder
+    replayCache.createVideoOf(1000L, 0L, 0, 100, 200, 1, 20_000)
+
+    assertWithMessage("encoder should be released even when EOS was never signalled")
+      .that(ReplayShadowMediaCodec.released)
+      .isTrue()
   }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -732,14 +732,14 @@ class ReplayCacheTest {
   }
 
   @Test
-  fun `close releases the encoder when the lock is available`() {
+  fun `createVideoOf releases the encoder even when EOS is never signalled`() {
     ReplayShadowMediaCodec.neverSignalEos = true
     val replayCache = fixture.getSut(tmpDir)
 
     val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
     replayCache.addFrame(bitmap, 1)
 
-    // createVideoOf bails out via the stall bound, but still releases the encoder
+    // the stall bound breaks the drain loop, but release() must still be called
     replayCache.createVideoOf(1000L, 0L, 0, 100, 200, 1, 20_000)
 
     assertWithMessage("encoder should be released even when EOS was never signalled")

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -4,6 +4,8 @@ import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat.JPEG
 import android.graphics.Bitmap.Config.ARGB_8888
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import io.sentry.DateUtils
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent.ReplayType
@@ -24,7 +26,9 @@ import io.sentry.rrweb.RRWebInteractionEvent.InteractionType.TouchEnd
 import io.sentry.rrweb.RRWebInteractionEvent.InteractionType.TouchStart
 import java.io.File
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,6 +63,9 @@ class ReplayCacheTest {
   fun `set up`() {
     ReplayShadowMediaCodec.framesToEncode = 5
     ReplayShadowMediaCodec.throwOnStart = false
+    ReplayShadowMediaCodec.neverSignalEos = false
+    ReplayShadowMediaCodec.blockOnDequeue = null
+    ReplayShadowMediaCodec.blockedOnDequeue = CountDownLatch(1)
     ShadowBitmapFactory.setAllowInvalidImageData(true)
   }
 
@@ -653,5 +660,69 @@ class ReplayCacheTest {
 
     // No crash is success
     assertNull(error.get())
+  }
+
+  @Test
+  fun `createVideoOf returns when the encoder never signals end of stream`() {
+    ReplayShadowMediaCodec.neverSignalEos = true
+    val replayCache = fixture.getSut(tmpDir)
+
+    val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
+    replayCache.addFrame(bitmap, 1)
+
+    val done = CountDownLatch(1)
+    val error = AtomicReference<Throwable?>()
+    val encoder =
+      thread(isDaemon = true) {
+        try {
+          replayCache.createVideoOf(1000L, 0L, 0, 100, 200, 1, 20_000)
+        } catch (t: Throwable) {
+          error.set(t)
+        } finally {
+          done.countDown()
+        }
+      }
+
+    assertWithMessage("createVideoOf did not return, the drain loop is spinning")
+      .that(done.await(30, SECONDS))
+      .isTrue()
+    encoder.join(SECONDS.toMillis(10))
+    assertThat(error.get()).isNull()
+  }
+
+  @Test
+  fun `close does not block when the encoder is wedged, and still marks the cache closed`() {
+    val wedge = CountDownLatch(1)
+    ReplayShadowMediaCodec.blockOnDequeue = wedge
+    val replayCache = fixture.getSut(tmpDir)
+
+    val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
+    replayCache.addFrame(bitmap, 1)
+
+    // parks inside MediaCodec while holding the encoder lock
+    val encoder =
+      thread(isDaemon = true) { replayCache.createVideoOf(1000L, 0L, 0, 100, 200, 1, 20_000) }
+    try {
+      assertWithMessage("the encoder never reached dequeueOutputBuffer")
+        .that(ReplayShadowMediaCodec.blockedOnDequeue.await(30, SECONDS))
+        .isTrue()
+
+      // on a separate thread so a regression fails the test instead of hanging the run
+      val closed = CountDownLatch(1)
+      thread(isDaemon = true) {
+        replayCache.close()
+        closed.countDown()
+      }
+      assertWithMessage("close() blocked on the wedged encoder")
+        .that(closed.await(30, SECONDS))
+        .isTrue()
+
+      // giving up on the lock still counts as closed, otherwise we'd keep persisting segments
+      replayCache.persistSegmentValues(SEGMENT_KEY_ID, "0")
+      assertThat(File(replayCache.replayCacheDir, ONGOING_SEGMENT).exists()).isFalse()
+    } finally {
+      wedge.countDown()
+      encoder.join(SECONDS.toMillis(10))
+    }
   }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ReplayShadowMediaCodec.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ReplayShadowMediaCodec.kt
@@ -3,6 +3,7 @@ package io.sentry.android.replay.util
 import android.media.MediaCodec
 import android.media.MediaCodec.BufferInfo
 import java.nio.ByteBuffer
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MICROSECONDS
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicBoolean
@@ -16,6 +17,18 @@ class ReplayShadowMediaCodec : ShadowMediaCodec() {
     var frameRate = 1
     var framesToEncode = 5
     var throwOnStart = false
+
+    /** Simulates an encoder that never emits [MediaCodec.BUFFER_FLAG_END_OF_STREAM]. */
+    var neverSignalEos = false
+
+    /**
+     * When set, [dequeueOutputBuffer] awaits this latch, simulating a native call that never
+     * returns. [blockedOnDequeue] is counted down right before, so tests can wait until the codec
+     * is actually stuck.
+     */
+    var blockOnDequeue: CountDownLatch? = null
+
+    var blockedOnDequeue = CountDownLatch(1)
   }
 
   private val encoded = AtomicBoolean(false)
@@ -30,6 +43,9 @@ class ReplayShadowMediaCodec : ShadowMediaCodec() {
 
   @Implementation
   fun signalEndOfInputStream() {
+    if (neverSignalEos) {
+      return
+    }
     encodeFrame(framesToEncode, frameRate, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
   }
 
@@ -37,6 +53,10 @@ class ReplayShadowMediaCodec : ShadowMediaCodec() {
 
   @Implementation
   fun dequeueOutputBuffer(info: BufferInfo, timeoutUs: Long): Int {
+    blockOnDequeue?.let {
+      blockedOnDequeue.countDown()
+      it.await()
+    }
     val encoderStatus = super.native_dequeueOutputBuffer(info, timeoutUs)
     super.validateOutputByteBuffer(getOutputBuffers(), encoderStatus, info)
     if (encoderStatus == MediaCodec.INFO_TRY_AGAIN_LATER && !encoded.getAndSet(true)) {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ReplayShadowMediaCodec.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ReplayShadowMediaCodec.kt
@@ -29,9 +29,17 @@ class ReplayShadowMediaCodec : ShadowMediaCodec() {
     var blockOnDequeue: CountDownLatch? = null
 
     var blockedOnDequeue = CountDownLatch(1)
+
+    /** Set to `true` when [release] is called. */
+    var released = false
   }
 
   private val encoded = AtomicBoolean(false)
+
+  @Implementation
+  fun release() {
+    released = true
+  }
 
   @Implementation
   fun start() {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7641,6 +7641,7 @@ public final class io/sentry/util/AutoClosableReentrantLock : io/sentry/ISentryL
 	public fun <init> ()V
 	public fun acquire ()Lio/sentry/ISentryLifecycleToken;
 	public fun close ()V
+	public fun tryAcquire (JLjava/util/concurrent/TimeUnit;)Lio/sentry/ISentryLifecycleToken;
 }
 
 public final class io/sentry/util/CheckInUtils {

--- a/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
+++ b/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
@@ -1,6 +1,7 @@
 package io.sentry.util;
 
 import io.sentry.ISentryLifecycleToken;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.ReentrantLock;
 import org.jetbrains.annotations.ApiStatus;
@@ -36,6 +37,19 @@ public final class AutoClosableReentrantLock implements ISentryLifecycleToken {
   public @NotNull ISentryLifecycleToken acquire() {
     getOrCreateLock().lock();
     return this;
+  }
+
+  /**
+   * Like {@link #acquire()}, but gives up after {@code timeout}. Use it when blocking forever would
+   * be worse than not doing the work at all, e.g. on a path that can run on the main thread.
+   *
+   * @return the token (this instance) if the lock was acquired, or {@code null} if it wasn't. A
+   *     {@code null} return means the lock is <b>not</b> held, so {@link #close()} must not be
+   *     called for it.
+   */
+  public @Nullable ISentryLifecycleToken tryAcquire(
+      final long timeout, final @NotNull TimeUnit unit) throws InterruptedException {
+    return getOrCreateLock().tryLock(timeout, unit) ? this : null;
   }
 
   @Override

--- a/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
+++ b/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.util
 
+import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -39,6 +40,55 @@ class AutoClosableReentrantLockTest {
       assertTrue(lock.isLocked)
     }
     assertFalse(lock.isLocked)
+  }
+
+  @Test
+  fun `tryAcquire returns the lock itself as the token when free`() {
+    val lock = AutoClosableReentrantLock()
+    val token = lock.tryAcquire(1, TimeUnit.SECONDS)
+    assertThat(token).isSameInstanceAs(lock)
+    token!!.use { assertThat(lock.isLocked).isTrue() }
+    assertThat(lock.isLocked).isFalse()
+  }
+
+  @Test
+  fun `tryAcquire does not allocate the underlying lock until first use`() {
+    val lock = AutoClosableReentrantLock()
+    assertThat(lock.isLockAllocated).isFalse()
+    lock.tryAcquire(1, TimeUnit.SECONDS)!!.use {}
+    assertThat(lock.isLockAllocated).isTrue()
+  }
+
+  @Test
+  fun `tryAcquire returns null when another thread holds the lock past the timeout`() {
+    val lock = AutoClosableReentrantLock()
+    val acquired = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val holder = Thread {
+      lock.acquire().use {
+        acquired.countDown()
+        release.await()
+      }
+    }
+    holder.start()
+    try {
+      assertThat(acquired.await(10, TimeUnit.SECONDS)).isTrue()
+      assertThat(lock.tryAcquire(10, TimeUnit.MILLISECONDS)).isNull()
+    } finally {
+      release.countDown()
+      holder.join(TimeUnit.SECONDS.toMillis(10))
+    }
+    assertThat(lock.isLocked).isFalse()
+  }
+
+  @Test
+  fun `tryAcquire is reentrant from the same thread`() {
+    val lock = AutoClosableReentrantLock()
+    lock.acquire().use {
+      lock.tryAcquire(0, TimeUnit.MILLISECONDS)!!.use { assertThat(lock.isLocked).isTrue() }
+      assertThat(lock.isLocked).isTrue()
+    }
+    assertThat(lock.isLocked).isFalse()
   }
 
   @Test


### PR DESCRIPTION
#### 📜 Description

Fixes an ANR where Android apps freeze on foreground/background transitions until the system kills the process.

A reporter pulled the full deobfuscated 131-thread dump from Play Console (the Sentry ANR event only carries `main`, which is why the lock holder was invisible), giving us the exact chain:

```
main ──waits──▶ lifecycleLock ──held by──▶ timer thread
                                              │ waits
                                              ▼
                                          encoderLock ──held by──▶ SentryReplayIntegration-0
                                                                       │ parked forever
                                                                       ▼
                                                          MediaCodec.dequeueOutputBuffer
```

Two cooperating defects, so two bounds — both are needed:

1. **`SimpleVideoEncoder.drainCodec()`** had a `while (true)` with no exit on the `endOfStream = true` path. Some hardware encoders never emit `BUFFER_FLAG_END_OF_STREAM` after `signalEndOfInputStream()`, so the loop spun forever while holding `encoderLock`. It now gives up after 10 consecutive no-progress iterations (~1s at the existing 100ms poll) and drops the remaining frames.
2. **`ReplayCache.close()`** used an unbounded `encoderLock.acquire()`. It runs inline on the caller's thread from `BaseCaptureStrategy.stop()`, which `ReplayIntegration.stop()` invokes while holding `lifecycleLock` — that nesting is what promotes a stuck encoder into a frozen main thread. It now waits at most 2s and skips the release otherwise.

The loop bound alone isn't sufficient: the native frames show `MediaCodec::dequeueOutputBuffer` → `AMessage::postAndAwaitResponse` → `ALooper::awaitResponse` with `MediaCodec_looper` idle. `TIMEOUT_USEC` is handed *to* the codec looper, which is supposed to reply once it elapses — a dead looper never replies, and `awaitResponse` has no deadline of its own. So a single call can never return, and only bounding the *lock wait* keeps the lifecycle path free.

On the timeout path the (already-dead) codec is not released, leaking a native handle. That's the deliberate trade: leaking a handle in a process whose encoder is wedged beats freezing the app. `isClosed.set(true)` still runs on every path, since `persistSegmentValues` gates on it.

The other four `encoderLock.acquire()` sites in `ReplayCache` are unchanged — they all run on the replay worker, the thread that would be stuck, so a deadline there buys nothing.

Adds `AutoClosableReentrantLock.tryAcquire(timeout, unit)` (`@ApiStatus.Internal`, additive) for the second bound. Returns the token on success and `null` on timeout, so callers must branch explicitly rather than silently no-op via `?.use {}`.

Net effect: a wedged codec degrades to "replay stops working for this process" instead of "the app freezes."

Fixes https://github.com/getsentry/sentry-dart/issues/3556
Fixes https://github.com/getsentry/sentry-java/issues/5870

#### 💚 How did you test it?

`ReplayShadowMediaCodec` gained two hooks, since it ignores `timeoutUs` and always eventually produces EOS: `neverSignalEos` and `blockOnDequeue`. New tests cover both bounds in `ReplayCacheTest`, plus 4 for `tryAcquire` in `AutoClosableReentrantLockTest`.

Both `ReplayCacheTest` cases were mutation-checked — reverting each fix in turn makes the matching test fail with its assertion message rather than hang. Full `:sentry-android-replay:testReleaseUnitTest` passes; `apiDump` adds exactly the one `tryAcquire` line.

No device repro is available (Redmi Note 14 Pro 5G / Pro+ 5G, Android 16, MediaTek), so the shadow-based tests are the verification of record.

#### 📝 Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
