### PR TITLE
fix(core): Clear contexts on Scope.clear()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))
 - Preserve custom `Throwable` identities when R8 optimizes Android apps ([#5881](https://github.com/getsentry/sentry-java/pull/5881))
 
 ## 8.52.0

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -227,6 +227,7 @@ public final class io/sentry/CheckInStatus : java/lang/Enum {
 
 public final class io/sentry/CombinedContextsView : io/sentry/protocol/Contexts {
 	public fun <init> (Lio/sentry/protocol/Contexts;Lio/sentry/protocol/Contexts;Lio/sentry/protocol/Contexts;Lio/sentry/ScopeType;)V
+	public fun clear ()V
 	public fun containsKey (Ljava/lang/Object;)Z
 	public fun entrySet ()Ljava/util/Set;
 	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
@@ -5795,6 +5796,7 @@ public class io/sentry/protocol/Contexts : io/sentry/JsonSerializable {
 	protected final field responseLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/protocol/Contexts;)V
+	public fun clear ()V
 	public fun containsKey (Ljava/lang/Object;)Z
 	public fun entrySet ()Ljava/util/Set;
 	public fun equals (Ljava/lang/Object;)Z

--- a/sentry/src/main/java/io/sentry/CombinedContextsView.java
+++ b/sentry/src/main/java/io/sentry/CombinedContextsView.java
@@ -294,6 +294,11 @@ public final class CombinedContextsView extends Contexts {
   }
 
   @Override
+  public void clear() {
+    getDefaultContexts().clear();
+  }
+
+  @Override
   public @NotNull Enumeration<String> keys() {
     return mergeContexts().keys();
   }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -575,10 +575,15 @@ public final class Scope implements IScope {
     tags.clear();
     attributes.clear();
     extra.clear();
+    contexts.clear();
     eventProcessors.clear();
     clearTransaction();
     clearAttachments();
     clearFeatureFlags();
+
+    for (final IScopeObserver observer : options.getScopeObservers()) {
+      observer.setContexts(contexts);
+    }
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/protocol/Contexts.java
+++ b/sentry/src/main/java/io/sentry/protocol/Contexts.java
@@ -248,6 +248,10 @@ public class Contexts implements JsonSerializable {
     return internalStorage.remove(key);
   }
 
+  public void clear() {
+    internalStorage.clear();
+  }
+
   public @NotNull Enumeration<String> keys() {
     return internalStorage.keys();
   }

--- a/sentry/src/test/java/io/sentry/CombinedContextsViewTest.kt
+++ b/sentry/src/test/java/io/sentry/CombinedContextsViewTest.kt
@@ -606,6 +606,20 @@ class CombinedContextsViewTest {
   }
 
   @Test
+  fun `clear clears default context only`() {
+    val combined = fixture.getSut()
+    fixture.current.put("test", "current")
+    fixture.isolation.put("test", "isolation")
+    fixture.global.put("test", "global")
+
+    combined.clear()
+
+    assertEquals("current", fixture.current.get("test"))
+    assertNull(fixture.isolation.get("test"))
+    assertEquals("global", fixture.global.get("test"))
+  }
+
+  @Test
   fun `set null value on context does not cause exception`() {
     val combined = fixture.getSut()
     combined.set("k", null)

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -292,6 +292,7 @@ class ScopeTest {
     scope.screen = "MainActivity"
     scope.setExtra("some", "extra")
     scope.setAttribute("some", "attribute")
+    scope.setContexts("some", "context")
     scope.addEventProcessor(eventProcessor())
     scope.addAttachment(Attachment("path"))
     scope.addFeatureFlag("flag", true)
@@ -308,6 +309,7 @@ class ScopeTest {
     assertEquals(0, scope.tags.size)
     assertEquals(0, scope.attributes.size)
     assertEquals(0, scope.extras.size)
+    assertTrue(scope.contexts.isEmpty)
     assertEquals(0, scope.eventProcessors.size)
     assertEquals(0, scope.attachments.size)
     assertEquals(0, scope.featureFlags!!.values.size)
@@ -884,6 +886,21 @@ class ScopeTest {
     data class Obj(val stuff: Int)
     scope.setContexts("test", Obj(3))
     verify(observer).setContexts(argThat { (get("test") as Obj).stuff == 3 })
+  }
+
+  @Test
+  fun `Scope clear contexts sync scopes`() {
+    val observer = mock<IScopeObserver>()
+    val options = SentryOptions().apply { addScopeObserver(observer) }
+    val scope = Scope(options)
+
+    // Populate the live contexts directly so the observer is only notified by clear().
+    scope.contexts.set("test", "value")
+    assertFalse(scope.contexts.isEmpty)
+
+    scope.clear()
+    assertTrue(scope.contexts.isEmpty)
+    verify(observer).setContexts(argThat { isEmpty })
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/protocol/ContextsTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/ContextsTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
 
 class ContextsTest {
   @Test
@@ -136,5 +137,16 @@ class ContextsTest {
     contexts.putAll(map)
 
     assertEquals(listOf("a"), contexts.keys().toList())
+  }
+
+  @Test
+  fun `clear removes all entries from context`() {
+    val contexts = Contexts()
+    contexts.put("a", "1")
+    contexts.put("b", "2")
+
+    contexts.clear()
+
+    assertTrue(contexts.isEmpty)
   }
 }


### PR DESCRIPTION
## :scroll: Description

`Scope.clear()` reset every field on the scope except `contexts`, so anything set via `setContexts(...)` survived a `clear()`. The root cause is that `Contexts` had no `clear()` method (unlike the `tags`, `extra`, and `fingerprint` collections that `clear()` already resets), so contexts were simply left untouched.

This PR:
- Adds `Contexts.clear()`.
- Overrides `clear()` in `CombinedContextsView` to delegate to the default context, consistent with how `put`/`remove` already delegate (otherwise `clear()` on the view would no-op against its always-empty inherited storage).
- Clears contexts in `Scope.clear()` and notifies scope observers with the now-empty contexts, so persisted scopes (e.g. Android's scope-on-disk used for native crashes) stay in sync — matching what `setContexts`/`clearBreadcrumbs` already do.

## :bulb: Motivation and Context

Reported while adding the scopes API to the Godot Engine (hybrid) SDK: `clear()` cleared everything except contexts, forcing a [manual workaround](https://github.com/getsentry/sentry-godot/blob/497f94e02023358a81391eea529193456e0b12cd/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt#L943-L948) that removes each context key by hand.

Fixes GH-5894
Fixes JAVA-683

## :green_heart: How did you test it?

Added unit tests:
- `ContextsTest` — `clear()` empties the contexts.
- `CombinedContextsViewTest` — `clear()` clears only the default context.
- `ScopeTest` — extended the reset test to cover contexts, plus a new test verifying `clear()` notifies scope observers with empty contexts.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Hybrid SDKs (e.g. Godot) can drop their manual context-clearing workaround once this ships.
