### PR TITLE
ref(android): Remove unused lock from SentryPerformanceProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Remove an unused lock from `SentryPerformanceProvider`, which was allocated on every cold start in `ContentProvider.onCreate` without ever being acquired ([#5871](https://github.com/getsentry/sentry-java/pull/5871))
+
 ## 8.51.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -23,7 +23,6 @@ import io.sentry.TracesSamplingDecision;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
-import io.sentry.util.AutoClosableReentrantLock;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -46,7 +45,6 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
 
   private final @NotNull ILogger logger;
   private final @NotNull BuildInfoProvider buildInfoProvider;
-  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   @TestOnly
   SentryPerformanceProvider(


### PR DESCRIPTION
## :scroll: Description

Removes the unused `AutoClosableReentrantLock` field from `SentryPerformanceProvider`, and its now-unneeded import.

```java
private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
```

The field was declared but never acquired. History:

- Added in #3715 ("Replace `synchronized` with `ReentrantLock`") to guard `onAppStartDone()`, which was its only user.
- `onAppStartDone()` was removed in #4033 (the `main` → `8.x.x` merge), leaving the lock orphaned.


## :bulb: Motivation and Context

Delete dead code

## :green_heart: How did you test it?

it compiles

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

Notes on the checklist: no new tests were added — this removes dead code with no behavior to test, and the existing suite covers the class. A changelog entry is added under `### Performance`.

## :crystal_ball: Next steps

None.
