### PR TITLE
perf(android): Defer Session Replay start off SDK init critical path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Performance
+
+- Defer starting Session Replay off the `Sentry.init` critical path to reduce app start time ([#5904](https://github.com/getsentry/sentry-java/pull/5904))
+
 ### Fixes
 
 - Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -3,6 +3,8 @@ package io.sentry.android.core;
 import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Process;
 import android.os.SystemClock;
 import android.os.Trace;
@@ -203,7 +205,11 @@ public final class SentryAndroid {
             scopes.startSession();
           }
         }
-        scopes.getOptions().getReplayController().start();
+        // Defer starting replay off the SDK init critical path so it doesn't add to app start
+        // time. start() is idempotent, so the later start() from the app lifecycle integration
+        // (once the first activity is in foreground) is a no-op if this one ran first.
+        new Handler(Looper.getMainLooper())
+            .post(() -> scopes.getOptions().getReplayController().start());
       }
     } catch (IllegalAccessException e) {
       logger.log(SentryLevel.FATAL, "Fatal error during SentryAndroid.init(...)", e);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -352,6 +352,8 @@ class SentryAndroidTest {
   @Config(sdk = [26])
   fun `init starts session replay if app is in foreground`() {
     initSentryWithForegroundImportance(true) { _ ->
+      // replay start is posted to the main looper, so drain it before asserting
+      Shadows.shadowOf(Looper.getMainLooper()).idle()
       assertTrue(Sentry.getCurrentHub().options.replayController.isRecording())
     }
   }


### PR DESCRIPTION
## :scroll: Description

This posts the Session Replay start to a new Handler, delaying the start of the Session Replay. This just speeds up the `SentryAndroid.init` but the work is just done later.

Alternatively, we could try moving some of that work to a background thread to move the work off the main thread but this is a one line easy change.

Benchmark results shows this speeds up the SDK start by another `10%`!!

## :bulb: Motivation and Context

Reduce the main-thread work performed synchronously during `Sentry.init`, improving SDK startup time on Android when Session Replay is enabled.

## :green_heart: How did you test it?

**Device benchmark (Pixel 3, `sentry-samples-android`, Session Replay at `session-sample-rate = 1.0`):** ran the `sentry-uitest-android-macrobenchmark` cold-start benchmark (`CompilationMode.Full`, `StartupMode.COLD`), A/B-ing baseline vs. this change in two interleaved rounds of 12 iterations each (first iteration per round dropped as a class-load outlier).

The change lifts ~8.6 ms of synchronous work off the init critical path. Measured on the traced `SentryAndroid.init` section (the `start()` work now runs outside it):

| `SentryAndroid.init` slice | median | mean | min | max |
|---|---|---|---|---|
| baseline (inline `start()`) | 80.3 ms | 81.3 | 75.8 | 89.3 |
| this change (posted `start()`) | **71.7 ms** | 72.9 | 67.8 | 96.2 |

**Δ median ≈ −8.6 ms (~11%)**, consistent in both interleaved rounds (−5.5 ms, −11.7 ms), so it is not thermal drift.

Whole-app `timeToInitialDisplay` trended slightly faster (median 1330 → 1312 ms, tighter tail) but the ranges overlap — within cold-start noise for a change this small, as the benchmark README notes. So the init-section reduction is the reliable signal, not TTID.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
