### PR TITLE
docs: Remove build command from agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,6 @@ The project uses **Gradle** with Kotlin DSL. Key build files:
 # Run all tests and linter
 ./gradlew check
 
-# Build entire project
-./gradlew build
-
 # Generate documentation
 ./gradlew aggregateJavadocs
 ```


### PR DESCRIPTION
## :scroll: Description

Remove the "Build entire project" command (`./gradlew build`) from the Essential Commands section of `AGENTS.md`.

## :bulb: Motivation and Context

`./gradlew build` is an expensive full-project build that isn't needed as part of the documented agent workflow — `./gradlew check` already covers running tests and the linter. Removing it keeps the agent instructions lean and avoids steering agents toward a slow, unnecessary step.

## :green_heart: How did you test it?

Docs-only change to `AGENTS.md`. Spotless only targets `.java`/`.kt`/`*.gradle.kts`, so no formatting is affected and there is no API change.

## :pencil: Checklist

- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

#skip-changelog
