### PR TITLE
perf: Drop pending timer tasks on shutdown to unblock close (JAVA-653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Performance
 
+- Avoid waiting up to `shutdownTimeoutMillis` when closing the SDK with a pending transaction timeout or session-end task ([#5851](https://github.com/getsentry/sentry-java/pull/5851))
 - Use `RGB_565` instead of `ARGB_8888` for screenshot and replay capture bitmaps, halving per-frame memory usage ([#5821](https://github.com/getsentry/sentry-java/pull/5821))
 - Remove an unused lock from `SentryPerformanceProvider`, which was allocated on every cold start in `ContentProvider.onCreate` without ever being acquired ([#5871](https://github.com/getsentry/sentry-java/pull/5871))
 - Parse the app start profiling config with only the deserializer it needs instead of building a full `JsonSerializer` and `SentryOptions`, cutting 188 of 221 allocations on the main thread before `Application.onCreate` ([#5867](https://github.com/getsentry/sentry-java/pull/5867))

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -55,6 +55,10 @@ public final class SentryExecutorService implements ISentryExecutorService {
     executorService.setRemoveOnCancelPolicy(removeOnCancelPolicy);
     executorService.setKeepAliveTime(keepAliveTime, keepAliveTimeUnit);
     executorService.allowCoreThreadTimeOut(true);
+    // by default shutdown() keeps queued delayed tasks, so awaitTermination blocks for the full
+    // shutdown timeout whenever a long timeout is still pending. Those tasks are discarded by the
+    // subsequent shutdownNow() anyway, so dropping them upfront only saves the wait.
+    executorService.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
   }
 
   public SentryExecutorService() {

--- a/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
@@ -8,7 +8,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.system.measureTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -109,27 +108,6 @@ class SentryExecutorServiceTest {
     val executor = sentryExecutor.getProperty<ScheduledThreadPoolExecutor>("executorService")
     assertFalse(executor.removeOnCancelPolicy)
     sentryExecutor.close(15000)
-  }
-
-  @Test
-  fun `SentryExecutorService discards pending delayed tasks on shutdown when requested`() {
-    val sentryExecutor = SentryExecutorService(null, true, 30, TimeUnit.SECONDS)
-    val executor = sentryExecutor.getProperty<ScheduledThreadPoolExecutor>("executorService")
-    assertFalse(executor.executeExistingDelayedTasksAfterShutdownPolicy)
-    sentryExecutor.close(15000)
-  }
-
-  @Test
-  fun `SentryExecutorService close does not wait for a pending delayed task`() {
-    val sentryExecutor = SentryExecutorService(null, true, 30, TimeUnit.SECONDS)
-    val ran = AtomicBoolean(false)
-    sentryExecutor.schedule({ ran.set(true) }, 30000)
-
-    val elapsed = measureTimeMillis { sentryExecutor.close(5000) }
-
-    assertTrue(elapsed < 5000, "close blocked for ${elapsed}ms waiting on the pending task")
-    assertTrue(sentryExecutor.isClosed)
-    assertFalse(ran.get())
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
@@ -8,6 +8,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.system.measureTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -108,6 +109,27 @@ class SentryExecutorServiceTest {
     val executor = sentryExecutor.getProperty<ScheduledThreadPoolExecutor>("executorService")
     assertFalse(executor.removeOnCancelPolicy)
     sentryExecutor.close(15000)
+  }
+
+  @Test
+  fun `SentryExecutorService discards pending delayed tasks on shutdown when requested`() {
+    val sentryExecutor = SentryExecutorService(null, true, 30, TimeUnit.SECONDS)
+    val executor = sentryExecutor.getProperty<ScheduledThreadPoolExecutor>("executorService")
+    assertFalse(executor.executeExistingDelayedTasksAfterShutdownPolicy)
+    sentryExecutor.close(15000)
+  }
+
+  @Test
+  fun `SentryExecutorService close does not wait for a pending delayed task`() {
+    val sentryExecutor = SentryExecutorService(null, true, 30, TimeUnit.SECONDS)
+    val ran = AtomicBoolean(false)
+    sentryExecutor.schedule({ ran.set(true) }, 30000)
+
+    val elapsed = measureTimeMillis { sentryExecutor.close(5000) }
+
+    assertTrue(elapsed < 5000, "close blocked for ${elapsed}ms waiting on the pending task")
+    assertTrue(sentryExecutor.isClosed)
+    assertFalse(ran.get())
   }
 
   @Test


### PR DESCRIPTION
This is a follow up on this comment: https://github.com/getsentry/sentry-java/pull/5814/changes#r3667006204

The timer executor is shut down in `Scopes.close()` via `shutdown()` followed by `awaitTermination(shutdownTimeoutMillis)`. `ScheduledThreadPoolExecutor` keeps queued delayed tasks across `shutdown()` by default, so `awaitTermination` blocks for the **full shutdown timeout (2s by default)** whenever a long timeout is still pending at close time:

- an unfinished transaction's idle/deadline timer (`SentryTracer`)
- the 30s `LifecycleWatcher` end-session task, only cancelled on foregrounding
- a rate limit lifted notification (`RateLimiter`, up to `retry_after`)

Setting `executeExistingDelayedTasksAfterShutdownPolicy(false)` drops those tasks at `shutdown()` instead. This is behaviour preserving: today they are discarded by the subsequent `shutdownNow()` once the timeout expires anyway, so the only thing lost is the wait.

The policy only affects `shutdown()`, so the SDK restart path that intentionally leaves the timer executor running (`Scopes.close(isRestarting = true)`) is unaffected. Scoped to the timer executor's constructor — the general-purpose executor keeps the default.

Measured with a standalone repro using the same executor configuration, one pending 60s task and a 2s timeout:

| | `terminated` | blocked |
|---|---|---|
| before | `false` | 2000ms |
| after | `true` | 0ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)