### PR TITLE
build: Replace Gradle APIs removed in Gradle 10

### DIFF
--- a/build-logic/src/main/kotlin/io.sentry.javadoc.aggregate.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.javadoc.aggregate.gradle.kts
@@ -1,11 +1,9 @@
 import io.sentry.gradle.AggregateJavadoc
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
-import org.gradle.kotlin.dsl.creating
-import org.gradle.kotlin.dsl.getValue
 import org.gradle.kotlin.dsl.named
 
-val javadocPublisher by configurations.creating {
+val javadocPublisher = configurations.create("javadocPublisher") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -15,7 +13,7 @@ val javadocPublisher by configurations.creating {
 }
 
 subprojects {
-    javadocPublisher.dependencies.add(dependencies.create(this))
+    javadocPublisher.dependencies.add(rootProject.dependencies.project(path))
 }
 
 val javadocCollection = javadocPublisher.incoming.artifactView { lenient(true) }.files

--- a/build-logic/src/main/kotlin/io.sentry.javadoc.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.javadoc.gradle.kts
@@ -1,4 +1,4 @@
-val javadocConfig: Configuration by configurations.creating {
+val javadocConfig: Configuration = configurations.create("javadocConfig") {
     isCanBeResolved = false
     isCanBeConsumed = true
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ apiValidation {
 
 allprojects {
     group = Config.Sentry.group
-    version = properties[Config.Sentry.versionNameProp].toString()
+    version = providers.gradleProperty(Config.Sentry.versionNameProp).get()
     description = Config.Sentry.description
     tasks {
         withType<Test>().configureEach {

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -7,10 +7,13 @@ private object Consts {
     val taskRegex = Regex("(.*)DistZip")
 }
 
+private fun Project.versionName(): String =
+    providers.gradleProperty("versionName").get()
+
 // configure distZip tasks for multiplatform
 fun DistributionContainer.configureForMultiplatform(project: Project) {
     val sep = File.separator
-    val version = project.properties["versionName"].toString()
+    val version = project.versionName()
     val name = project.name
 
     this.maybeCreate("android").contents {
@@ -69,7 +72,7 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
 
 fun DistributionContainer.configureForJvm(project: Project) {
     val sep = File.separator
-    val version = project.properties["versionName"].toString()
+    val version = project.versionName()
     val name = project.name
 
     this.getByName("main").contents {

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -44,13 +44,13 @@ kotlin {
   }
 
   sourceSets {
-    val commonMain by getting {
+    getByName("commonMain") {
       compilerOptions {
         apiVersion.set(KotlinVersion.KOTLIN_1_9)
         languageVersion.set(KotlinVersion.KOTLIN_1_9)
       }
     }
-    val androidMain by getting {
+    getByName("androidMain") {
       dependencies {
         api(projects.sentry)
         api(projects.sentryAndroidNavigation)
@@ -60,7 +60,7 @@ kotlin {
         implementation(libs.androidx.lifecycle.common.java8)
       }
     }
-    val androidUnitTest by getting {
+    getByName("androidUnitTest") {
       dependencies {
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.navigation.compose)


### PR DESCRIPTION
## :scroll: Description

This PR removes build warnings from deprecations used in our build. Behavior should be the same and we'll save our LLM tokens on every build!

| Deprecated API | Replacement | Files |
|---|---|---|
| `Project.getProperties` (fails in Gradle 10) | `providers.gradleProperty(...)` | `build.gradle.kts`, `buildSrc/.../Publication.kt` (2 sites) |
| `Project` object as dependency notation (fails in Gradle 10) | `dependencies.project(path)` | `io.sentry.javadoc.aggregate.gradle.kts` |
| `val x by creating` configuration delegate (removed in Gradle 10) | `configurations.create("...")` | `io.sentry.javadoc.aggregate.gradle.kts`, `io.sentry.javadoc.gradle.kts` |
| `val x by getting` source set delegate (removed in Gradle 10) | `sourceSets.getByName("...")` | `sentry-compose/build.gradle.kts` (3 sites) |

No behavior change — this is a mechanical API swap.

## :bulb: Motivation and Context

Gets us ahead of Gradle 10, where these stop being warnings and start breaking the build. Doing it now keeps the eventual Gradle 10 bump small.

## :green_heart: How did you test it?

CI passes

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

rest of the warnings!
