### PR TITLE
perf(android): Move start-reason binder off main thread (JAVA-616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ### Performance
 
+- Defer the API 35+ `getHistoricalProcessStartReasons` binder call to a background thread so it no longer blocks the main thread during app start ([#5866](https://github.com/getsentry/sentry-java/pull/5866))
 - Create the outbox and cache directories lazily in their consumers instead of during SDK init, moving the `mkdirs()` calls off the init (main) thread ([#5792](https://github.com/getsentry/sentry-java/pull/5792))
 - Reduce the number of SDK threads: `LifecycleWatcher` now schedules the session-end task on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5819](https://github.com/getsentry/sentry-java/pull/5819))
 - Reduce the number of SDK threads: `RateLimiter` now schedules its rate-limit-lifted notifications on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5814](https://github.com/getsentry/sentry-java/pull/5814))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -1,5 +1,6 @@
 package io.sentry.android.core.performance;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.Application;
@@ -35,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,6 +72,13 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
 
   private @NotNull AppStartType appStartType = AppStartType.UNKNOWN;
   private @Nullable volatile Boolean appLaunchedInForeground;
+  // True/false once the deferred ApplicationStartInfo start reason says whether the OS spawned this
+  // process for a user interaction; null while unresolved or when the reason is inconclusive.
+  // Written from the lookup thread, read from the main thread.
+  private @Nullable volatile Boolean startReasonForeground;
+  // Set once an Activity or the headless check has observed the actual launch. Those signals beat
+  // the start reason, so it stops being consulted from then on.
+  private volatile boolean appLaunchedInForegroundObserved;
   private volatile long firstIdle = -1;
 
   private final @NotNull TimeSpan appStartSpan;
@@ -92,7 +101,17 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   private @Nullable String appStartSentryTraceHeader;
   private @Nullable String appStartBaggageHeader;
   private @Nullable SentryDate appStartEndTime;
-  private @Nullable ApplicationStartInfo cachedStartInfo;
+  // Volatile: written from the background lookup thread, read from the main thread. Null until the
+  // deferred getHistoricalProcessStartReasons lookup resolves.
+  private volatile @Nullable ApplicationStartInfo cachedStartInfo;
+  // Runs the getHistoricalProcessStartReasons binder call off the main thread. The Sentry executor
+  // does not exist this early (ContentProvider time), so a plain daemon thread is used by default.
+  private @NotNull Executor startInfoExecutor =
+      command -> {
+        final Thread thread = new Thread(command, "SentryAppStartInfo");
+        thread.setDaemon(true);
+        thread.start();
+      };
   private final @NotNull AppStartExtension appStartExtension = new AppStartExtension(this);
 
   public static @NotNull AppStartMetrics getInstance() {
@@ -231,12 +250,23 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   }
 
   public boolean isAppLaunchedInForeground() {
+    // The start reason is a more reliable signal than the process-importance fallback below, so it
+    // wins whenever the deferred lookup has resolved it and no Activity/headless signal has
+    // observed the launch first. Resolved at read time because the lookup completes asynchronously
+    // and may land either side of the fallback.
+    if (!appLaunchedInForegroundObserved) {
+      final @Nullable Boolean startReason = startReasonForeground;
+      if (startReason != null) {
+        return startReason;
+      }
+    }
     return Boolean.TRUE.equals(appLaunchedInForeground);
   }
 
   @VisibleForTesting
   public void setAppLaunchedInForeground(final boolean appLaunchedInForeground) {
     this.appLaunchedInForeground = appLaunchedInForeground;
+    this.appLaunchedInForegroundObserved = true;
   }
 
   public void setHeadlessAppStartListener(final @Nullable HeadlessAppStartListener listener) {
@@ -404,6 +434,8 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     appStartContinuousProfiler = null;
     appStartSamplingDecision = null;
     appLaunchedInForeground = null;
+    startReasonForeground = null;
+    appLaunchedInForegroundObserved = false;
     isCallbackRegistered = false;
     shouldSendStartMeasurements = true;
     firstDrawDone.set(false);
@@ -502,46 +534,72 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     }
     isCallbackRegistered = true;
     appLaunchedInForeground = null;
+    startReasonForeground = null;
+    appLaunchedInForegroundObserved = false;
     application.registerActivityLifecycleCallbacks(instance);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
       final @Nullable ActivityManager activityManager =
           (ActivityManager) application.getSystemService(Context.ACTIVITY_SERVICE);
       if (activityManager != null) {
-        try {
-          final List<ApplicationStartInfo> historicalProcessStartReasons =
-              activityManager.getHistoricalProcessStartReasons(1);
-          if (!historicalProcessStartReasons.isEmpty()) {
-            final @NotNull ApplicationStartInfo info = historicalProcessStartReasons.get(0);
-            cachedStartInfo = info;
-            if (info.getStartupState() == ApplicationStartInfo.STARTUP_STATE_STARTED) {
-              if (info.getStartType() == ApplicationStartInfo.START_TYPE_COLD) {
-                appStartType = AppStartType.COLD;
-              } else {
-                appStartType = AppStartType.WARM;
-              }
-              appLaunchedInForeground = isForegroundStartReason(info.getReason());
-            }
-          }
-        } catch (RuntimeException ignored) {
-          // getHistoricalProcessStartReasons may throw different kinds of exceptions, namely:
-          // - SecurityException when called from an isolated process
-          // - IllegalArgumentException when called with a wrong userId
-          // - others
-          // See impl:
-          // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/services/core/java/com/android/server/am/ActivityManagerService.java;l=10866-10893
-          Log.w("AppStartMetrics", ignored); // no logger instance here, so we just Log
-        }
+        // getHistoricalProcessStartReasons blocks on a system_server binder round-trip. Run it off
+        // the main thread so it doesn't stall the coldest part of app start. The result is consumed
+        // best-effort: appStartType (see onActivityCreated) falls back to the pre-API-35 heuristic
+        // and getAppStartReason returns null if the lookup hasn't resolved yet.
+        startInfoExecutor.execute(() -> loadStartInfo(activityManager));
       }
     }
-    // Fallback, if no matching ApplicationStartInfo is available
+    // Fallback, if no start reason is available. isAppLaunchedInForeground prefers the deferred
+    // start reason over this once its lookup resolves.
     if (appLaunchedInForeground == null) {
       appLaunchedInForeground = ContextUtils.isForegroundImportance();
     }
 
-    if (appStartType == AppStartType.UNKNOWN || headlessAppStartListener != null) {
-      scheduleHeadlessAppStartCheckOnMain();
+    scheduleHeadlessAppStartCheckOnMain();
+  }
+
+  @SuppressLint("NewApi") // reached only from the API 35+ guarded branch above
+  private void loadStartInfo(final @NotNull ActivityManager activityManager) {
+    try {
+      final List<ApplicationStartInfo> historicalProcessStartReasons =
+          activityManager.getHistoricalProcessStartReasons(1);
+      if (!historicalProcessStartReasons.isEmpty()) {
+        final @NotNull ApplicationStartInfo info = historicalProcessStartReasons.get(0);
+        cachedStartInfo = info;
+        startReasonForeground = isForegroundStartReason(info.getReason());
+      }
+    } catch (RuntimeException ignored) {
+      // getHistoricalProcessStartReasons may throw different kinds of exceptions, namely:
+      // - SecurityException when called from an isolated process
+      // - IllegalArgumentException when called with a wrong userId
+      // - others
+      // See impl:
+      // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/services/core/java/com/android/server/am/ActivityManagerService.java;l=10866-10893
+      Log.w("AppStartMetrics", ignored); // no logger instance here, so we just Log
     }
+  }
+
+  /**
+   * Maps the deferred {@link ApplicationStartInfo} to an app start type. Returns {@link
+   * AppStartType#UNKNOWN} when the lookup hasn't resolved yet or the OS hadn't finished the start,
+   * so callers fall back to the pre-API-35 heuristic.
+   */
+  private @NotNull AppStartType getStartInfoAppStartType() {
+    final @Nullable ApplicationStartInfo info = cachedStartInfo;
+    if (info == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      return AppStartType.UNKNOWN;
+    }
+    if (info.getStartupState() != ApplicationStartInfo.STARTUP_STATE_STARTED) {
+      return AppStartType.UNKNOWN;
+    }
+    return info.getStartType() == ApplicationStartInfo.START_TYPE_COLD
+        ? AppStartType.COLD
+        : AppStartType.WARM;
+  }
+
+  @TestOnly
+  void setStartInfoExecutor(final @NotNull Executor startInfoExecutor) {
+    this.startInfoExecutor = startInfoExecutor;
   }
 
   private void scheduleHeadlessAppStartCheckOnMain() {
@@ -587,11 +645,14 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       }
 
       appLaunchedInForeground = false;
+      appLaunchedInForegroundObserved = true;
 
-      // Headless starts have no Activity signal for the pre-API 35 warm/cold heuristic.
-      // If ApplicationStartInfo did not resolve the type, classify the process start as cold.
+      // Headless starts have no Activity signal for the pre-API 35 warm/cold heuristic. Prefer the
+      // deferred ApplicationStartInfo type if its lookup has resolved, otherwise classify the
+      // process start as cold.
       if (appStartType == AppStartType.UNKNOWN) {
-        appStartType = AppStartType.COLD;
+        final @NotNull AppStartType startInfoType = getStartInfoAppStartType();
+        appStartType = startInfoType != AppStartType.UNKNOWN ? startInfoType : AppStartType.COLD;
       }
 
       // we stop the app start profilers, as they are useless and likely to timeout
@@ -683,8 +744,12 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
         contentProviderOnCreates.clear();
         applicationOnCreate.reset();
       } else if (appStartType == AppStartType.UNKNOWN) {
-        // pre API 35 handling
-        if (savedInstanceState != null) {
+        // Prefer the authoritative API 35+ ApplicationStartInfo if its deferred lookup has
+        // resolved, otherwise fall back to the pre-API-35 heuristic.
+        final @NotNull AppStartType startInfoType = getStartInfoAppStartType();
+        if (startInfoType != AppStartType.UNKNOWN) {
+          appStartType = startInfoType;
+        } else if (savedInstanceState != null) {
           appStartType = AppStartType.WARM;
         } else if (firstIdle != -1 && activityCreatedUptimeMillis > firstIdle) {
           appStartType = AppStartType.WARM;
@@ -694,6 +759,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       }
     }
     appLaunchedInForeground = true;
+    appLaunchedInForegroundObserved = true;
   }
 
   @Override
@@ -740,6 +806,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     if (remainingActivities == 0 && !activity.isChangingConfigurations()) {
       appStartType = AppStartType.WARM;
       appLaunchedInForeground = true;
+      appLaunchedInForegroundObserved = true;
       shouldSendStartMeasurements = true;
       firstDrawDone.set(false);
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTestApi35.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTestApi35.kt
@@ -40,6 +40,9 @@ class AppStartMetricsTestApi35 {
     SentryShadowActivityManager.reset()
     AppStartMetrics.getInstance().setClassLoadedUptimeMs(42)
     AppStartMetrics.getInstance().isAppLaunchedInForeground = true
+    // Resolve the deferred getHistoricalProcessStartReasons lookup synchronously so tests can
+    // observe cachedStartInfo right after registerLifecycleCallbacks.
+    AppStartMetrics.getInstance().setStartInfoExecutor { it.run() }
   }
 
   @Test
@@ -47,28 +50,34 @@ class AppStartMetricsTestApi35 {
     val mockStartInfo = mock<ApplicationStartInfo>()
     whenever(mockStartInfo.startupState).thenReturn(ApplicationStartInfo.STARTUP_STATE_STARTED)
     whenever(mockStartInfo.startType).thenReturn(ApplicationStartInfo.START_TYPE_COLD)
+    whenever(mockStartInfo.reason).thenReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
     SentryShadowActivityManager.setHistoricalProcessStartReasons(listOf(mockStartInfo))
 
     val app = ApplicationProvider.getApplicationContext<Application>()
-    AppStartMetrics.getInstance().registerLifecycleCallbacks(app)
+    val metrics = AppStartMetrics.getInstance()
+    metrics.registerLifecycleCallbacks(app)
+    metrics.onActivityCreated(mock(), null)
 
-    assertEquals(AppStartMetrics.AppStartType.COLD, AppStartMetrics.getInstance().appStartType)
+    assertEquals(AppStartMetrics.AppStartType.COLD, metrics.appStartType)
   }
 
   @Test
-  fun `known ApplicationStartInfo type without listener does not schedule headless check`() {
+  fun `foreground launch with known start type is not treated as headless`() {
     val mockStartInfo = mock<ApplicationStartInfo>()
     whenever(mockStartInfo.startupState).thenReturn(ApplicationStartInfo.STARTUP_STATE_STARTED)
     whenever(mockStartInfo.startType).thenReturn(ApplicationStartInfo.START_TYPE_COLD)
+    whenever(mockStartInfo.reason).thenReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
     SentryShadowActivityManager.setHistoricalProcessStartReasons(listOf(mockStartInfo))
     val metrics = AppStartMetrics.getInstance()
 
     val app = ApplicationProvider.getApplicationContext<Application>()
     metrics.registerLifecycleCallbacks(app)
+    metrics.onActivityCreated(mock(), null)
+    // The headless idle check is always scheduled now; a created activity must keep it a no-op.
     waitForMainLooperIdle()
 
     assertEquals(AppStartMetrics.AppStartType.COLD, metrics.appStartType)
-    assertEquals(-1, metrics.firstIdle)
+    assertTrue(metrics.isAppLaunchedInForeground)
   }
 
   @Test
@@ -76,39 +85,48 @@ class AppStartMetricsTestApi35 {
     val mockStartInfo = mock<ApplicationStartInfo>()
     whenever(mockStartInfo.startupState).thenReturn(ApplicationStartInfo.STARTUP_STATE_STARTED)
     whenever(mockStartInfo.startType).thenReturn(ApplicationStartInfo.START_TYPE_WARM)
+    whenever(mockStartInfo.reason).thenReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
     SentryShadowActivityManager.setHistoricalProcessStartReasons(listOf(mockStartInfo))
 
     val app = ApplicationProvider.getApplicationContext<Application>()
-    AppStartMetrics.getInstance().registerLifecycleCallbacks(app)
+    val metrics = AppStartMetrics.getInstance()
+    metrics.registerLifecycleCallbacks(app)
+    metrics.onActivityCreated(mock(), null)
 
-    assertEquals(AppStartMetrics.AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
+    assertEquals(AppStartMetrics.AppStartType.WARM, metrics.appStartType)
   }
 
   @Test
-  fun `does not set app start type when ApplicationStartInfo list is invalid`() {
+  fun `ignores ApplicationStartInfo when startup state is not started`() {
     val mockStartInfo = mock<ApplicationStartInfo>()
     whenever(mockStartInfo.startupState)
       .thenReturn(ApplicationStartInfo.STARTUP_STATE_FIRST_FRAME_DRAWN)
     whenever(mockStartInfo.startType).thenReturn(ApplicationStartInfo.START_TYPE_WARM)
+    whenever(mockStartInfo.reason).thenReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
     SentryShadowActivityManager.setHistoricalProcessStartReasons(listOf(mockStartInfo))
 
     val metrics = AppStartMetrics.getInstance()
 
     val app = ApplicationProvider.getApplicationContext<Application>()
     metrics.registerLifecycleCallbacks(app)
-
     assertEquals(AppStartMetrics.AppStartType.UNKNOWN, metrics.appStartType)
+
+    // Not STARTED, so the start type is ignored and the heuristic classifies the foreground launch.
+    metrics.onActivityCreated(mock(), null)
+    assertEquals(AppStartMetrics.AppStartType.COLD, metrics.appStartType)
   }
 
   @Test
-  fun `does not set app start type when ApplicationStartInfo list is empty`() {
+  fun `falls back to heuristic when ApplicationStartInfo list is empty`() {
     SentryShadowActivityManager.setHistoricalProcessStartReasons(emptyList())
     val metrics = AppStartMetrics.getInstance()
 
     val app = ApplicationProvider.getApplicationContext<Application>()
     metrics.registerLifecycleCallbacks(app)
-
     assertEquals(AppStartMetrics.AppStartType.UNKNOWN, metrics.appStartType)
+
+    metrics.onActivityCreated(mock(), null)
+    assertEquals(AppStartMetrics.AppStartType.COLD, metrics.appStartType)
   }
 
   @Test
@@ -362,7 +380,8 @@ class AppStartMetricsTestApi35 {
     metrics.registerLifecycleCallbacks(app)
 
     assertFalse(metrics.isAppLaunchedInForeground)
-    assertEquals(AppStartMetrics.AppStartType.COLD, metrics.appStartType)
+    // The start type stays UNKNOWN until a consumer resolves it from the deferred start info.
+    assertEquals(AppStartMetrics.AppStartType.UNKNOWN, metrics.appStartType)
 
     // User opens the app 20s later (under the 1-minute warm threshold).
     val activityCreatedUptimeMs = 20_000L


### PR DESCRIPTION
## 📜 Description

On API 35+, `AppStartMetrics.registerLifecycleCallbacks` performed an `ActivityManager.getHistoricalProcessStartReasons(1)` binder call **synchronously on the main thread**. Under auto-init this runs at `ContentProvider` time (`SentryPerformanceProvider.onAppLaunched`), blocking the main thread on a `system_server` round-trip during the coldest part of app start.

This moves the lookup onto a short-lived background daemon thread. The Sentry executor doesn't exist this early (ContentProvider time), so a plain thread is used. `cachedStartInfo` is now `volatile` and consumed best-effort:

* Cold/warm classification moves into `onActivityCreated`: it prefers the resolved `ApplicationStartInfo` and falls back to the existing pre-API-35 heuristic if the lookup hasn't resolved yet.
* The headless-start path consults the resolved start info before defaulting to `COLD`.
* `getAppStartReason()` returns `null` if the lookup hasn't resolved by the time it is read.

No public API change (`apiDump` clean).

## 💡 Motivation and Context

getsentry/sentry-java#5702. Fixes getsentry/sentry-java#5702.

The binder call stalled the main thread at the most latency-sensitive moment of startup. Measured on a Pixel 10 (API 36) across cold starts, the synchronous call cost **\~0.5–2.2 ms of main-thread time** (median \~0.7 ms, mean \~0.9 ms). Deferring it reclaims that time from the main thread.

## 💚 How did you test it?

* `AppStartMetricsTestApi35` unit tests updated to inject a synchronous executor and drive `onActivityCreated`; all pass.
* On-device (Pixel 10, API 36, cold starts via force-stop → launch): **before** ≈ 0.5–2.2 ms on the main thread (median \~0.7 ms); **after**, the same work runs on the background thread and `cachedStartInfo` was ready before the first activity in every observed cold start — even with the sample's artificial start-padding removed — so cold/warm and `app.start.reason` are preserved in practice.

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps

* Consider a follow-up to reuse a shared background executor once one is available that early, instead of a one-off thread.