### PR TITLE
feat(core): Add ExceptionUtils.handleFatal to rethrow non-recoverable throwables

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7705,6 +7705,7 @@ public final class io/sentry/util/EventSizeLimitingUtils {
 public final class io/sentry/util/ExceptionUtils {
 	public fun <init> ()V
 	public static fun findRootCause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
+	public static fun handleFatal (Ljava/lang/Throwable;)V
 	public static fun isIgnored (Ljava/util/Set;Ljava/lang/Throwable;)Z
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7705,8 +7705,8 @@ public final class io/sentry/util/EventSizeLimitingUtils {
 public final class io/sentry/util/ExceptionUtils {
 	public fun <init> ()V
 	public static fun findRootCause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
-	public static fun handleFatal (Ljava/lang/Throwable;)V
 	public static fun isIgnored (Ljava/util/Set;Ljava/lang/Throwable;)Z
+	public static fun rethrowIfFatal (Ljava/lang/Throwable;)V
 }
 
 public final class io/sentry/util/FileUtils {

--- a/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
@@ -29,4 +29,24 @@ public final class ExceptionUtils {
       final @NotNull Throwable throwable) {
     return ignoredExceptionsForType.contains(throwable.getClass());
   }
+
+  /**
+   * Handles non-recoverable {@link Throwable}s that should never be swallowed. Rethrows {@link
+   * VirtualMachineError} (e.g. OutOfMemoryError/StackOverflowError) and {@link ThreadDeath} as-is.
+   * For {@link InterruptedException}, restores the thread's interrupted status instead of
+   * rethrowing, since it is a checked exception. All other throwables are left untouched for the
+   * caller to handle/log/ignore as before.
+   *
+   * @param throwable - the throwable to check
+   */
+  public static void handleFatal(final @NotNull Throwable throwable) {
+    // VirtualMachineError covers OutOfMemoryError, StackOverflowError, InternalError, and
+    // UnknownError
+    if (throwable instanceof VirtualMachineError || throwable instanceof ThreadDeath) {
+      throw (Error) throwable;
+    }
+    if (throwable instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+    }
+  }
 }

--- a/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
@@ -32,17 +32,27 @@ public final class ExceptionUtils {
 
   /**
    * Rethrows non-recoverable {@link Throwable}s that should never be swallowed: {@link
-   * VirtualMachineError} (e.g. OutOfMemoryError/StackOverflowError) and {@link ThreadDeath} are
-   * rethrown as-is. For {@link InterruptedException}, the thread's interrupted status is restored
-   * instead of rethrowing, since it is a checked exception. All other throwables are left untouched
-   * for the caller to handle/log/ignore as before.
+   * VirtualMachineError} (e.g. OutOfMemoryError/StackOverflowError), {@link ThreadDeath} and {@link
+   * LinkageError} are rethrown as-is. For {@link InterruptedException}, the thread's interrupted
+   * status is restored instead of rethrowing, since it is a checked exception. All other throwables
+   * are left untouched for the caller to handle/log/ignore as before.
+   *
+   * <p>Note on {@link LinkageError}: its subclasses (e.g. {@link NoClassDefFoundError}, {@link
+   * NoSuchMethodError}, {@link AbstractMethodError}, {@link UnsatisfiedLinkError}) are also the
+   * expected runtime signal for a missing or version-mismatched optional dependency, which is a
+   * normal condition for integrations built against {@code compileOnly} dependencies. Call sites
+   * that probe for such a dependency must catch the relevant {@link LinkageError} subclass locally
+   * <em>before</em> delegating to this method — see {@code SentrySQLiteDriver.hasConnectionPool}
+   * and {@link LoadClass} for examples.
    *
    * @param throwable - the throwable to check
    */
   public static void rethrowIfFatal(final @NotNull Throwable throwable) {
     // VirtualMachineError covers OutOfMemoryError, StackOverflowError, InternalError, and
     // UnknownError
-    if (throwable instanceof VirtualMachineError || throwable instanceof ThreadDeath) {
+    if (throwable instanceof VirtualMachineError
+        || throwable instanceof ThreadDeath
+        || throwable instanceof LinkageError) {
       throw (Error) throwable;
     }
     if (throwable instanceof InterruptedException) {

--- a/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
@@ -31,15 +31,15 @@ public final class ExceptionUtils {
   }
 
   /**
-   * Handles non-recoverable {@link Throwable}s that should never be swallowed. Rethrows {@link
-   * VirtualMachineError} (e.g. OutOfMemoryError/StackOverflowError) and {@link ThreadDeath} as-is.
-   * For {@link InterruptedException}, restores the thread's interrupted status instead of
-   * rethrowing, since it is a checked exception. All other throwables are left untouched for the
-   * caller to handle/log/ignore as before.
+   * Rethrows non-recoverable {@link Throwable}s that should never be swallowed: {@link
+   * VirtualMachineError} (e.g. OutOfMemoryError/StackOverflowError) and {@link ThreadDeath} are
+   * rethrown as-is. For {@link InterruptedException}, the thread's interrupted status is restored
+   * instead of rethrowing, since it is a checked exception. All other throwables are left untouched
+   * for the caller to handle/log/ignore as before.
    *
    * @param throwable - the throwable to check
    */
-  public static void handleFatal(final @NotNull Throwable throwable) {
+  public static void rethrowIfFatal(final @NotNull Throwable throwable) {
     // VirtualMachineError covers OutOfMemoryError, StackOverflowError, InternalError, and
     // UnknownError
     if (throwable instanceof VirtualMachineError || throwable instanceof ThreadDeath) {

--- a/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
@@ -1,9 +1,11 @@
 package io.sentry.util
 
+import com.google.common.truth.Truth.assertThat
 import java.lang.RuntimeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -35,6 +37,27 @@ class ExceptionUtilsTest {
   @Test
   fun `rethrowIfFatal rethrows ThreadDeath`() {
     assertFails { ExceptionUtils.rethrowIfFatal(ThreadDeath()) }
+  }
+
+  @Test
+  fun `rethrowIfFatal rethrows NoClassDefFoundError as-is`() {
+    val error = NoClassDefFoundError()
+    val thrown = assertFailsWith<NoClassDefFoundError> { ExceptionUtils.rethrowIfFatal(error) }
+    assertThat(thrown).isSameInstanceAs(error)
+  }
+
+  @Test
+  fun `rethrowIfFatal rethrows NoSuchMethodError as-is`() {
+    val error = NoSuchMethodError()
+    val thrown = assertFailsWith<NoSuchMethodError> { ExceptionUtils.rethrowIfFatal(error) }
+    assertThat(thrown).isSameInstanceAs(error)
+  }
+
+  @Test
+  fun `rethrowIfFatal rethrows UnsatisfiedLinkError as-is`() {
+    val error = UnsatisfiedLinkError()
+    val thrown = assertFailsWith<UnsatisfiedLinkError> { ExceptionUtils.rethrowIfFatal(error) }
+    assertThat(thrown).isSameInstanceAs(error)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
@@ -3,6 +3,9 @@ package io.sentry.util
 import java.lang.RuntimeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ExceptionUtilsTest {
   @Test
@@ -17,5 +20,37 @@ class ExceptionUtilsTest {
     val cause = RuntimeException(rootCause)
     val ex = RuntimeException(cause)
     assertEquals(rootCause, ExceptionUtils.findRootCause(ex))
+  }
+
+  @Test
+  fun `handleFatal rethrows OutOfMemoryError`() {
+    assertFails { ExceptionUtils.handleFatal(OutOfMemoryError()) }
+  }
+
+  @Test
+  fun `handleFatal rethrows StackOverflowError`() {
+    assertFails { ExceptionUtils.handleFatal(StackOverflowError()) }
+  }
+
+  @Test
+  fun `handleFatal rethrows ThreadDeath`() {
+    assertFails { ExceptionUtils.handleFatal(ThreadDeath()) }
+  }
+
+  @Test
+  fun `handleFatal restores interrupt flag for InterruptedException without rethrowing`() {
+    try {
+      ExceptionUtils.handleFatal(InterruptedException())
+      assertTrue(Thread.currentThread().isInterrupted)
+    } finally {
+      // clear the interrupt flag so it doesn't leak into other tests
+      Thread.interrupted()
+    }
+  }
+
+  @Test
+  fun `handleFatal does nothing for regular exceptions`() {
+    ExceptionUtils.handleFatal(RuntimeException())
+    assertFalse(Thread.currentThread().isInterrupted)
   }
 }

--- a/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
@@ -23,24 +23,24 @@ class ExceptionUtilsTest {
   }
 
   @Test
-  fun `handleFatal rethrows OutOfMemoryError`() {
-    assertFails { ExceptionUtils.handleFatal(OutOfMemoryError()) }
+  fun `rethrowIfFatal rethrows OutOfMemoryError`() {
+    assertFails { ExceptionUtils.rethrowIfFatal(OutOfMemoryError()) }
   }
 
   @Test
-  fun `handleFatal rethrows StackOverflowError`() {
-    assertFails { ExceptionUtils.handleFatal(StackOverflowError()) }
+  fun `rethrowIfFatal rethrows StackOverflowError`() {
+    assertFails { ExceptionUtils.rethrowIfFatal(StackOverflowError()) }
   }
 
   @Test
-  fun `handleFatal rethrows ThreadDeath`() {
-    assertFails { ExceptionUtils.handleFatal(ThreadDeath()) }
+  fun `rethrowIfFatal rethrows ThreadDeath`() {
+    assertFails { ExceptionUtils.rethrowIfFatal(ThreadDeath()) }
   }
 
   @Test
-  fun `handleFatal restores interrupt flag for InterruptedException without rethrowing`() {
+  fun `rethrowIfFatal restores interrupt flag for InterruptedException without rethrowing`() {
     try {
-      ExceptionUtils.handleFatal(InterruptedException())
+      ExceptionUtils.rethrowIfFatal(InterruptedException())
       assertTrue(Thread.currentThread().isInterrupted)
     } finally {
       // clear the interrupt flag so it doesn't leak into other tests
@@ -49,8 +49,8 @@ class ExceptionUtilsTest {
   }
 
   @Test
-  fun `handleFatal does nothing for regular exceptions`() {
-    ExceptionUtils.handleFatal(RuntimeException())
+  fun `rethrowIfFatal does nothing for regular exceptions`() {
+    ExceptionUtils.rethrowIfFatal(RuntimeException())
     assertFalse(Thread.currentThread().isInterrupted)
   }
 }


### PR DESCRIPTION
## Summary

Adds `ExceptionUtils.handleFatal(Throwable)`, a small utility for use inside broad `catch (Throwable t)` blocks. It rethrows `VirtualMachineError` (e.g. `OutOfMemoryError`, `StackOverflowError`) and `ThreadDeath` as-is, and restores the thread's interrupt flag for `InterruptedException` instead of swallowing it. All other throwables are left untouched for the caller to handle as before.

Closes getsentry/sentry-java#5865

#skip-changelog