### PR TITLE
fix(core): Restore directory processor interrupt flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Restore the interrupt flag when cached envelope processing is interrupted between files ([#5884](https://github.com/getsentry/sentry-java/issues/5884))
 - Prevent inflated cold app start when the OS spawns the process in the background (e.g. FCM push) on API 35+ ([#5841](https://github.com/getsentry/sentry-java/pull/5841), [#5880](https://github.com/getsentry/sentry-java/pull/5880))
 - Preserve single-sample ANR profile chunks so profiles remain available on ANR events ([#5872](https://github.com/getsentry/sentry-java/pull/5872))
 - Avoid a CPU busy-loop when recording discarded log or metric envelopes under rate limiting ([#5835](https://github.com/getsentry/sentry-java/pull/5835))

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -93,10 +93,14 @@ abstract class DirectoryProcessor {
         // InterruptedException will be handled by the outer try-catch
         Thread.sleep(ENVELOPE_PROCESSING_DELAY);
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.log(
+          SentryLevel.INFO,
+          e,
+          "Thread interrupted during processing '%s'",
+          directory.getAbsolutePath());
     } catch (Throwable e) {
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
       logger.log(SentryLevel.ERROR, e, "Failed processing '%s'", directory.getAbsolutePath());
     }
   }

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -94,6 +94,9 @@ abstract class DirectoryProcessor {
         Thread.sleep(ENVELOPE_PROCESSING_DELAY);
       }
     } catch (Throwable e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       logger.log(SentryLevel.ERROR, e, "Failed processing '%s'", directory.getAbsolutePath());
     }
   }

--- a/sentry/src/test/java/io/sentry/DirectoryProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DirectoryProcessorTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.hints.ApplyScopeData
 import io.sentry.hints.Enqueable
 import io.sentry.hints.Retryable
@@ -133,6 +134,28 @@ class DirectoryProcessorTest {
 
     // should only capture once
     verify(fixture.scopes).captureEvent(any(), anyOrNull<Hint>())
+  }
+
+  @Test
+  fun `when envelope processing delay is interrupted, restores interrupt flag`() {
+    getTempEnvelope("envelope-event-attachment.txt")
+    val sut =
+      object : DirectoryProcessor(fixture.scopes, fixture.logger, 500, 30) {
+        override fun processFile(file: File, hint: Hint) = Unit
+
+        override fun isRelevantFileName(fileName: String): Boolean = true
+      }
+
+    Thread.currentThread().interrupt()
+    val interruptFlagRestored =
+      try {
+        sut.processDirectory(file)
+        Thread.currentThread().isInterrupted
+      } finally {
+        Thread.interrupted()
+      }
+
+    assertThat(interruptFlagRestored).isTrue()
   }
 
   private fun getTempEnvelope(fileName: String): String {


### PR DESCRIPTION
## :scroll: Description

Restores thread interrupt status when the inter-envelope processing delay is interrupted so callers can observe the status after directory processing returns.

## :bulb: Motivation and Context

Fixes [JAVA-666](https://linear.app/getsentry/issue/JAVA-666/directoryprocessor-interruptedexception-caught-but-interrupt-flag)

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?

Via a new regression test

<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
