### PR TITLE
perf(core): Use build-time class availability

### DIFF
--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public class LoadClass {
 
   // Populated by the Sentry Android Gradle plugin for class names it can resolve at build time.
-  private static @Nullable Map<String, Boolean> classAvailability;
+  static @Nullable Map<String, Boolean> classAvailability;
 
   /**
    * Loads and initializes a class via reflection. Use this when you intend to actually use the

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -4,12 +4,16 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** An Adapter for making Class.forName testable */
 @Open
 public class LoadClass {
+
+  // Populated by the Sentry Android Gradle plugin for class names it can resolve at build time.
+  private static @Nullable Map<String, Boolean> classAvailability;
 
   /**
    * Loads and initializes a class via reflection. Use this when you intend to actually use the
@@ -57,6 +61,16 @@ public class LoadClass {
    * @return true if the class is on the classpath
    */
   public boolean isClassAvailable(final @NotNull String clazz, final @Nullable ILogger logger) {
+    final @Nullable Map<String, Boolean> availability = classAvailability;
+    if (availability != null) {
+      final @Nullable Boolean available = availability.get(clazz);
+      if (available != null) {
+        if (!available && logger != null) {
+          logger.log(SentryLevel.INFO, "Class not available: " + clazz);
+        }
+        return available;
+      }
+    }
     return loadClass(clazz, logger, false) != null;
   }
 

--- a/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
@@ -10,12 +10,11 @@ import kotlin.test.assertTrue
 class LoadClassTest {
   @Test
   fun `isClassAvailable uses known build-time results and reflects unknown classes`() {
-    setClassAvailability(
+    LoadClass.classAvailability =
       mapOf(
         "io.sentry.SentryEvent" to false,
         "io.sentry.ThisClassDoesNotExist" to true,
       )
-    )
 
     try {
       val loadClass = LoadClass()
@@ -31,7 +30,7 @@ class LoadClassTest {
       assertThat(loadClass.isClassAvailable("io.sentry.Sentry", null as io.sentry.ILogger?))
         .isTrue()
     } finally {
-      setClassAvailability(null)
+      LoadClass.classAvailability = null
     }
   }
 
@@ -74,12 +73,6 @@ class LoadClassTest {
     LoadClass().loadClass(LoadClassInitProbe::class.java.name, null)
 
     assertTrue(LoadClassInitFlag.initialized)
-  }
-
-  private fun setClassAvailability(availability: Any?) {
-    val field = LoadClass::class.java.getDeclaredField("classAvailability")
-    field.isAccessible = true
-    field.set(null, availability)
   }
 }
 

--- a/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.util
 
+import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -7,6 +8,33 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LoadClassTest {
+  @Test
+  fun `isClassAvailable uses known build-time results and reflects unknown classes`() {
+    setClassAvailability(
+      mapOf(
+        "io.sentry.SentryEvent" to false,
+        "io.sentry.ThisClassDoesNotExist" to true,
+      )
+    )
+
+    try {
+      val loadClass = LoadClass()
+      assertThat(loadClass.isClassAvailable("io.sentry.SentryEvent", null as io.sentry.ILogger?))
+        .isFalse()
+      assertThat(
+          loadClass.isClassAvailable(
+            "io.sentry.ThisClassDoesNotExist",
+            null as io.sentry.ILogger?,
+          )
+        )
+        .isTrue()
+      assertThat(loadClass.isClassAvailable("io.sentry.Sentry", null as io.sentry.ILogger?))
+        .isTrue()
+    } finally {
+      setClassAvailability(null)
+    }
+  }
+
   @Test
   fun `loadClass returns the class when it is available`() {
     assertNotNull(LoadClass().loadClass("io.sentry.SentryEvent", null))
@@ -46,6 +74,12 @@ class LoadClassTest {
     LoadClass().loadClass(LoadClassInitProbe::class.java.name, null)
 
     assertTrue(LoadClassInitFlag.initialized)
+  }
+
+  private fun setClassAvailability(availability: Any?) {
+    val field = LoadClass::class.java.getDeclaredField("classAvailability")
+    field.isAccessible = true
+    field.set(null, availability)
   }
 }
 


### PR DESCRIPTION
## :scroll: Description

Allow `LoadClass.isClassAvailable` to use class-availability results supplied by build tooling before falling back to `Class.forName`. The lookup map is nullable and private, so applications without compatible tooling keep the existing reflection behavior.

## :bulb: Motivation and Context

Android SDK initialization probes optional integrations reflectively. Build tooling already knows whether their owning modules are present, so it can avoid those runtime checks.

Refs [JAVA-654](https://linear.app/getsentry/issue/JAVA-654/move-reflection-checks-to-compile-time)

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:test --tests '*LoadClassTest*'`
- Pixel 2 XL microbenchmark: map construction and lookups were about 160× faster than the equivalent absent-heavy 11-class reflection batch.
- In the absent-heavy startup macrobenchmark, SDK initialization was 1.08% faster and full startup was 0.88% faster, though variance exceeded the measured delta. The representative 10-present/1-absent case showed no measurable improvement.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

[getsentry/sentry-android-gradle-plugin#1375](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1375) injects the build-time results.

#skip-changelog
