### PR TITLE
fix(android): Reduce SQLite cursor SDK crash false-positives

### DIFF
--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentryCrossProcessCursor.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentryCrossProcessCursor.kt
@@ -2,20 +2,20 @@ package io.sentry.android.sqlite
 
 import android.database.CrossProcessCursor
 import android.database.CursorWindow
+import android.database.CursorWrapper
 
 /*
  * SQLiteCursor executes the query lazily, when one of getCount() and onMove() is called.
  * Also, by docs, fillWindow() can be used to fill the cursor with data.
  * So we wrap these methods to create a span.
- * SQLiteCursor is never used directly in the code, but only the Cursor interface.
- *  This means we can use CrossProcessCursor - that extends Cursor - as wrapper, since
- *   CrossProcessCursor is an interface and we can use Kotlin delegation.
+ * Ordinary Cursor methods are delegated through CursorWrapper to avoid adding Sentry frames to
+ * app database exceptions that the wrapper did not instrument.
  */
 internal class SentryCrossProcessCursor(
   private val delegate: CrossProcessCursor,
   private val spans: OpenHelperSpans,
   private val sql: String,
-) : CrossProcessCursor by delegate {
+) : CursorWrapper(delegate), CrossProcessCursor {
   // We have to start the span only the first time, regardless of how many times its methods get
   // called.
   private var isSpanStarted = false
@@ -35,6 +35,8 @@ internal class SentryCrossProcessCursor(
     isSpanStarted = true
     return spans.performSql(sql) { delegate.onMove(oldPosition, newPosition) }
   }
+
+  override fun getWindow(): CursorWindow? = delegate.window
 
   override fun fillWindow(position: Int, window: CursorWindow?) {
     if (isSpanStarted) {

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentryCrossProcessCursorTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentryCrossProcessCursorTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.sqlite
 
 import android.database.CrossProcessCursor
+import android.database.CursorWrapper
 import io.sentry.IScopes
 import io.sentry.ISpan
 import io.sentry.SentryOptions
@@ -52,13 +53,14 @@ class SentryCrossProcessCursorTest {
 
     cursor.fillWindow(0, mock())
     verify(fixture.mockCursor).fillWindow(eq(0), any())
+  }
 
-    // Let's verify other methods are delegated, even if not explicitly
-    cursor.close()
-    verify(fixture.mockCursor).close()
+  @Test
+  fun `ordinary cursor methods are delegated by Android CursorWrapper`() {
+    val getStringMethod =
+      SentryCrossProcessCursor::class.java.getMethod("getString", Int::class.javaPrimitiveType!!)
 
-    cursor.getString(1)
-    verify(fixture.mockCursor).getString(eq(1))
+    assertEquals(CursorWrapper::class.java, getStringMethod.declaringClass)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

PR helps us avoid incorrectly attributing host app SQLite crashes to the Sentry SDK in situations where a pass-through cursor method shows up in the crash stack trace. 

In particular, it replaces Kotlin interface delegation in SentryCrossProcessCursor in favor of Android's CursorWrapper. That keeps lazy-query span instrumentation on getCount, onMove, and fillWindow, but avoids generating Sentry-owned methods like getString for pass-through cursor calls.

## :bulb: Motivation and Context

Reduces false-positive crash rates associated with the Sentry Android SDK. Something we saw a lot of in 8.44.1 and 8.43.3, as mentioned [here](https://sentry.slack.com/archives/G01PW6HRQNN/p1785748167877479?thread_ts=1785741441.590429&cid=G01PW6HRQNN).

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?

<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps

 #skip-changelog
