### PR TITLE
feat(android): Add trace markers to SentryAndroid.init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add systrace sections to `SentryAndroid.init` for startup profiling ([#5901](https://github.com/getsentry/sentry-java/pull/5901))
+- Add a systrace section to `SentryAndroid.init` for startup profiling ([#5901](https://github.com/getsentry/sentry-java/pull/5901))
 
 ## 8.52.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add systrace sections to `SentryAndroid.init` for startup profiling ([#5901](https://github.com/getsentry/sentry-java/pull/5901))
+
 ## 8.52.0
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Features
-
-- Add a systrace section to `SentryAndroid.init` for startup profiling ([#5901](https://github.com/getsentry/sentry-java/pull/5901))
-
 ## 8.52.0
 
 ### Fixes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -96,8 +96,10 @@ public final class SentryAndroid {
       @NotNull final Context context,
       @NotNull ILogger logger,
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration) {
+    // Started before acquiring the lock so it stays balanced with the endSection() in the finally
+    // even if acquire() throws.
+    Trace.beginSection("SentryAndroid.init");
     try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
-      Trace.beginSection("SentryAndroid.init");
       Sentry.init(
           new SentryAndroidOptionsContainer(),
           options -> {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -140,7 +140,6 @@ public final class SentryAndroid {
                 isReplayAvailable,
                 isDistributionAvailable);
 
-            Trace.beginSection("SentryAndroid.init.configure");
             try {
               configuration.configure(options);
             } catch (Throwable t) {
@@ -151,8 +150,6 @@ public final class SentryAndroid {
                       SentryLevel.ERROR,
                       "Error in the 'OptionsConfiguration.configure' callback.",
                       t);
-            } finally {
-              Trace.endSection();
             }
 
             // if SentryPerformanceProvider was disabled or removed,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -5,6 +5,7 @@ import android.app.Application;
 import android.content.Context;
 import android.os.Process;
 import android.os.SystemClock;
+import android.os.Trace;
 import io.sentry.ILogger;
 import io.sentry.IScopes;
 import io.sentry.ISentryLifecycleToken;
@@ -96,6 +97,7 @@ public final class SentryAndroid {
       @NotNull ILogger logger,
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration) {
     try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
+      Trace.beginSection("SentryAndroid.init");
       Sentry.init(
           new SentryAndroidOptionsContainer(),
           options -> {
@@ -138,6 +140,7 @@ public final class SentryAndroid {
                 isReplayAvailable,
                 isDistributionAvailable);
 
+            Trace.beginSection("SentryAndroid.init.configure");
             try {
               configuration.configure(options);
             } catch (Throwable t) {
@@ -148,6 +151,8 @@ public final class SentryAndroid {
                       SentryLevel.ERROR,
                       "Error in the 'OptionsConfiguration.configure' callback.",
                       t);
+            } finally {
+              Trace.endSection();
             }
 
             // if SentryPerformanceProvider was disabled or removed,
@@ -219,6 +224,8 @@ public final class SentryAndroid {
       logger.log(SentryLevel.FATAL, "Fatal error during SentryAndroid.init(...)", e);
 
       throw new RuntimeException("Failed to initialize Sentry's SDK", e);
+    } finally {
+      Trace.endSection();
     }
   }
 


### PR DESCRIPTION
## :scroll: Description

Adds a `android.os.Trace` section around `SentryAndroid.init`, so we can benchmark this in a Perfetto trace / Macrobenchmark.

**Cost:** negligible. When no trace is recording (i.e. essentially always, in production), `Trace.beginSection`/`endSection` is a cached in-process flag check — no JNI, no allocation, and the section name is a constant. It's one begin/end pair on the existing try/catch: no new `try` blocks and no API change.

## :bulb: Motivation and Context

So we can add a Macrobenchmark that measures the `SentryAndroid.init` slice and tracks SDK startup cost across releases, letting us catch regressions. Resolves JAVA-685.

## :green_heart: How did you test it?

`./gradlew :sentry-android-core:testReleaseUnitTest --tests "*SentryAndroidTest*"` passes (Robolectric no-ops `android.os.Trace`, so init still succeeds). The `SentryAndroid.init` slice still needs to be confirmed in a Perfetto capture.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog
