### PR TITLE
fix(android): Defer frame metrics reflection during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Performance
 
+- Defer `Choreographer` reflection for frame metrics collection until after SDK init to avoid blocking the main thread during `Sentry.init` ([#5886](https://github.com/getsentry/sentry-java/pull/5886))
 - Use `RGB_565` instead of `ARGB_8888` for screenshot and replay capture bitmaps, halving per-frame memory usage ([#5821](https://github.com/getsentry/sentry-java/pull/5821))
 - Remove an unused lock from `SentryPerformanceProvider`, which was allocated on every cold start in `ContentProvider.onCreate` without ever being acquired ([#5871](https://github.com/getsentry/sentry-java/pull/5871))
 - Parse the app start profiling config with only the deserializer it needs instead of building a full `JsonSerializer` and `SentryOptions`, cutting 188 of 221 allocations on the main thread before `Application.onCreate` ([#5867](https://github.com/getsentry/sentry-java/pull/5867))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -56,8 +56,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
   private final WindowFrameMetricsManager windowFrameMetricsManager;
 
   private @Nullable Window.OnFrameMetricsAvailableListener frameMetricsAvailableListener;
-  private @Nullable Choreographer choreographer;
-  private @Nullable Field choreographerLastFrameTimeField;
+  private volatile @Nullable Choreographer choreographer;
+  private volatile @Nullable Field choreographerLastFrameTimeField;
   private long lastFrameStartNanos = 0;
   private long lastFrameEndNanos = 0;
 
@@ -126,7 +126,9 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
     // Most considerations regarding timestamps of frames are inspired from JankStats library:
     // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:metrics/metrics-performance/src/main/java/androidx/metrics/performance/JankStatsApi24Impl.kt
 
-    // The Choreographer instance must be accessed on the main thread
+    // The Choreographer instance and private field reflection must be accessed asynchronously on
+    // the main thread to avoid blocking SDK init. getLastKnownFrameStartTimeNanos() uses this for
+    // pending frame interpolation on all supported API levels.
     new Handler(Looper.getMainLooper())
         .post(
             () -> {
@@ -138,15 +140,19 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
                     "Error retrieving Choreographer instance. Slow and frozen frames will not be reported.",
                     e);
               }
+
+              // Let's get the last frame timestamp from the choreographer private field
+              try {
+                choreographerLastFrameTimeField =
+                    Choreographer.class.getDeclaredField("mLastFrameTimeNanos");
+                choreographerLastFrameTimeField.setAccessible(true);
+              } catch (NoSuchFieldException e) {
+                logger.log(
+                    SentryLevel.ERROR,
+                    "Unable to get the frame timestamp from the choreographer: ",
+                    e);
+              }
             });
-    // Let's get the last frame timestamp from the choreographer private field
-    try {
-      choreographerLastFrameTimeField = Choreographer.class.getDeclaredField("mLastFrameTimeNanos");
-      choreographerLastFrameTimeField.setAccessible(true);
-    } catch (NoSuchFieldException e) {
-      logger.log(
-          SentryLevel.ERROR, "Unable to get the frame timestamp from the choreographer: ", e);
-    }
 
     frameMetricsAvailableListener =
         (window, frameMetrics, dropCountSinceLastInvocation) -> {
@@ -165,7 +171,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
           final long delayNanos = Math.max(0, cpuDuration - expectedFrameDuration);
 
           long startTime = getFrameStartTimestamp(frameMetrics);
-          // If we couldn't get the timestamp through reflection, we use current time
+          // If we couldn't get the timestamp through FrameMetrics or reflection, we use the current
+          // time.
           if (startTime < 0) {
             startTime = now - cpuDuration;
           }
@@ -217,8 +224,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
   }
 
   /**
-   * Return the internal timestamp in the choreographer of the last frame start timestamp through
-   * reflection. On Android O the value is read from the frameMetrics itself.
+   * Return the frame start timestamp. On API 26+, this value is read directly from {@link
+   * FrameMetrics}; older APIs use the reflected Choreographer timestamp.
    */
   @SuppressLint("NewApi")
   private long getFrameStartTimestamp(final @NotNull FrameMetrics frameMetrics) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -126,9 +126,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
     // Most considerations regarding timestamps of frames are inspired from JankStats library:
     // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:metrics/metrics-performance/src/main/java/androidx/metrics/performance/JankStatsApi24Impl.kt
 
-    // The Choreographer instance and private field reflection must be accessed asynchronously on
-    // the main thread to avoid blocking SDK init. getLastKnownFrameStartTimeNanos() uses this for
-    // pending frame interpolation on all supported API levels.
+    // The Choreographer instance should be initialized asynchronously on the main thread to avoid
+    // reflection during SDK init.
     new Handler(Looper.getMainLooper())
         .post(
             () -> {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollectorTest.kt
@@ -19,7 +19,6 @@ import io.sentry.test.getCtor
 import io.sentry.test.getProperty
 import io.sentry.test.injectForField
 import java.lang.ref.WeakReference
-import java.lang.reflect.Field
 import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -302,18 +301,41 @@ class SentryFrameMetricsCollectorTest {
   }
 
   @Test
-  fun `collector accesses choreographer instance on creation on main thread`() {
+  fun `collector accesses choreographer instance and field asynchronously on main thread`() {
     val collector = fixture.getSut(context)
-    val field: Field? = collector.getProperty("choreographerLastFrameTimeField")
+
+    val field: Any? = collector.getProperty("choreographerLastFrameTimeField")
     var choreographer: Choreographer? = collector.getProperty("choreographer")
-    // Choreographer instance is accessed on main thread, but the field accessor happens in whatever
-    // thread created the collector
-    assertNotNull(field)
+
     assertNull(choreographer)
+    assertNull(field)
+
     // Execute all posted tasks
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     choreographer = collector.getProperty("choreographer")
     assertNotNull(choreographer)
+    assertNotNull(collector.getProperty<Any?>("choreographerLastFrameTimeField"))
+  }
+
+  // Frame callbacks on API 26+ read their per-frame start timestamp directly from FrameMetrics,
+  // which can make the Choreographer fallback look like it should be specific to APIs < 26.
+  // But SpanFrameMetricsCollector separately calls getLastKnownFrameStartTimeNanos() on every
+  // API level for pending-frame interpolation, so API 26+ still needs the Choreographer
+  // fallback to be initialized.
+  @Test
+  fun `collector keeps choreographer fallback available on version O+`() {
+    val buildInfo =
+      mock<BuildInfoProvider> { whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.O) }
+    val collector = fixture.getSut(context, buildInfo)
+
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+    val choreographer = collector.getProperty<Choreographer>("choreographer")
+    assertNotNull(collector.getProperty<Any?>("choreographerLastFrameTimeField"))
+
+    choreographer.injectForField("mLastFrameTimeNanos", 100)
+
+    assertEquals(100, collector.getLastKnownFrameStartTimeNanos())
   }
 
   @Test
@@ -621,10 +643,6 @@ class SentryFrameMetricsCollectorTest {
     // emit a fast frame (21ns cpu time — well under 16ms budget)
     listener.onFrameMetricsAvailable(createMockWindow(), createMockFrameMetrics(), 0)
 
-    // choreographer is at end of range so no pending delay
-    val choreographer = collector.getProperty<Choreographer>("choreographer")
-    choreographer.injectForField("mLastFrameTimeNanos", TimeUnit.SECONDS.toNanos(1))
-
     val result = collector.getFramesDelay(0, TimeUnit.SECONDS.toNanos(1))
     assertEquals(0.0, result.delaySeconds)
     assertEquals(0, result.framesContributingToDelayCount)
@@ -643,21 +661,22 @@ class SentryFrameMetricsCollectorTest {
     // emit a slow frame (~100ms extra = ~116ms total, well over 16ms budget)
     listener.onFrameMetricsAvailable(
       createMockWindow(),
-      createMockFrameMetrics(extraCpuDurationNanos = TimeUnit.MILLISECONDS.toNanos(100)),
+      createMockFrameMetrics(
+        extraCpuDurationNanos = TimeUnit.MILLISECONDS.toNanos(100),
+        intendedVsyncTimestampNanos = TimeUnit.SECONDS.toNanos(1),
+      ),
       0,
     )
 
     // emit a frozen frame (~1000ms extra = ~1016ms total, well over 700ms)
     listener.onFrameMetricsAvailable(
       createMockWindow(),
-      createMockFrameMetrics(extraCpuDurationNanos = TimeUnit.MILLISECONDS.toNanos(1000)),
+      createMockFrameMetrics(
+        extraCpuDurationNanos = TimeUnit.MILLISECONDS.toNanos(1000),
+        intendedVsyncTimestampNanos = TimeUnit.SECONDS.toNanos(2),
+      ),
       0,
     )
-
-    // choreographer is at end of range so no pending delay
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
-    val choreographer = collector.getProperty<Choreographer>("choreographer")
-    choreographer.injectForField("mLastFrameTimeNanos", TimeUnit.SECONDS.toNanos(5))
 
     val result = collector.getFramesDelay(0, TimeUnit.SECONDS.toNanos(5))
     assertTrue(result.delaySeconds > 0)
@@ -681,11 +700,6 @@ class SentryFrameMetricsCollectorTest {
       0,
     )
 
-    // choreographer is at end of range
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
-    val choreographer = collector.getProperty<Choreographer>("choreographer")
-    choreographer.injectForField("mLastFrameTimeNanos", TimeUnit.SECONDS.toNanos(5))
-
     // The frame's delay interval is roughly [~16ms, ~1000ms].
     // Query from 500ms so the range clips the delay interval in half.
     val queryStart = TimeUnit.MILLISECONDS.toNanos(500)
@@ -708,7 +722,6 @@ class SentryFrameMetricsCollectorTest {
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     val listener =
       collector.getProperty<Window.OnFrameMetricsAvailableListener>("frameMetricsAvailableListener")
-    val choreographer = collector.getProperty<Choreographer>("choreographer")
 
     collector.startCollection(mock())
 
@@ -719,8 +732,6 @@ class SentryFrameMetricsCollectorTest {
       createMockFrameMetrics(extraCpuDurationNanos = TimeUnit.MILLISECONDS.toNanos(100))
     whenever(frameMetrics1.getMetric(FrameMetrics.INTENDED_VSYNC_TIMESTAMP)).thenReturn(t0)
     listener.onFrameMetricsAvailable(createMockWindow(), frameMetrics1, 0)
-
-    choreographer.injectForField("mLastFrameTimeNanos", t0 + TimeUnit.SECONDS.toNanos(1))
 
     // verify frame exists
     val resultBefore = collector.getFramesDelay(t0, t0 + TimeUnit.SECONDS.toNanos(1))
@@ -734,7 +745,6 @@ class SentryFrameMetricsCollectorTest {
     listener.onFrameMetricsAvailable(createMockWindow(), frameMetrics2, 0)
 
     // the first frame should have been pruned (>5min old)
-    choreographer.injectForField("mLastFrameTimeNanos", t1 + TimeUnit.SECONDS.toNanos(1))
     val resultAfter = collector.getFramesDelay(t0, t0 + TimeUnit.SECONDS.toNanos(1))
     assertEquals(0, resultAfter.framesContributingToDelayCount)
   }
@@ -762,6 +772,7 @@ class SentryFrameMetricsCollectorTest {
     syncNanos: Long = 6,
     extraCpuDurationNanos: Long = 0,
     totalDurationNanos: Long = 60,
+    intendedVsyncTimestampNanos: Long = 50,
   ): FrameMetrics {
     val frameMetrics = mock<FrameMetrics>()
     whenever(frameMetrics.getMetric(FrameMetrics.UNKNOWN_DELAY_DURATION))
@@ -774,7 +785,8 @@ class SentryFrameMetricsCollectorTest {
     whenever(frameMetrics.getMetric(FrameMetrics.DRAW_DURATION)).thenReturn(drawNanos)
     whenever(frameMetrics.getMetric(FrameMetrics.SYNC_DURATION)).thenReturn(syncNanos)
     whenever(frameMetrics.getMetric(FrameMetrics.TOTAL_DURATION)).thenReturn(totalDurationNanos)
-    whenever(frameMetrics.getMetric(FrameMetrics.INTENDED_VSYNC_TIMESTAMP)).thenReturn(50)
+    whenever(frameMetrics.getMetric(FrameMetrics.INTENDED_VSYNC_TIMESTAMP))
+      .thenReturn(intendedVsyncTimestampNanos)
     return frameMetrics
   }
 }


### PR DESCRIPTION
## :scroll: Description

Moves Choreographer private field lookup out of the frame metrics collector constructor so that `Sentry.init()` doesn't synchronously perform framework reflection. Helps us reduce the likelihood of another common class of init ANRs (see [here](https://sentry.sentry.io/issues/6138715212/?project=4506812075540480&referrer=seer.agent.in-chat-link)).


## :bulb: Motivation and Context

We've seen 583k ANR events involving the SentryFrameMetricsCollector across 257 affected users since November 2024 ([link](https://sentry.sentry.io/issues/6138715212/?referrer=seer.agent.in-chat-link)), making it the highest-volume SDK-caused ANR we track. 

Those numbers got lots better thanks to @runningcode's fix in [#5641](https://github.com/getsentry/sentry-java/pull/5641): events peaked at ~12k per 3-day window in June 2026, then dropped sharply to (a fairly consistent) ~4k/3d. But the reflection this PR addresses continues to contribute to those remaining ANRs across all SDK versions, including the newest ones.

<!--
* resolves: #1234
* resolves: LIN-1234
-->

### Any behavior changes?

Behavior change from the user's perspective should be nonexistant in most cases, and minor in the worst case. 

The choreographer and choreographerLastFrameTimeField properties are still initialized by a main-thread Handler post made during collector construction, before later startCollection() calls post frame-listener registration work to the same main looper. Since those main looper tasks run in order, the Choreographer fallback should be populated before any collected frame or pending-frame interpolation normally needs it. If it's not ready yet, the failure mode is a missed/less precise first pending-frame calculation rather than a crash.

## :green_heart: How did you test it?
<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->

Unit tests + manual smoke tests on Android sample app.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
