### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: make preMerge
 
       - name: Install Sentry CLI
-        run: curl -sL https://sentry.io/get-cli/ | bash
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - name: Upload Snapshots to Sentry
         # Skip on PRs from forks, which don't have access to the upload secret

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install Sentry CLI
         if: ${{ !cancelled() && env.SAUCE_USERNAME != null }}
-        run: curl -sL https://sentry.io/get-cli/ | bash
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - name: Upload Replay Snapshots to Sentry
         # Skip on PRs from forks, which don't have access to the upload secret


### PR DESCRIPTION
## Summary
- Two "Install Sentry CLI" steps (`build.yml`, `integration-tests-ui.yml`) used `curl -sL https://sentry.io/get-cli/ | bash`, piping a remote install script directly into a shell.
- Replaced both with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.
- Preserved the existing `if:` condition on the `integration-tests-ui.yml` step.

## Test plan
- [x] Validated both workflow files parse correctly
- [ ] Verify both jobs still install sentry-cli and upload snapshots correctly on this PR

Fixes VULN-2261

🤖 Generated with [Claude Code](https://claude.com/claude-code)