### PR TITLE
perf(android): Parse app start profiling config without JsonSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Performance
 
 - Remove an unused lock from `SentryPerformanceProvider`, which was allocated on every cold start in `ContentProvider.onCreate` without ever being acquired ([#5871](https://github.com/getsentry/sentry-java/pull/5871))
+- Parse the app start profiling config with only the deserializer it needs instead of building a full `JsonSerializer` and `SentryOptions`, cutting 188 of 221 allocations on the main thread before `Application.onCreate` ([#5867](https://github.com/getsentry/sentry-java/pull/5867))
 
 ## 8.51.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -13,7 +13,7 @@ import io.sentry.IContinuousProfiler;
 import io.sentry.ILogger;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransactionProfiler;
-import io.sentry.JsonSerializer;
+import io.sentry.JsonObjectReader;
 import io.sentry.SentryAppStartProfilingOptions;
 import io.sentry.SentryExecutorService;
 import io.sentry.SentryLevel;
@@ -117,8 +117,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
     try (final @NotNull Reader reader =
             new BufferedReader(new InputStreamReader(new FileInputStream(configFile)))) {
       final @Nullable SentryAppStartProfilingOptions profilingOptions =
-          new JsonSerializer(SentryOptions.empty())
-              .deserialize(reader, SentryAppStartProfilingOptions.class);
+          deserializeProfilingConfig(reader);
 
       if (profilingOptions == null) {
         logger.log(
@@ -163,6 +162,25 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
       logger.log(SentryLevel.ERROR, "App start profiling config file not found. ", e);
     } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error reading app start profiling config file. ", e);
+    }
+  }
+
+  /**
+   * Parses the app start profiling config with only the deserializer it needs. Going through {@link
+   * io.sentry.JsonSerializer} would allocate a full {@link SentryOptions} plus every registered
+   * deserializer on the main thread before {@code Application.onCreate}, to use exactly one of
+   * them.
+   *
+   * <p>Returns null on malformed input, matching what {@code JsonSerializer.deserialize} did, so
+   * callers keep reporting it as a deserialization failure rather than a read error.
+   */
+  private @Nullable SentryAppStartProfilingOptions deserializeProfilingConfig(
+      final @NotNull Reader reader) {
+    try (final @NotNull JsonObjectReader jsonReader = new JsonObjectReader(reader)) {
+      return new SentryAppStartProfilingOptions.Deserializer().deserialize(jsonReader, logger);
+    } catch (Throwable e) {
+      logger.log(SentryLevel.ERROR, "Error when deserializing", e);
+      return null;
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -172,11 +172,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
    * them.
    *
    * <p>Returns null on malformed input, matching what {@code JsonSerializer.deserialize} did, so
-   * callers keep reporting it as a deserialization failure rather than a read error. The vendored
-   * JSON reader signals bad input with {@link java.io.IOException} (including {@code
-   * MalformedJsonException} and {@code EOFException}), {@link IllegalStateException} on a token
-   * type mismatch, and {@link NumberFormatException} on an unparseable number — all {@link
-   * Exception} subclasses, so {@code Error} propagates instead of being swallowed here.
+   * callers keep reporting it as a deserialization failure rather than a read error.
    */
   private @Nullable SentryAppStartProfilingOptions deserializeProfilingConfig(
       final @NotNull Reader reader) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -172,13 +172,17 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
    * them.
    *
    * <p>Returns null on malformed input, matching what {@code JsonSerializer.deserialize} did, so
-   * callers keep reporting it as a deserialization failure rather than a read error.
+   * callers keep reporting it as a deserialization failure rather than a read error. The vendored
+   * JSON reader signals bad input with {@link java.io.IOException} (including {@code
+   * MalformedJsonException} and {@code EOFException}), {@link IllegalStateException} on a token
+   * type mismatch, and {@link NumberFormatException} on an unparseable number — all {@link
+   * Exception} subclasses, so {@code Error} propagates instead of being swallowed here.
    */
   private @Nullable SentryAppStartProfilingOptions deserializeProfilingConfig(
       final @NotNull Reader reader) {
     try (final @NotNull JsonObjectReader jsonReader = new JsonObjectReader(reader)) {
       return new SentryAppStartProfilingOptions.Deserializer().deserialize(jsonReader, logger);
-    } catch (Throwable e) {
+    } catch (Exception e) {
       logger.log(SentryLevel.ERROR, "Error when deserializing", e);
       return null;
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -154,6 +154,21 @@ class SentryPerformanceProviderTest {
   }
 
   @Test
+  fun `when config file is malformed, profiler is not started`() {
+    fixture.getSut { config -> config.writeText("{\"profile_sampled\": tru") }
+    assertNull(AppStartMetrics.getInstance().appStartProfiler)
+    assertNull(AppStartMetrics.getInstance().appStartContinuousProfiler)
+    verify(fixture.logger).log(eq(SentryLevel.ERROR), eq("Error when deserializing"), any())
+    verify(fixture.logger)
+      .log(
+        eq(SentryLevel.WARNING),
+        eq(
+          "Unable to deserialize the SentryAppStartProfilingOptions. App start profiling will not start."
+        ),
+      )
+  }
+
+  @Test
   fun `when profiling is disabled, profiler is not started`() {
     fixture.getSut { config ->
       writeConfig(config, profilingEnabled = false, continuousProfilingEnabled = false)


### PR DESCRIPTION
## 📜 Description

`JsonSerializer` is a massive object with 60 serializers but we only need one of them in `SentryPerformanceProvider`. We can't re-use the one held in `SentryOptions` because the `SentryPerformanceProvider` content provider has a higher priority than the `SentryInitProvider`.  <br>So instead we create a serializer with only the serializer we need for this specific purpose.

Measured on a Pixel 10 (API 37) with androidx Microbenchmark, release build:

<!-- linear:table-colwidths:266,266,266 -->
|  | allocations | time (median) |
| -- | -- | -- |
| via `JsonSerializer` (before) | 221 | 7548 ns |
| direct `Deserializer` (after) | **33** | **3687 ns** |

`allocationCount` is deterministic, so the allocation figures are exact. The timings are steady-state (JIT-warmed, clocks unlocked), so they understate the real cold-start saving — warmup amortizes away the class loading and verification of all those deserializer classes, which the real one-shot path pays in full. No claim is made about measurable end-to-end startup improvement; \~3.9 µs is small against a \~1 s cold start. The point is main-thread work removed from before `Application.onCreate`.

## 💡 Motivation and Context

Perf improvement

Related: getsentry/sentry-java#5708 and getsentry/sentry-java#5709 were previously closed for the same "small allocation win, not worth the trade off" reason.

GH Issue: getsentry/sentry-java#5707  <br>Linear: getsentry/sentry-java#5707

## 💚 How did you test it?

Unit tests

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps

`createAndStartContinuousProfiler` also calls `SentryOptions.empty()`, for `TracesSampler`. That one genuinely needs a mutable options object (`setProfileSessionSampleRate`) and only runs when a sampled continuous-profiling config exists, so it is deliberately left alone.