### PR TITLE
fix(anr): Use Proguard ID from origination ANR process with ANR profie chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Use the original app build's ProGuard UUID for ANR profile chunks ([#5852](https://github.com/getsentry/sentry-java/pull/5852))
 - Fix potential ANR/deadlock in Session Replay when `checkCanRecord` runs on the replay executor thread ([#5837](https://github.com/getsentry/sentry-java/pull/5837))
 - Prevent concurrent PixelCopy access during Session Replay masking and bitmap cleanup ([#5808](https://github.com/getsentry/sentry-java/pull/5808))
 - Release `MediaMuxer` when the replay video encoder fails to start to avoid a resource leak ([#5607](https://github.com/getsentry/sentry-java/pull/5607))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoEventProcessor.java
@@ -184,7 +184,7 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
     setStaticValues(event);
 
     if (hintEnricher != null) {
-      hintEnricher.applyPostEnrichment(event, backfillable, unwrappedHint);
+      hintEnricher.applyPostEnrichment(event, backfillable, unwrappedHint, optionsSource);
     }
 
     return event;
@@ -504,10 +504,7 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
               PROGUARD_UUID_FILENAME, String.class, options.getProguardUuid(), optionsSource);
 
       if (proguardUuid != null) {
-        final DebugImage debugImage = new DebugImage();
-        debugImage.setType(DebugImage.PROGUARD);
-        debugImage.setUuid(proguardUuid);
-        images.add(debugImage);
+        images.add(createProguardDebugImage(proguardUuid));
       }
       event.setDebugMeta(debugMeta);
     }
@@ -790,7 +787,10 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
         @NotNull SentryEvent event, @NotNull Backfillable hint, @NotNull Object rawHint);
 
     void applyPostEnrichment(
-        @NotNull SentryEvent event, @NotNull Backfillable hint, @NotNull Object rawHint);
+        @NotNull SentryEvent event,
+        @NotNull Backfillable hint,
+        @NotNull Object rawHint,
+        @NotNull OptionsSource optionsSource);
   }
 
   private final class AnrHintEnricher implements HintEnricher {
@@ -822,11 +822,14 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
 
     @Override
     public void applyPostEnrichment(
-        @NotNull SentryEvent event, @NotNull Backfillable hint, @NotNull Object rawHint) {
+        @NotNull SentryEvent event,
+        @NotNull Backfillable hint,
+        @NotNull Object rawHint,
+        @NotNull OptionsSource optionsSource) {
       final boolean isBackgroundAnr = isBackgroundAnr(rawHint);
 
       if (options.isAnrProfilingEnabled()) {
-        applyAnrProfile(event, hint, isBackgroundAnr);
+        applyAnrProfile(event, hint, isBackgroundAnr, optionsSource);
       }
 
       setDefaultAnrFingerprint(event, isBackgroundAnr);
@@ -920,7 +923,10 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
     }
 
     private void applyAnrProfile(
-        @NotNull SentryEvent event, @NotNull Backfillable hint, boolean isBackgroundAnr) {
+        @NotNull SentryEvent event,
+        @NotNull Backfillable hint,
+        boolean isBackgroundAnr,
+        @NotNull OptionsSource optionsSource) {
 
       // Skip background ANRs (as profiling only runs in foreground)
       if (isBackgroundAnr) {
@@ -981,7 +987,8 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
       }
 
       // Capture profile chunk
-      final @Nullable SentryId profilerId = captureAnrProfile(anrTimestamp, anrProfile);
+      final @Nullable SentryId profilerId =
+          captureAnrProfile(anrTimestamp, anrProfile, optionsSource);
       final @NotNull StackTraceElement[] stack = culprit.getStack();
 
       if (stack.length > 0) {
@@ -1012,7 +1019,10 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
     }
 
     @Nullable
-    private SentryId captureAnrProfile(final long anrTimestampMs, @NotNull AnrProfile anrProfile) {
+    private SentryId captureAnrProfile(
+        final long anrTimestampMs,
+        @NotNull AnrProfile anrProfile,
+        final @NotNull OptionsSource optionsSource) {
       final SentryProfile profile = StackTraceConverter.convert(anrProfile);
       final ProfileChunk chunk =
           new ProfileChunk(
@@ -1024,6 +1034,7 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
               ProfileChunk.PLATFORM_JAVA,
               options);
       chunk.setSentryProfile(profile);
+      chunk.setDebugMeta(createAnrProfileDebugMeta(optionsSource));
 
       final SentryId profilerId = Sentry.getCurrentScopes().captureProfileChunk(chunk);
       if (SentryId.EMPTY_ID.equals(profilerId)) {
@@ -1058,5 +1069,37 @@ public final class ApplicationExitInfoEventProcessor implements BackfillingEvent
       }
       return true;
     }
+
+    /**
+     * Creates debug metadata for an ANR profile chunk using the build metadata selected for the ANR
+     * event.
+     *
+     * <p>ANR profile chunks are captured after app relaunch. If the app was updated between the ANR
+     * and the relaunch, the current options may contain the new build's ProGuard UUID. The provided
+     * {@link OptionsSource} lets us resolve the profile chunk and ANR event to the same originating
+     * build.
+     */
+    private @Nullable DebugMeta createAnrProfileDebugMeta(
+        final @NotNull OptionsSource optionsSource) {
+      final String proguardUuid =
+          getBuildOption(
+              PROGUARD_UUID_FILENAME, String.class, options.getProguardUuid(), optionsSource);
+      if (proguardUuid == null) {
+        // If no historical UUID is available, let the generic profile chunk pipeline apply the
+        // current options UUID as its normal best-effort fallback.
+        return null;
+      }
+
+      final DebugMeta debugMeta = new DebugMeta();
+      debugMeta.setImages(Collections.singletonList(createProguardDebugImage(proguardUuid)));
+      return debugMeta;
+    }
+  }
+
+  private static @NotNull DebugImage createProguardDebugImage(final @NotNull String proguardUuid) {
+    final DebugImage debugImage = new DebugImage();
+    debugImage.setType(DebugImage.PROGUARD);
+    debugImage.setUuid(proguardUuid);
+    return debugImage;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitInfoEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitInfoEventProcessorTest.kt
@@ -11,6 +11,7 @@ import io.sentry.Hint
 import io.sentry.IScopes
 import io.sentry.IpAddressUtils
 import io.sentry.NoOpLogger
+import io.sentry.ProfileChunk
 import io.sentry.Sentry
 import io.sentry.SentryBaseEvent
 import io.sentry.SentryEvent
@@ -75,7 +76,9 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import org.robolectric.shadow.api.Shadow
@@ -1012,6 +1015,60 @@ class ApplicationExitInfoEventProcessorTest {
 
       assertNotNull(processed?.contexts?.profile)
       assertNotNull(processed.contexts.profile?.profilerId)
+    }
+  }
+
+  @Test
+  fun `uses persisted proguard uuid for ANR profile chunk after app update`() {
+    fixture.options.anrProfilingSampleRate = 1.0
+    fixture.options.proguardUuid = "current-uuid"
+    val processor =
+      fixture.getSut(
+        tmpDir,
+        populateScopeCache = false,
+        populateOptionsCache = false,
+        isSendDefaultPii = false,
+      )
+    fixture.persistOptions(PROGUARD_UUID_FILENAME, "previous-uuid")
+    setLastUpdateTime(2_000)
+
+    val hint =
+      HintUtils.createWithTypeCheckHint(
+        AbnormalExitHint(mechanism = "anr_foreground", timestamp = 1_000)
+      )
+
+    AnrProfileManager(
+        fixture.options,
+        AnrProfileRotationHelper.getFileForRecording(File(fixture.options.cacheDirPath!!)),
+      )
+      .apply {
+        add(
+          AnrStackTrace(
+            1_000,
+            arrayOf(
+              StackTraceElement("com.example.MyApp", "blocked", "MyApp.java", 42),
+              StackTraceElement("android.os.Handler", "dispatchMessage", "Handler.java", 5678),
+            ),
+          )
+        )
+        close()
+      }
+    AnrProfileRotationHelper.rotate()
+
+    val scopes = mock<IScopes>()
+    whenever(scopes.captureProfileChunk(any())).thenReturn(SentryId())
+
+    mockStatic(Sentry::class.java).use { mockedSentry ->
+      mockedSentry.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(scopes)
+
+      processor.process(SentryEvent(), hint)
+
+      val chunkCaptor = argumentCaptor<ProfileChunk>()
+      verify(scopes).captureProfileChunk(chunkCaptor.capture())
+      val images = chunkCaptor.firstValue.debugMeta!!.images!!
+      assertEquals(1, images.size)
+      assertEquals(DebugImage.PROGUARD, images[0].type)
+      assertEquals("previous-uuid", images[0].uuid)
     }
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
+++ b/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
@@ -57,6 +57,19 @@ public final class DebugMeta implements JsonUnknown, JsonSerializable {
   @ApiStatus.Internal
   public static @Nullable DebugMeta buildDebugMeta(
       final @Nullable DebugMeta eventDebugMeta, final @NotNull SentryOptions options) {
+    final @NotNull List<DebugImage> optionDebugImages = createDebugImagesFromOptions(options);
+
+    if (eventDebugMeta == null && optionDebugImages.isEmpty()) {
+      return null;
+    }
+
+    DebugMeta debugMeta = eventDebugMeta != null ? eventDebugMeta : new DebugMeta();
+    addMissingDebugImages(debugMeta, optionDebugImages);
+    return debugMeta;
+  }
+
+  private static @NotNull List<DebugImage> createDebugImagesFromOptions(
+      final @NotNull SentryOptions options) {
     final @NotNull List<DebugImage> debugImages = new ArrayList<>();
 
     if (options.getProguardUuid() != null) {
@@ -73,21 +86,56 @@ public final class DebugMeta implements JsonUnknown, JsonSerializable {
       debugImages.add(sourceBundleImage);
     }
 
-    if (!debugImages.isEmpty()) {
-      DebugMeta debugMeta = eventDebugMeta;
+    return debugImages;
+  }
 
-      if (debugMeta == null) {
-        debugMeta = new DebugMeta();
-      }
-      if (debugMeta.getImages() == null) {
-        debugMeta.setImages(debugImages);
-      } else {
-        debugMeta.getImages().addAll(debugImages);
-      }
-
-      return debugMeta;
+  private static void addMissingDebugImages(
+      final @NotNull DebugMeta debugMeta, final @NotNull List<DebugImage> candidates) {
+    if (candidates.isEmpty()) {
+      return;
     }
-    return null;
+
+    if (debugMeta.getImages() == null) {
+      debugMeta.setImages(new ArrayList<>());
+    }
+
+    final @Nullable List<DebugImage> images = debugMeta.getImages();
+    if (images == null) {
+      return;
+    }
+
+    for (final @NotNull DebugImage candidate : candidates) {
+      if (isMissingDebugImage(images, candidate)) {
+        images.add(candidate);
+      }
+    }
+  }
+
+  private static boolean isMissingDebugImage(
+      final @NotNull List<DebugImage> images, final @NotNull DebugImage candidate) {
+    for (final @NotNull DebugImage image : images) {
+      if (isMatchingDebugImage(image, candidate)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isMatchingDebugImage(
+      final @NotNull DebugImage image, final @NotNull DebugImage candidate) {
+    // There can only be one ProGuard mapping per payload, so an existing ProGuard image takes
+    // precedence over the option-derived default.
+    if (DebugImage.PROGUARD.equals(candidate.getType())) {
+      return DebugImage.PROGUARD.equals(image.getType());
+    }
+
+    if (DebugImage.JVM.equals(candidate.getType())) {
+      return DebugImage.JVM.equals(image.getType())
+          && candidate.getDebugId() != null
+          && candidate.getDebugId().equals(image.getDebugId());
+    }
+
+    return false;
   }
 
   // JsonKeys

--- a/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
+++ b/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
@@ -63,7 +63,7 @@ public final class DebugMeta implements JsonUnknown, JsonSerializable {
       return null;
     }
 
-    DebugMeta debugMeta = eventDebugMeta != null ? eventDebugMeta : new DebugMeta();
+    final @NotNull DebugMeta debugMeta = eventDebugMeta != null ? eventDebugMeta : new DebugMeta();
     addMissingDebugImages(debugMeta, optionDebugImages);
     return debugMeta;
   }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -18,6 +18,8 @@ import io.sentry.logger.ILoggerBatchProcessorFactory
 import io.sentry.metrics.IMetricsBatchProcessor
 import io.sentry.metrics.IMetricsBatchProcessorFactory
 import io.sentry.protocol.Contexts
+import io.sentry.protocol.DebugImage
+import io.sentry.protocol.DebugMeta
 import io.sentry.protocol.Feedback
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.Message
@@ -1991,6 +1993,56 @@ class SentryClientTest {
     val client = fixture.getSut()
     client.captureProfileChunk(fixture.profileChunk, mock())
     verifyProfileChunkInEnvelope(fixture.profileChunk.chunkId)
+  }
+
+  @Test
+  fun `captureProfileChunk adds options proguard debug meta`() {
+    fixture.sentryOptions.proguardUuid = "current-uuid"
+
+    val client = fixture.getSut()
+    client.captureProfileChunk(fixture.profileChunk, mock())
+
+    verify(fixture.transport)
+      .send(
+        check { actual ->
+          val profileChunk = getProfileChunkFromEnvelope(actual)
+          val images = profileChunk.debugMeta!!.images!!
+
+          assertEquals(1, images.size)
+          assertEquals(DebugImage.PROGUARD, images[0].type)
+          assertEquals("current-uuid", images[0].uuid)
+        }
+      )
+  }
+
+  @Test
+  fun `captureProfileChunk preserves existing proguard debug meta`() {
+    fixture.sentryOptions.proguardUuid = "current-uuid"
+    fixture.profileChunk.debugMeta =
+      DebugMeta().apply {
+        images =
+          listOf(
+            DebugImage().apply {
+              type = DebugImage.PROGUARD
+              uuid = "previous-uuid"
+            }
+          )
+      }
+
+    val client = fixture.getSut()
+    client.captureProfileChunk(fixture.profileChunk, mock())
+
+    verify(fixture.transport)
+      .send(
+        check { actual ->
+          val profileChunk = getProfileChunkFromEnvelope(actual)
+          val images = profileChunk.debugMeta!!.images!!
+
+          assertEquals(1, images.size)
+          assertEquals(DebugImage.PROGUARD, images[0].type)
+          assertEquals("previous-uuid", images[0].uuid)
+        }
+      )
   }
 
   @Test
@@ -4167,6 +4219,17 @@ class SentryClientTest {
       inputStream,
       SentryTransaction::class.java,
     )!!
+  }
+
+  private fun getProfileChunkFromData(data: ByteArray): ProfileChunk {
+    val inputStream = InputStreamReader(ByteArrayInputStream(data))
+    return fixture.sentryOptions.serializer.deserialize(inputStream, ProfileChunk::class.java)!!
+  }
+
+  private fun getProfileChunkFromEnvelope(envelope: SentryEnvelope): ProfileChunk {
+    val profileChunkItem =
+      envelope.items.first { item -> item.header.type == SentryItemType.ProfileChunk }
+    return getProfileChunkFromData(profileChunkItem.data)
   }
 
   private fun getReplayFromData(data: ByteArray): SentryReplayEvent? {

--- a/sentry/src/test/java/io/sentry/protocol/DebugMetaTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/DebugMetaTest.kt
@@ -58,6 +58,98 @@ class DebugMetaTest {
   }
 
   @Test
+  fun `when debug meta already has proguard image, does not attach options proguard uuid`() {
+    val options = SentryOptions().apply { proguardUuid = "current-id" }
+    val debugMeta =
+      DebugMeta.buildDebugMeta(
+        DebugMeta().apply {
+          images =
+            listOf(
+              DebugImage().apply {
+                type = DebugImage.PROGUARD
+                uuid = "existing-id"
+              }
+            )
+        },
+        options,
+      )
+
+    assertNotNull(debugMeta) {
+      assertNotNull(it.images) { images ->
+        assertEquals(1, images.size)
+        assertEquals("existing-id", images[0].uuid)
+        assertEquals(DebugImage.PROGUARD, images[0].type)
+      }
+    }
+  }
+
+  @Test
+  fun `when debug meta already has proguard image, still attaches missing bundle ids`() {
+    val options =
+      SentryOptions().apply {
+        proguardUuid = "current-id"
+        bundleIds.add("bundle-id")
+      }
+    val debugMeta =
+      DebugMeta.buildDebugMeta(
+        DebugMeta().apply {
+          images =
+            listOf(
+              DebugImage().apply {
+                type = DebugImage.PROGUARD
+                uuid = "existing-id"
+              }
+            )
+        },
+        options,
+      )
+
+    assertNotNull(debugMeta) {
+      assertNotNull(it.images) { images ->
+        assertEquals(2, images.size)
+        assertEquals(DebugImage.PROGUARD, images[0].type)
+        assertEquals("existing-id", images[0].uuid)
+        assertEquals(DebugImage.JVM, images[1].type)
+        assertEquals("bundle-id", images[1].debugId)
+      }
+    }
+  }
+
+  @Test
+  fun `when debug meta has unrelated debug image, attaches option debug information`() {
+    val options =
+      SentryOptions().apply {
+        proguardUuid = "proguard-id"
+        bundleIds.add("bundle-id")
+      }
+    val debugMeta =
+      DebugMeta.buildDebugMeta(
+        DebugMeta().apply {
+          images =
+            listOf(
+              DebugImage().apply {
+                type = "elf"
+                debugId = "native-id"
+              }
+            )
+        },
+        options,
+      )
+
+    assertNotNull(debugMeta) {
+      assertNotNull(it.images) { images ->
+        assertEquals(3, images.size)
+        assertEquals("elf", images[0].type)
+        assertEquals("native-id", images[0].debugId)
+        assertEquals(DebugImage.PROGUARD, images[1].type)
+        assertEquals("proguard-id", images[1].uuid)
+        assertEquals(DebugImage.JVM, images[2].type)
+        assertEquals("bundle-id", images[2].debugId)
+      }
+    }
+  }
+
+  @Test
   fun `when event has debug meta and bundle ids are set, attaches debug information`() {
     val options = SentryOptions().apply { bundleIds.addAll(listOf("id1", "id2")) }
     val debugMeta = DebugMeta.buildDebugMeta(DebugMeta(), options)
@@ -83,6 +175,34 @@ class DebugMetaTest {
         assertEquals("jvm", images[0].type)
         assertEquals("id2", images[1].debugId)
         assertEquals("jvm", images[1].type)
+      }
+    }
+  }
+
+  @Test
+  fun `when debug meta already has jvm image, only attaches missing bundle ids`() {
+    val options = SentryOptions().apply { bundleIds.addAll(listOf("id1", "id2")) }
+    val debugMeta =
+      DebugMeta.buildDebugMeta(
+        DebugMeta().apply {
+          images =
+            listOf(
+              DebugImage().apply {
+                type = DebugImage.JVM
+                debugId = "id1"
+              }
+            )
+        },
+        options,
+      )
+
+    assertNotNull(debugMeta) {
+      assertNotNull(it.images) { images ->
+        assertEquals(2, images.size)
+        assertEquals("id1", images[0].debugId)
+        assertEquals(DebugImage.JVM, images[0].type)
+        assertEquals("id2", images[1].debugId)
+        assertEquals(DebugImage.JVM, images[1].type)
       }
     }
   }


### PR DESCRIPTION
## :scroll: Description

Prior to this PR, we'd always (rightly) bind originating process Proguard IDs to ANR events, but we'd (wrongly) bind current Proguard ID to ANR profile chunks. Usually the originating Proguard ID == the current Proguard ID, and so the discrepancy didn't matter. But the two differ in the situation when a user updates the host app after the ANR occurs but before it's reported. When that happens, deobfuscation for ANR profile chunks in the Sentry UI can break.

This PR ensures both the ANR event and the ANR profile chunk receive the same originating Proguard ID by: 

1. having the entity that determines the originating Proguard ID (ApplicationExitInfoEventProcessor) pass that ID to the profile chunk pipeline; and
2. updating our DebugMeta.buildDebugMeta(ProfileChunk, ...) method so that the profile chunk pipeline honors (rather than clobbers) the Proguard ID the event processor bakes into the DebugMeta owned by the incoming profile chunk.


## :bulb: Motivation and Context

_(Sorry for the wall of text ahead, but it's worth a quick read! Yours truly wrote it to make sure my LLM's approach was sane, so it should be easy to follow. It lays out the problem in detail and our possible options – including closing this PR and living with the edge case.)_

### Background

We report ANRs from app processs launched _after_ each ANR occurs. Usually the same app installation is used with both processes and so the Proguard ID used to deobfuscate stack traces is the same for each. But not always! A user could have installed a new version of the app in between, so we need to make sure we grab the Proguard ID associated with the original process. 

Nicely, logic to do that already exists in ApplicationExitInfoEventProcessor ([link](https://github.com/getsentry/sentry-java/blob/a30048b0fc30280201fdba44a7ab4a91ad98c80a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoEventProcessor.java#L584)). Not so nicely, the Proguard ID produced by that logic isn't used by the profile chunk we associate with the ANR event – or at least it wasn't prior to this PR. (The profile chunk would always use the Proguard ID for the current process.)

The upshot is that app owners would see properly deobfuscated stack traces for the ANR event but possibly broken / still-obfuscated stack traces for the profile chunk in the rare case that someone installs a new version of the host app before the ANR can be reported out.

### So what's going on?

ANRs are composites of two separate entities: an ANR event proper and an ANR profile chunk. That distinction goes all the way down, as the Sentry UI displays ANR events and profile chunks in different dashboards. Each entity owns a DebugMeta instance, which is the data structure used to associate a Proguard ID with the entity it belongs to. 

In the SDK, the ApplicationExitInfoEventProcessor owns the pipeline for constructing both the ANR event and its profile chunk. It goes like this:

0. User launches the app after an ANR was recorded.
1. ApplicationExitInfoEventProcessor recreates the ANR event proper + creates DebugMeta for the event with the Proguard ID from the originating process.
2. ApplicationExitInfoEventProcessor recreates the profile chunk associated with the ANR and then passes it on to SentryClient.captureProfileChunk(). 
3. SentryClient creates DebugMeta for the chunk with the Proguard ID from the current process (which is usually fine but is wrong in our edge case). SentryClient then sends the profile chunk to Relay.
5. ApplicationExitInfoEventProcessor binds the profile chunk ID to the ANR event and then sends the ANR event to Relay.

Step (2) receives the DebugMeta instance with the correct Proguard ID from ApplicationExitInfoEventProcessor. But our profile chunk processing ignores it and instead selects the Proguard ID from the current process. That’s because ApplicationExitInfoEventProcessor delegates to the existing profile chunk pipeline used for non-ANR profiles, and non-ANR profiles are always concerned with the current app process. (Note that the profile chunk pipeline is shared by the Java. Ideally that’d mean it’s Android-agnostic, but that isn’t quite the case atm, eg, it knows about Proguard IDs.)

### What should we do?

Possible approaches:

**[A]** Introduce the concept of “originating process" into our profile chunk pipeline.

**[B]** Update the profile chunk API to accept a pre-selected Proguard ID (whether directly as a string param, via a Context/Hint-esque parameter, or by lookup).

**[C]** Include the originating Proguard ID inside the chunk already passed to our profile chunk pipeline by ApplicationExitInfoEventProcessor + update DebugMeta.builder(incomingAnrDebugMeta, …) so that it honors that ID rather than clobbering it.

**[D]** Do nothing / close this PR and live with the edge case of potentially (but not inevitably) broken or misleading ANR profile chunk stack traces.

### The path I chose

This PR implements [C]. 

Approach [A] sounded best in the abstract, but it’d be a big lift as a number of the inputs ApplicationExitInfoEventProcessor relies on to decide which Proguard ID to use are either Android-specific or aren’t currently available to our profile chunk pipeline. Option [B] was a more explicit version of [C] but at the cost of modifying the public API in ways that are, at best, debatable. 

Option [D] is legit, esp if you look at this PR and think the fix is more of a maintenance burden than it’s worth. (Chime in if you do!)


Addresses: [JAVA-549](https://linear.app/getsentry/issue/JAVA-549/deobfuscate-anr-profile-stack-frames)

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
