### PR TITLE
fix(app-start): Fix detection of foreground app start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Prevent inflated cold app start when the OS spawns the process in the background (e.g. FCM push) on API 35+ ([#5841](https://github.com/getsentry/sentry-java/pull/5841))
+- Prevent inflated cold app start when the OS spawns the process in the background (e.g. FCM push) on API 35+ ([#5841](https://github.com/getsentry/sentry-java/pull/5841), [#5880](https://github.com/getsentry/sentry-java/pull/5880))
 - Avoid a CPU busy-loop when recording discarded log or metric envelopes under rate limiting ([#5835](https://github.com/getsentry/sentry-java/pull/5835))
   - `ClientReportRecorder` now reads the item count from the envelope item header instead of deserializing the payload, which under sustained rate limiting could pin CPU cores while repeatedly throwing exceptions
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -534,7 +534,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
         }
       }
     }
-    // Fallback, if not matching ApplicationStartInfo is available
+    // Fallback, if no matching ApplicationStartInfo is available
     if (appLaunchedInForeground == null) {
       appLaunchedInForeground = ContextUtils.isForegroundImportance();
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -30,7 +30,6 @@ import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
 import io.sentry.protocol.SentryId;
 import io.sentry.util.AutoClosableReentrantLock;
-import io.sentry.util.LazyEvaluator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,14 +69,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       new AutoClosableReentrantLock();
 
   private @NotNull AppStartType appStartType = AppStartType.UNKNOWN;
-  private final LazyEvaluator<Boolean> appLaunchedInForeground =
-      new LazyEvaluator<>(
-          new LazyEvaluator.Evaluator<Boolean>() {
-            @Override
-            public @NotNull Boolean evaluate() {
-              return ContextUtils.isForegroundImportance();
-            }
-          });
+  private @Nullable volatile Boolean appLaunchedInForeground;
   private volatile long firstIdle = -1;
 
   private final @NotNull TimeSpan appStartSpan;
@@ -239,12 +231,12 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   }
 
   public boolean isAppLaunchedInForeground() {
-    return appLaunchedInForeground.getValue();
+    return Boolean.TRUE.equals(appLaunchedInForeground);
   }
 
   @VisibleForTesting
   public void setAppLaunchedInForeground(final boolean appLaunchedInForeground) {
-    this.appLaunchedInForeground.setValue(appLaunchedInForeground);
+    this.appLaunchedInForeground = appLaunchedInForeground;
   }
 
   public void setHeadlessAppStartListener(final @Nullable HeadlessAppStartListener listener) {
@@ -318,8 +310,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   }
 
   public boolean shouldSendStartMeasurements(final boolean ignoreForegroundCheck) {
-    return shouldSendStartMeasurements
-        && (ignoreForegroundCheck || appLaunchedInForeground.getValue());
+    return shouldSendStartMeasurements && (ignoreForegroundCheck || isAppLaunchedInForeground());
   }
 
   public boolean shouldSendStartMeasurements() {
@@ -349,7 +340,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       final @NotNull SentryAndroidOptions options) {
     // If the app start type was never determined or app wasn't launched in foreground,
     // the app start is considered invalid
-    if (appStartType != AppStartType.UNKNOWN && appLaunchedInForeground.getValue()) {
+    if (appStartType != AppStartType.UNKNOWN && isAppLaunchedInForeground()) {
       if (options.isEnablePerformanceV2()) {
         // Only started when sdk version is >= N
         final @NotNull TimeSpan appStartSpan = getAppStartTimeSpan();
@@ -412,7 +403,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     }
     appStartContinuousProfiler = null;
     appStartSamplingDecision = null;
-    appLaunchedInForeground.resetValue();
+    appLaunchedInForeground = null;
     isCallbackRegistered = false;
     shouldSendStartMeasurements = true;
     firstDrawDone.set(false);
@@ -510,7 +501,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       return;
     }
     isCallbackRegistered = true;
-    appLaunchedInForeground.resetValue();
+    appLaunchedInForeground = null;
     application.registerActivityLifecycleCallbacks(instance);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
@@ -529,7 +520,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
               } else {
                 appStartType = AppStartType.WARM;
               }
-              appLaunchedInForeground.setValue(isForegroundStartReason(info.getReason()));
+              appLaunchedInForeground = isForegroundStartReason(info.getReason());
             }
           }
         } catch (RuntimeException ignored) {
@@ -542,6 +533,10 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
           Log.w("AppStartMetrics", ignored); // no logger instance here, so we just Log
         }
       }
+    }
+    // Fallback, if not matching ApplicationStartInfo is available
+    if (appLaunchedInForeground == null) {
+      appLaunchedInForeground = ContextUtils.isForegroundImportance();
     }
 
     if (appStartType == AppStartType.UNKNOWN || headlessAppStartListener != null) {
@@ -591,7 +586,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
         return;
       }
 
-      appLaunchedInForeground.setValue(false);
+      appLaunchedInForeground = false;
 
       // Headless starts have no Activity signal for the pre-API 35 warm/cold heuristic.
       // If ApplicationStartInfo did not resolve the type, classify the process start as cold.
@@ -677,7 +672,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       // An active extension explicitly keeps the launch alive: resetting the span here would make
       // the extended vital measure from the activity while the eager app.start transaction stays
       // anchored at process start.
-      if ((!appLaunchedInForeground.getValue()
+      if ((!isAppLaunchedInForeground()
               || durationSinceAppStartMillis > TimeUnit.MINUTES.toMillis(1))
           && !appStartExtension.isActive()) {
         appStartType = AppStartType.WARM;
@@ -698,7 +693,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
         }
       }
     }
-    appLaunchedInForeground.setValue(true);
+    appLaunchedInForeground = true;
   }
 
   @Override
@@ -744,7 +739,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     // as the next onActivityCreated will treat it as a new warm app start
     if (remainingActivities == 0 && !activity.isChangingConfigurations()) {
       appStartType = AppStartType.WARM;
-      appLaunchedInForeground.setValue(true);
+      appLaunchedInForeground = true;
       shouldSendStartMeasurements = true;
       firstDrawDone.set(false);
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -241,15 +241,16 @@ class AppStartMetricsTest {
   }
 
   @Test
-  fun `headless app start fires HeadlessAppStartListener`() = headlessProcess {
-    val listenerCalls = AtomicInteger()
+  fun `headless app start fires HeadlessAppStartListener`() =
+    withProcessImportance(false) {
+      val listenerCalls = AtomicInteger()
 
-    AppStartMetrics.getInstance().setHeadlessAppStartListener { listenerCalls.incrementAndGet() }
-    AppStartMetrics.getInstance().registerLifecycleCallbacks(mock<Application>())
-    waitForMainLooperIdle()
+      AppStartMetrics.getInstance().setHeadlessAppStartListener { listenerCalls.incrementAndGet() }
+      AppStartMetrics.getInstance().registerLifecycleCallbacks(mock<Application>())
+      waitForMainLooperIdle()
 
-    assertEquals(1, listenerCalls.get())
-  }
+      assertEquals(1, listenerCalls.get())
+    }
 
   @Test
   fun `foreground process does not fire HeadlessAppStartListener`() {
@@ -295,7 +296,7 @@ class AppStartMetricsTest {
 
   @Test
   fun `resolveHeadlessAppStartEndTime uses applicationOnCreate stop when Gradle plugin instrumented`() =
-    headlessProcess {
+    withProcessImportance(false) {
       val metrics = AppStartMetrics.getInstance()
       metrics.appStartTimeSpan.setStartedAt(100)
       metrics.setHeadlessAppStartListener {}
@@ -312,7 +313,7 @@ class AppStartMetricsTest {
 
   @Test
   fun `resolveHeadlessAppStartEndTime falls back to CLASS_LOADED_UPTIME_MS when no plugin and no ApplicationStartInfo`() =
-    headlessProcess {
+    withProcessImportance(false) {
       val metrics = AppStartMetrics.getInstance()
       metrics.setClassLoadedUptimeMs(200)
       metrics.appStartTimeSpan.setStartedAt(100)
@@ -371,12 +372,18 @@ class AppStartMetricsTest {
     Shadows.shadowOf(Looper.getMainLooper()).idle()
   }
 
-  // Simulates a real headless start (broadcast/service), i.e. a non-foreground-importance process.
-  // The Robolectric default importance in this test class is IMPORTANCE_FOREGROUND, so headless
-  // scenarios must opt into a background importance explicitly.
-  private fun <T> headlessProcess(block: () -> T): T =
+  /**
+   * Mocks the process importance to simulate a user initiated start (e.g. launcher) or a real
+   * headless start (broadcast/service), i.e. a non-foreground-importance process.
+   *
+   * The Robolectric default importance in this test class is IMPORTANCE_FOREGROUND, so any headless
+   * scenarios must opt into a background importance explicitly.
+   */
+  private fun <T> withProcessImportance(isForeground: Boolean, block: () -> T): T =
     mockStatic(ContextUtils::class.java).use { contextUtils ->
-      contextUtils.`when`<Boolean> { ContextUtils.isForegroundImportance() }.thenReturn(false)
+      contextUtils
+        .`when`<Boolean> { ContextUtils.isForegroundImportance() }
+        .thenReturn(isForeground)
       block()
     }
 
@@ -1123,4 +1130,20 @@ class AppStartMetricsTest {
     assertEquals(now, metrics.appStartTimeSpan.startUptimeMs)
     metrics.appStartExtension.setExtendAppStartListener(null)
   }
+
+  @Test
+  fun `broadcast starts are not considered a foreground start`() =
+    withProcessImportance(false) {
+      val metrics = AppStartMetrics.getInstance()
+      metrics.registerLifecycleCallbacks(mock<Application>())
+      assertFalse(metrics.isAppLaunchedInForeground)
+    }
+
+  @Test
+  fun `typical app starts are considered a foreground start`() =
+    withProcessImportance(true) {
+      val metrics = AppStartMetrics.getInstance()
+      metrics.registerLifecycleCallbacks(mock<Application>())
+      assertTrue(metrics.isAppLaunchedInForeground)
+    }
 }


### PR DESCRIPTION
## Description

Pre Android 15, `AppStartMetrics.appLaunchedInForeground` uses a `LazyEvaluator<Boolean>` that only
evaluated `ContextUtils.isForegroundImportance()` on the first read. Since the read can happen at a later point in time, e.g. during `Activity.onCreate()` the process importance might have changed by now, and we incorrectly detect foreground / background starts - causing long app starts.

This PR changes the behavior, and we now immediately evaluate the foreground flag. This will make foreground/background app starts pre Android 15 more correct, at the cost of an extra binder call via `ContextUtils.isForegroundImportance()`.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-java/issues/4693 (pre Android 15)

## :green_heart: How did you test it?

Unit Tests.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
