### PR TITLE
fix(compose): Restore Compose 1.6 compatibility for sentry-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - `ClientReportRecorder` now reads the item count from the envelope item header instead of deserializing the payload, which under sustained rate limiting could pin CPU cores while repeatedly throwing exceptions
 - Report tasks handed to a no-op `ISentryExecutorService` as cancelled ([#5874](https://github.com/getsentry/sentry-java/pull/5874))
   - `NoOpSentryExecutorService` previously returned a `Future` that was never run and never cancelled, so callers could not tell a dropped task from a queued one and `get()` would block until its timeout
+- Fix `NoSuchMethodError` when using `SentryTraced` or `SentryUserFeedbackButton` with Jetpack Compose older than 1.8 ([#5887](https://github.com/getsentry/sentry-java/pull/5887))
+  - Since `8.32.0`, `sentry-compose` was compiled against a newer `androidx.compose.material3`, whose transitive Compose versions were inlined into the SDK by composables like `Box`. This made the SDK reference Compose internals (`Composer.shouldExecute`, `BoxKt.maybeCachedBoxMeasurePolicy`) that do not exist on older Compose versions.
 
 ### Performance
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,10 @@ androidxLifecycle = "2.2.0"
 androidxNavigation = "2.4.2"
 androidxTestCore = "1.7.0"
 androidxCompose = "1.6.3"
+# Oldest material3 we support. Kept in lockstep with androidxCompose: material3 drags its own
+# transitive Compose versions onto the compile classpath, so a newer value here raises the effective
+# Compose floor of sentry-compose's published bytecode.
+androidxComposeMaterial3Floor = "1.2.1"
 asyncProfiler = "4.4"
 camerax = "1.4.0"
 composeCompiler = "1.5.14"
@@ -89,6 +93,12 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidxCompose" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidxCompose" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version = "1.4.0" }
+# Compiling against material3 pulls its transitive compose-runtime/foundation onto the classpath, and
+# inline composables like Box bake those internals straight into our bytecode. Keep this at the oldest
+# material3 we support so sentry-compose stays loadable on androidxCompose above.
+# Note: don't change without testing backwards compatibility.
+# :sentry-android-integration-tests:compose-floor-integration-tests guards this.
+androidx-compose-material3-floor = { module = "androidx.compose.material3:material3", version.ref = "androidxComposeMaterial3Floor" }
 androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version="1.7.8" }
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version="1.7.8" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidxCompose" }
@@ -240,6 +250,10 @@ tomcat-embed-jasper-jakarta = { module = "org.apache.tomcat.embed:tomcat-embed-j
 # test libraries
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version = "1.4.1" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.9.5" }
+# Floor-matched test harness for :sentry-android-integration-tests:compose-floor-integration-tests.
+# Must track androidxCompose, otherwise the test runtime pulls a newer Compose and the check silently
+# passes.
+androidx-compose-ui-test-junit4-floor = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidxCompose" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }

--- a/sentry-android-integration-tests/compose-floor-integration-tests/build.gradle.kts
+++ b/sentry-android-integration-tests/compose-floor-integration-tests/build.gradle.kts
@@ -1,0 +1,84 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+plugins {
+  id("com.android.library")
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.detekt)
+}
+
+android {
+  compileSdk = libs.versions.compileSdk.get().toInt()
+  namespace = "io.sentry.compose.floortest"
+
+  defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+
+  // AGP 9 only generates unit tests for the testBuildType. The debug variant is
+  // disabled, so unit tests must target release to run at all.
+  testBuildType = "release"
+
+  kotlin {
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+    compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
+  }
+
+  testOptions {
+    animationsDisabled = true
+    unitTests.apply {
+      isReturnDefaultValues = true
+      isIncludeAndroidResources = true
+    }
+  }
+
+  lint {
+    warningsAsErrors = true
+    checkDependencies = true
+    checkReleaseBuilds = false
+  }
+
+  androidComponents.beforeVariants {
+    it.enable = !Config.Android.shouldSkipDebugVariant(it.buildType)
+  }
+}
+
+// This module exists purely to run sentry-compose against the oldest Compose we claim to support.
+// Compose artifacts are inlined into consumer bytecode, so building sentry-compose against a newer
+// Compose can emit references to internals that do not exist on the floor, which only surfaces as a
+// NoSuchMethodError at runtime on a consumer's older Compose. Pinning here makes that a test
+// failure.
+// The pins must stay at the floor: raising them silently disables the check this module provides.
+configurations.configureEach {
+  resolutionStrategy {
+    val floor = libs.versions.androidxCompose.get()
+    eachDependency {
+      when (requested.group) {
+        "androidx.compose.material3" ->
+          useVersion(libs.versions.androidxComposeMaterial3Floor.get())
+        "androidx.compose.runtime",
+        "androidx.compose.foundation",
+        "androidx.compose.ui",
+        "androidx.compose.animation" -> useVersion(floor)
+      }
+    }
+  }
+}
+
+dependencies {
+  implementation(projects.sentryCompose)
+
+  testImplementation(libs.androidx.compose.material3.floor)
+  testImplementation(libs.androidx.compose.ui.test.junit4.floor)
+  testImplementation(libs.androidx.test.ext.junit)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.roboelectric)
+}
+
+tasks.withType<Detekt>().configureEach { jvmTarget = JavaVersion.VERSION_1_8.toString() }

--- a/sentry-android-integration-tests/compose-floor-integration-tests/src/test/kotlin/io/sentry/compose/floortest/ComposeFloorCompatibilityTest.kt
+++ b/sentry-android-integration-tests/compose-floor-integration-tests/src/test/kotlin/io/sentry/compose/floortest/ComposeFloorCompatibilityTest.kt
@@ -1,0 +1,66 @@
+package io.sentry.compose.floortest
+
+import android.app.Application
+import android.content.ComponentName
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.Text
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.compose.SentryTraced
+import io.sentry.compose.SentryUserFeedbackButton
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+/**
+ * Composes the public entry points of sentry-compose against the oldest Compose version we support.
+ *
+ * Compose inlines composables such as `Box` into calling bytecode, so sentry-compose can end up
+ * referencing Compose internals from whatever version it was compiled against. Those references
+ * resolve fine in our own test suite, which runs on a recent Compose, but throw NoSuchMethodError
+ * on a consumer using an older one. Compose is pinned to the floor for this module so that mismatch
+ * fails here instead of in a user's app.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [30])
+class ComposeFloorCompatibilityTest {
+  // workaround for robolectric tests with composeRule
+  // from https://github.com/robolectric/robolectric/pull/4736#issuecomment-1831034882
+  @get:Rule(order = 1)
+  val addActivityToRobolectricRule =
+    object : TestWatcher() {
+      override fun starting(description: Description?) {
+        super.starting(description)
+        val appContext: Application = ApplicationProvider.getApplicationContext()
+        Shadows.shadowOf(appContext.packageManager)
+          .addActivityIfNotPresent(
+            ComponentName(appContext.packageName, ComponentActivity::class.java.name)
+          )
+      }
+    }
+
+  @get:Rule(order = 2) val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @OptIn(ExperimentalComposeUiApi::class)
+  @Test
+  fun `SentryTraced composes on the oldest supported Compose`() {
+    rule.setContent { SentryTraced("floor-tag") { Text("content") } }
+
+    rule.onNodeWithText("content").assertExists()
+  }
+
+  @Suppress("DEPRECATION")
+  @Test
+  fun `SentryUserFeedbackButton composes on the oldest supported Compose`() {
+    rule.setContent { SentryUserFeedbackButton(text = "Report a Bug") }
+
+    rule.onNodeWithText("Report a Bug").assertExists()
+  }
+}

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
         api(projects.sentry)
         api(projects.sentryAndroidNavigation)
 
-        compileOnly(libs.androidx.compose.material3)
+        compileOnly(libs.androidx.compose.material3.floor)
         compileOnly(libs.androidx.navigation.compose)
         implementation(libs.androidx.lifecycle.common.java8)
       }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -125,6 +125,7 @@ include(
     "sentry-samples:sentry-samples-spring-boot-4-otlp",
     "sentry-samples:sentry-samples-spring-boot-4-webflux",
     "sentry-samples:sentry-samples-netflix-dgs",
+    "sentry-android-integration-tests:compose-floor-integration-tests",
     "sentry-android-integration-tests:sentry-uitest-android-critical",
     "sentry-android-integration-tests:sentry-uitest-android-benchmark",
     "sentry-android-integration-tests:sentry-uitest-android-macrobenchmark",


### PR DESCRIPTION
## :scroll: Description

`sentry-compose` was shipping bytecode that references Jetpack Compose internals newer than the Compose floor the module declares (`androidxCompose = "1.6.3"`), so composing `SentryTraced` on an app with an older Compose threw `NoSuchMethodError`.

`androidx.compose.foundation.layout.Box` is an **inline** composable, so the Compose compiler bakes its body into *our* bytecode rather than leaving a call to `BoxKt.Box`. That means whatever Compose version is on `sentry-compose`'s compile classpath gets inlined into the published artifact. The 8.51.0 `SentryComposeTracingKt` contains zero `BoxKt.Box` call sites and instead references:

| Symbol | First available in |
| --- | --- |
| `BoxKt.maybeCachedBoxMeasurePolicy` | foundation-layout **1.7.0** |
| `Composer.shouldExecute` | runtime **1.8.0** |
| `ComposableLambdaKt.rememberComposableLambda` | runtime **1.8.0** |

`sentry-compose` declares `compileOnly(libs.androidx.compose.material3)`, and material3 drags its own transitive Compose onto that classpath. When material3 was bumped `1.2.1 → 1.4.0` in #5017 (a **samples** refactor), it pulled in runtime 1.9.0 / foundation-layout 1.8.1 and silently raised the floor of the inlined code.

Bisecting published artifacts on Maven Central confirms where it regressed:

- **8.31.0** and earlier → `rememberBoxMeasurePolicy` (resolvable on 1.6.x)
- **8.32.0** onward → `maybeCachedBoxMeasurePolicy` + `shouldExecute`

`SentryUserFeedbackButton` was affected the same way.

**The fix** pins the `compileOnly` material3 used by `sentry-compose` to the oldest version we support via a new `androidx-compose-material3-floor` catalog alias. The unpinned `androidx-compose-material3` (1.4.0) is left untouched for the samples and test modules that need newer material3 APIs. No source or public API changes — `apiDump` produces no diff.

The second commit adds `:sentry-android-integration-tests:compose-floor-integration-tests`, which consumes `sentry-compose` with Compose forced to the floor and composes both affected entry points. It has to be a separate module because `sentry-compose`'s own `androidUnitTest` pins `ui-test-junit4` to 1.9.5 — a test added there would run against new Compose and pass even with the bug present.

> [!NOTE]
> Seer's suggested autofix on SDK-CRASHES-JAVA-48AR (remove `propagateMinConstraints = true` from the `Box`) is **not** the fix. `BoxKt`'s public signature is identical from foundation-layout 1.5.4 through 1.11.2 — `propagateMinConstraints` has always been a parameter. Removing it would change layout behavior and regress #2637 without addressing the crash.

## :bulb: Motivation and Context

Fixes SDK-CRASHES-JAVA-48AR (157 events, first seen 2026-03-19, reported on 8.51.0).

Linear: JAVA-681

Users on Compose older than 1.8 crash with an unhandled `NoSuchMethodError` as soon as a `SentryTraced` composable enters composition — the SDK takes down the host app.

## :green_heart: How did you test it?

New Robolectric test module (no emulator needed), verified in **both** directions:

**With the fix:**

```
ComposeFloorCompatibilityTest > SentryTraced composes on the oldest supported Compose PASSED
ComposeFloorCompatibilityTest > SentryUserFeedbackButton composes on the oldest supported Compose PASSED
```

**With the material3 pin reverted** — reproduces the exact production error:

```
ComposeFloorCompatibilityTest > SentryTraced ... FAILED
    java.lang.NoSuchMethodError: 'boolean androidx.compose.runtime.Composer.shouldExecute(boolean, int)'
ComposeFloorCompatibilityTest > SentryUserFeedbackButton ... FAILED  (same)
```

Also confirmed:

- The test **runtime** genuinely resolves the floor (Compose 1.6.3, material3 1.2.1) — a check that silently ran on new Compose would be worthless here.
- Emitted bytecode no longer references `shouldExecute` / `maybeCachedBoxMeasurePolicy`; only `rememberBoxMeasurePolicy`, which exists in foundation-layout 1.5.4 → 1.11.2 (backward *and* forward compatible).
- `:sentry-compose:check` green — all 20 pre-existing tests pass.
- `:sentry-samples-android:compileReleaseKotlin` green — samples still get material3 1.4.0, so the other five modules on the unpinned alias are unaffected.
- The new module produces no publish/`distZip` tasks, so it won't ship to Maven Central.
- `spotlessApply apiDump` clean, no API diff.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Two things deliberately left out of this PR:

1. **Ceiling coverage.** This guards the floor only. The mirror-image failure — forward-incompatibility like the `AbstractMethodError` on compose-ui 1.11+ fixed in #5672 — needs a check against the *newest* Compose. Worth a follow-up.
2. **`SentryUserFeedbackButton` constraint.** It genuinely uses material3 APIs (`Button`, `Icon`, `Text`), so pinning its compile version to 1.2.1 is what restores compatibility, but it also means that composable can't adopt newer material3 APIs without reintroducing this problem. It's already `@Deprecated` for removal in the next major, so this is likely fine — flagging it as a real constraint rather than a free win.

Open question for reviewers: this **restores the 1.6.3 floor**. The alternative is to *raise* the documented minimum to Compose 1.8.0, which is simpler but a breaking change for users on older Compose and would need an explicit minimum-version statement in the docs. Happy to switch direction if that's preferred.
