### PR TITLE
fix(android): Prevent Relay from rejecting single-sample ANR profiles 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Preserve single-sample ANR profile chunks so profiles remain available on ANR events ([#5872](https://github.com/getsentry/sentry-java/pull/5872))
+
 ### Performance
 
 - Remove an unused lock from `SentryPerformanceProvider`, which was allocated on every cold start in `ContentProvider.onCreate` without ever being acquired ([#5871](https://github.com/getsentry/sentry-java/pull/5871))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/anr/StackTraceConverter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/anr/StackTraceConverter.java
@@ -174,11 +174,8 @@ public final class StackTraceConverter {
    */
   @NotNull
   private static SentrySample createSyntheticSample(@NotNull SentrySample originalSample) {
-    final @NotNull SentrySample syntheticSample = new SentrySample();
+    final @NotNull SentrySample syntheticSample = new SentrySample(originalSample);
     syntheticSample.setTimestamp(originalSample.getTimestamp() + SYNTHETIC_SAMPLE_OFFSET_SECONDS);
-    syntheticSample.setStackId(originalSample.getStackId());
-    syntheticSample.setThreadId(originalSample.getThreadId());
-    syntheticSample.setUnknown(originalSample.getUnknown());
     return syntheticSample;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/anr/StackTraceConverter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/anr/StackTraceConverter.java
@@ -34,6 +34,14 @@ public final class StackTraceConverter {
   private static final String MAIN_THREAD_NAME = "main";
 
   /**
+   * Timestamp offset used with synthetic ANR profile samples. (Currently 33 ms.)
+   *
+   * <p>Places the synthetic sample halfway to the next ANR polling tick.
+   */
+  private static final double SYNTHETIC_SAMPLE_OFFSET_SECONDS =
+      (AnrProfilingIntegration.POLLING_INTERVAL_MS / 2.0d) / 1000.0d;
+
+  /**
    * Converts a list of {@link AnrStackTrace} objects to a {@link SentryProfile}.
    *
    * @param anrProfile The ANR Profile
@@ -78,6 +86,15 @@ public final class StackTraceConverter {
       sample.setThreadId(MAIN_THREAD_ID);
 
       profile.getSamples().add(sample);
+    }
+
+    // Relay will reject ANR profiles with only one sample, even though they're still useful.
+    // (Relay's policy was defined with continuous profiles in mind, before ANR profiles were a
+    // thing.) If we only have one sample, synthesize another that only differs in its timestamp.
+    if (profile.getSamples().size() == 1) {
+      final @NotNull SentrySample originalSample = profile.getSamples().get(0);
+      final @NotNull SentrySample syntheticSample = createSyntheticSample(originalSample);
+      profile.getSamples().add(syntheticSample);
     }
 
     profile.setFrames(frames);
@@ -146,5 +163,22 @@ public final class StackTraceConverter {
       frame.setNative(true);
     }
     return frame;
+  }
+
+  /**
+   * Creates a {@link SentrySample} identical to {@code originalSample}, save that its timestamp is
+   * advanced by {@link #SYNTHETIC_SAMPLE_OFFSET_SECONDS}.
+   *
+   * <p>Lets us produce a plausible synthetic sample without misleading the user about the ANR's
+   * actual duration or cause.
+   */
+  @NotNull
+  private static SentrySample createSyntheticSample(@NotNull SentrySample originalSample) {
+    final @NotNull SentrySample syntheticSample = new SentrySample();
+    syntheticSample.setTimestamp(originalSample.getTimestamp() + SYNTHETIC_SAMPLE_OFFSET_SECONDS);
+    syntheticSample.setStackId(originalSample.getStackId());
+    syntheticSample.setThreadId(originalSample.getThreadId());
+    syntheticSample.setUnknown(originalSample.getUnknown());
+    return syntheticSample;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitInfoEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitInfoEventProcessorTest.kt
@@ -1012,9 +1012,15 @@ class ApplicationExitInfoEventProcessorTest {
       mockedSentry.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(scopes)
 
       val processed = processor.process(SentryEvent(), hint)
+      val chunkCaptor = argumentCaptor<ProfileChunk>()
+      verify(scopes).captureProfileChunk(chunkCaptor.capture())
+      val sentryProfile = chunkCaptor.firstValue.sentryProfile
 
       assertNotNull(processed?.contexts?.profile)
       assertNotNull(processed.contexts.profile?.profilerId)
+      assertNotNull(sentryProfile)
+      // Two samples are present b/c the converter adds a synthetic one to keep Relay happy.
+      assertEquals(2, sentryProfile.samples.size)
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/anr/AnrStackTraceConverterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/anr/AnrStackTraceConverterTest.kt
@@ -19,7 +19,8 @@ class AnrStackTraceConverterTest {
     val profile = StackTraceConverter.convert(AnrProfile(anrStackTraces))
 
     Assert.assertNotNull(profile)
-    Assert.assertEquals(1, profile.samples.size)
+    // Two samples are present b/c the converter adds a synthetic one to keep Relay happy.
+    Assert.assertEquals(2, profile.samples.size)
     Assert.assertEquals(2, profile.frames.size)
     Assert.assertEquals(1, profile.stacks.size)
 
@@ -44,6 +45,60 @@ class AnrStackTraceConverterTest {
     Assert.assertEquals(0, sample.stackId)
     Assert.assertEquals("0", sample.threadId)
     Assert.assertEquals(1.0, sample.timestamp, 0.001) // 1000ms = 1s
+  }
+
+  @Test
+  fun testAddSyntheticSampleIfOnlyOneSamplePresent() {
+    val elements = arrayOf(StackTraceElement("com.example.MyClass", "method1", "MyClass.java", 42))
+
+    val anrStackTraces: MutableList<AnrStackTrace?> = ArrayList()
+    anrStackTraces.add(AnrStackTrace(1000, elements))
+
+    val profile = StackTraceConverter.convert(AnrProfile(anrStackTraces))
+
+    val originalSample = profile.samples[0]
+    val syntheticSample = profile.samples[1]
+    val expectedOffsetSeconds = AnrProfilingIntegration.POLLING_INTERVAL_MS / 2.0 / 1000.0
+
+    Assert.assertEquals(originalSample.stackId, syntheticSample.stackId)
+    Assert.assertEquals(originalSample.threadId, syntheticSample.threadId)
+    Assert.assertEquals(originalSample.unknown, syntheticSample.unknown)
+    Assert.assertEquals(
+      originalSample.timestamp + expectedOffsetSeconds,
+      syntheticSample.timestamp,
+      0.001,
+    )
+
+    Assert.assertTrue(profile.stacks[syntheticSample.stackId].isNotEmpty())
+    Assert.assertEquals(2, profile.samples.size)
+    Assert.assertEquals(1, profile.stacks.size)
+    Assert.assertEquals(1, profile.frames.size)
+  }
+
+  @Test
+  fun testDoNotAddSyntheticSampleIfMultipleSamplesPresent() {
+    val elements = arrayOf(StackTraceElement("com.example.MyClass", "method1", "MyClass.java", 42))
+
+    val anrStackTraces: MutableList<AnrStackTrace?> = ArrayList()
+    anrStackTraces.add(AnrStackTrace(1000, elements))
+    anrStackTraces.add(AnrStackTrace(2000, elements))
+
+    val profile = StackTraceConverter.convert(AnrProfile(anrStackTraces))
+
+    Assert.assertEquals(2, profile.samples.size)
+    Assert.assertEquals(1.0, profile.samples[0].timestamp, 0.001)
+    Assert.assertEquals(2.0, profile.samples[1].timestamp, 0.001)
+    Assert.assertEquals(1, profile.stacks.size)
+    Assert.assertEquals(1, profile.frames.size)
+  }
+
+  @Test
+  fun testDoNotAddSyntheticSampleIfNoSamplesPresent() {
+    val profile = StackTraceConverter.convert(AnrProfile(ArrayList()))
+
+    Assert.assertEquals(0, profile.samples.size)
+    Assert.assertEquals(0, profile.stacks.size)
+    Assert.assertEquals(0, profile.frames.size)
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/anr/AnrStackTraceConverterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/anr/AnrStackTraceConverterTest.kt
@@ -60,9 +60,6 @@ class AnrStackTraceConverterTest {
     val syntheticSample = profile.samples[1]
     val expectedOffsetSeconds = AnrProfilingIntegration.POLLING_INTERVAL_MS / 2.0 / 1000.0
 
-    Assert.assertEquals(originalSample.stackId, syntheticSample.stackId)
-    Assert.assertEquals(originalSample.threadId, syntheticSample.threadId)
-    Assert.assertEquals(originalSample.unknown, syntheticSample.unknown)
     Assert.assertEquals(
       originalSample.timestamp + expectedOffsetSeconds,
       syntheticSample.timestamp,

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7066,6 +7066,7 @@ public final class io/sentry/protocol/profiling/SentryProfile$JsonKeys {
 
 public final class io/sentry/protocol/profiling/SentrySample : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/protocol/profiling/SentrySample;)V
 	public fun getStackId ()I
 	public fun getThreadId ()Ljava/lang/String;
 	public fun getTimestamp ()D

--- a/sentry/src/main/java/io/sentry/protocol/profiling/SentrySample.java
+++ b/sentry/src/main/java/io/sentry/protocol/profiling/SentrySample.java
@@ -8,6 +8,7 @@ import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
 import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
+import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
 import java.util.HashMap;
@@ -26,6 +27,15 @@ public final class SentrySample implements JsonUnknown, JsonSerializable {
   private @Nullable String threadId;
 
   private @Nullable Map<String, Object> unknown;
+
+  public SentrySample() {}
+
+  public SentrySample(final @NotNull SentrySample sample) {
+    this.timestamp = sample.timestamp;
+    this.stackId = sample.stackId;
+    this.threadId = sample.threadId;
+    this.unknown = CollectionUtils.newConcurrentHashMap(sample.unknown);
+  }
 
   public double getTimestamp() {
     return timestamp;

--- a/sentry/src/test/java/io/sentry/protocol/profiling/SentrySampleTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/profiling/SentrySampleTest.kt
@@ -1,0 +1,30 @@
+package io.sentry.protocol.profiling
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SentrySampleTest {
+
+  @Test
+  fun `copying sample keeps values and copies unknown`() {
+    val unknown = mutableMapOf<String, Any>("key" to "value")
+    val original =
+      SentrySample().apply {
+        timestamp = 1.23
+        stackId = 4
+        threadId = "main"
+        setUnknown(unknown)
+      }
+
+    val copy = SentrySample(original)
+
+    assertThat(copy.timestamp).isEqualTo(original.timestamp)
+    assertThat(copy.stackId).isEqualTo(original.stackId)
+    assertThat(copy.threadId).isEqualTo(original.threadId)
+    assertThat(copy.unknown).containsExactlyEntriesIn(original.unknown)
+    assertThat(copy.unknown).isNotSameInstanceAs(original.unknown)
+
+    unknown["key"] = "changed"
+    assertThat(copy.unknown).containsEntry("key", "value")
+  }
+}


### PR DESCRIPTION
## :scroll: Description

Relay currently rejects ANR profiles with a single sample, even though they're still useful to customers. This PR updates our StackTraceConverter to add a second, synthetic sample whenever an ANR profile would otherwise only contain one.

The synthetic sample duplicates the original, save for a minor offset to its timestamp. (Lets us avoid misleading the user about the ANRs cause or duration.)

## :bulb: Motivation and Context

Customers occasionally see ANR events with no attached profile despite having sufficient quota and ANR profiling enabled. That's because Relay drops any profile chunk with fewer than two samples, and an ANR chunk can have exactly one sample if the main thread is caught on the very first poll after the 1-second suspicion threshold. 

Relay's policy was developed with continuous profiles in mind, where a one-point series has no meaningful time axis. But for ANR profiles a single sample is highly actionable, as it shows exactly where the main thread was stuck when the ANR began.

Resolves: [JAVA-550](https://linear.app/getsentry/issue/JAVA-550/prevent-single-sample-anr-profile-chunks-from-being-silently-dropped)

## Options considered

**[A] Make it more likely that the SDK satisfies Relay's requirements** -> In particular, narrow the polling interval used with ANRs. Would only reduce the risk of single-sample ANRs but not eliminate it + requires more resources from host app.

**[B] Guarantee the SDK satisfies Relay's requirements** -> The approach this PR takes.

**[C] Relax Relay's requirements** ->  Too big of a lift to implement and would require substantial input by the Relay folks.


## :green_heart: How did you test it?

Unit tests + integration test + had my LLM check E2E against Relay and entire backend pipeline.


## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
