### PR TITLE
fix(core): [Unhandled Sessions 2] Make session cache writes session-id aware

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4862,6 +4862,7 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	public static fun getPreviousSessionFile (Ljava/lang/String;)Ljava/io/File;
 	public fun iterator ()Ljava/util/Iterator;
 	public fun movePreviousSession (Ljava/io/File;Ljava/io/File;)V
+	public fun persistCurrentSession (Lio/sentry/Session;)V
 	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 	public fun storeEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Z
 	public fun waitPreviousSessionFlush ()Z

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -122,17 +122,17 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
         final @Nullable Session endingSession = readSessionFromEnvelope(envelope);
         final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
-        final boolean preservePendingSession =
+        final boolean preserveCurrentSession =
             endingSession != null
                 && currentSession != null
-                && currentSession.isPendingUnhandled()
+                && currentSession.hasNonTerminatingUnhandledError()
                 && endingSession.getSessionId() != null
                 && currentSession.getSessionId() != null
                 && !Objects.equals(endingSession.getSessionId(), currentSession.getSessionId())
                 && endingSession.getStarted() != null
                 && currentSession.getStarted() != null
                 && currentSession.getStarted().after(endingSession.getStarted());
-        if (!preservePendingSession && !currentSessionFile.delete()) {
+        if (!preserveCurrentSession && !currentSessionFile.delete()) {
           options.getLogger().log(WARNING, "Current envelope doesn't exist.");
         }
       }
@@ -149,7 +149,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         if (startingSession != null) {
           final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
           if (currentSession != null && hasSameSessionId(currentSession, startingSession)) {
-            if (!isNewerPendingOrErrorSnapshot(currentSession, startingSession)) {
+            if (!isNewerUnhandledOrErrorSnapshot(currentSession, startingSession)) {
               writeSessionToDisk(currentSessionFile, startingSession);
             }
           } else {
@@ -355,9 +355,10 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
   }
 
-  private boolean isNewerPendingOrErrorSnapshot(
+  private boolean isNewerUnhandledOrErrorSnapshot(
       final @NotNull Session currentSession, final @NotNull Session startingSession) {
-    return (currentSession.isPendingUnhandled() && !startingSession.isPendingUnhandled())
+    return (currentSession.hasNonTerminatingUnhandledError()
+            && !startingSession.hasNonTerminatingUnhandledError())
         || currentSession.errorCount() > startingSession.errorCount();
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -106,6 +106,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     return storeInternal(envelope, hint);
   }
 
+  @SuppressWarnings("JavaUtilDate")
   private boolean storeInternal(final @NotNull SentryEnvelope envelope, final @NotNull Hint hint) {
     Objects.requireNonNull(envelope, "Envelope is required.");
 
@@ -118,8 +119,22 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     final File previousSessionFile = getPreviousSessionFile(directoryPath);
 
     if (HintUtils.hasType(hint, SessionEnd.class)) {
-      if (!currentSessionFile.delete()) {
-        options.getLogger().log(WARNING, "Current envelope doesn't exist.");
+      try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+        final @Nullable Session endingSession = readSessionFromEnvelope(envelope);
+        final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
+        final boolean preservePendingSession =
+            endingSession != null
+                && currentSession != null
+                && currentSession.isPendingUnhandled()
+                && endingSession.getSessionId() != null
+                && currentSession.getSessionId() != null
+                && !Objects.equals(endingSession.getSessionId(), currentSession.getSessionId())
+                && endingSession.getStarted() != null
+                && currentSession.getStarted() != null
+                && currentSession.getStarted().after(endingSession.getStarted());
+        if (!preservePendingSession && !currentSessionFile.delete()) {
+          options.getLogger().log(WARNING, "Current envelope doesn't exist.");
+        }
       }
     }
 
@@ -129,8 +144,22 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
 
     if (HintUtils.hasType(hint, SessionStart.class)) {
-      movePreviousSession(currentSessionFile, previousSessionFile);
-      updateCurrentSession(currentSessionFile, envelope);
+      try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+        final @Nullable Session startingSession = readSessionFromEnvelope(envelope);
+        if (startingSession != null) {
+          final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
+          if (currentSession != null && hasSameSessionId(currentSession, startingSession)) {
+            if (!isNewerPendingOrErrorSnapshot(currentSession, startingSession)) {
+              writeSessionToDisk(currentSessionFile, startingSession);
+            }
+          } else {
+            movePreviousSession(currentSessionFile, previousSessionFile);
+            writeSessionToDisk(currentSessionFile, startingSession);
+          }
+        } else {
+          movePreviousSession(currentSessionFile, previousSessionFile);
+        }
+      }
 
       boolean crashedLastRun = false;
       final File crashMarkerFile = new File(options.getCacheDirPath(), NATIVE_CRASH_MARKER_FILE);
@@ -274,8 +303,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
   }
 
-  private void updateCurrentSession(
-      final @NotNull File currentSessionFile, final @NotNull SentryEnvelope envelope) {
+  private @Nullable Session readSessionFromEnvelope(final @NotNull SentryEnvelope envelope) {
     final Iterable<SentryEnvelopeItem> items = envelope.getItems();
 
     // we know that an envelope with a SessionStart hint has a single item inside
@@ -295,7 +323,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
                     "Item of type %s returned null by the parser.",
                     item.getHeader().getType());
           } else {
-            writeSessionToDisk(currentSessionFile, session);
+            return session;
           }
         } catch (Throwable e) {
           options.getLogger().log(ERROR, "Item failed to process.", e);
@@ -309,10 +337,35 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
                 item.getHeader().getType());
       }
     } else {
-      options
-          .getLogger()
-          .log(INFO, "Current envelope %s is empty", currentSessionFile.getAbsolutePath());
+      options.getLogger().log(INFO, "Current envelope is empty.");
     }
+    return null;
+  }
+
+  private @Nullable Session readSessionFromDisk(final @NotNull File sessionFile) {
+    if (!sessionFile.exists()) {
+      return null;
+    }
+    try (final Reader reader =
+        new BufferedReader(new InputStreamReader(new FileInputStream(sessionFile), UTF_8))) {
+      return serializer.getValue().deserialize(reader, Session.class);
+    } catch (Exception e) {
+      options.getLogger().log(ERROR, "Failed to read session from disk.", e);
+      return null;
+    }
+  }
+
+  private boolean isNewerPendingOrErrorSnapshot(
+      final @NotNull Session currentSession, final @NotNull Session startingSession) {
+    return (currentSession.isPendingUnhandled() && !startingSession.isPendingUnhandled())
+        || currentSession.errorCount() > startingSession.errorCount();
+  }
+
+  private boolean hasSameSessionId(
+      final @NotNull Session firstSession, final @NotNull Session secondSession) {
+    return firstSession.getSessionId() != null
+        && secondSession.getSessionId() != null
+        && Objects.equals(firstSession.getSessionId(), secondSession.getSessionId());
   }
 
   private boolean writeEnvelopeToDisk(
@@ -349,6 +402,13 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       options
           .getLogger()
           .log(ERROR, e, "Error writing Session to offline storage: %s", session.getSessionId());
+    }
+  }
+
+  @ApiStatus.Internal
+  public void persistCurrentSession(final @NotNull Session session) {
+    try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+      writeSessionToDisk(getCurrentSessionFile(directory.getOrCreate().getAbsolutePath()), session);
     }
   }
 

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.cache
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.DateUtils
 import io.sentry.Hint
 import io.sentry.ILogger
@@ -158,6 +159,213 @@ class EnvelopeCacheTest {
 
     file.deleteRecursively()
     assertTrue(didStore)
+  }
+
+  @Test
+  fun `delayed same SID SessionStart preserves newer pending snapshot`() {
+    val cache = fixture.getSUT()
+    val sid = SentryUUID.generateSentryId()
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val newerSession = createSession(sessionId = sid)
+    newerSession.markPendingUnhandled()
+    cache.persistCurrentSession(newerSession)
+
+    val delayedStart = createSession(sessionId = sid)
+    val envelope = SentryEnvelope.from(fixture.options.serializer, delayedStart, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val persistedSession =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedSession.sessionId).isEqualTo(sid)
+    assertThat(persistedSession.isPendingUnhandled).isTrue()
+    assertThat(persistedSession.errorCount()).isEqualTo(1)
+    assertThat(previousSessionFile.exists()).isFalse()
+  }
+
+  @Test
+  fun `delayed same SID SessionStart preserves newer error count snapshot`() {
+    val cache = fixture.getSUT()
+    val sid = SentryUUID.generateSentryId()
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val newerSession = createSession(sessionId = sid)
+    newerSession.update(null, null, true)
+    cache.persistCurrentSession(newerSession)
+
+    val delayedStart = createSession(sessionId = sid)
+    val envelope = SentryEnvelope.from(fixture.options.serializer, delayedStart, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val persistedSession =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedSession.sessionId).isEqualTo(sid)
+    assertThat(persistedSession.isPendingUnhandled).isFalse()
+    assertThat(persistedSession.errorCount()).isEqualTo(1)
+    assertThat(previousSessionFile.exists()).isFalse()
+  }
+
+  @Test
+  fun `null SIDs on SessionStart rotate instead of preserving as same session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession(sessionId = null)
+    currentSession.update(null, null, true)
+    cache.persistCurrentSession(currentSession)
+    val startingSession = createSession(sessionId = null)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, startingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val persistedCurrent =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    val persistedPrevious =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedCurrent.sessionId).isNull()
+    assertThat(persistedCurrent.errorCount()).isEqualTo(0)
+    assertThat(persistedPrevious.sessionId).isNull()
+    assertThat(persistedPrevious.errorCount()).isEqualTo(1)
+  }
+
+  @Test
+  fun `different SID SessionStart rotates current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+    val nextSession = createSession()
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, nextSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val persistedCurrent =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    val persistedPrevious =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedCurrent.sessionId).isEqualTo(nextSession.sessionId)
+    assertThat(persistedPrevious.sessionId).isEqualTo(currentSession.sessionId)
+  }
+
+  @Test
+  fun `matching SessionEnd deletes current session`() {
+    val cache = fixture.getSUT()
+    val session = createSession()
+    cache.persistCurrentSession(session)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, session, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `mismatching SessionEnd preserves newer pending current session`() {
+    val cache = fixture.getSUT()
+    val endingSession = createSession(started = Date(1_000))
+    val currentSession = createSession(started = Date(2_000))
+    currentSession.markPendingUnhandled()
+    cache.persistCurrentSession(currentSession)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val persistedSession =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedSession.sessionId).isEqualTo(currentSession.sessionId)
+  }
+
+  @Test
+  fun `mismatching newer SessionEnd deletes stale pending current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession(started = Date(1_000))
+    currentSession.markPendingUnhandled()
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession(started = Date(2_000))
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `mismatching SessionEnd deletes non-pending current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession()
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `null SIDs on SessionEnd delete current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession(sessionId = null)
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession(sessionId = null)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `malformed SessionEnd deletes current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+
+    val envelope = SentryEnvelope(null, null, emptyList())
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `unreadable current session on SessionEnd is deleted`() {
+    val cache = fixture.getSUT()
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    currentSessionFile.writeText("not-a-session")
+
+    val endingSession = createSession()
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(currentSessionFile.exists()).isFalse()
   }
 
   @Test
@@ -347,6 +555,36 @@ class EnvelopeCacheTest {
   }
 
   @Test
+  fun `AbnormalExit hint keeps persisted pending session as abnormal`() {
+    val cache = fixture.getSUT()
+
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val session = createSession().apply { setPendingUnhandled(true) }
+    fixture.options.serializer.serialize(session, previousSessionFile.bufferedWriter())
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null)
+    val abnormalHint =
+      object : AbnormalExit {
+        override fun mechanism(): String = "abnormal_mechanism"
+
+        override fun ignoreCurrentThread(): Boolean = false
+
+        override fun timestamp(): Long = session.started!!.time + TimeUnit.HOURS.toMillis(1)
+      }
+    val hints = HintUtils.createWithTypeCheckHint(abnormalHint)
+    cache.storeEnvelope(envelope, hints)
+
+    val updatedSession =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )
+    assertEquals(State.Abnormal, updatedSession!!.status)
+    assertEquals("abnormal_mechanism", updatedSession.abnormalMechanism)
+    assertTrue(updatedSession.isPendingUnhandled)
+  }
+
+  @Test
   fun `when AbnormalExit happened before previous session start, does not mark as abnormal`() {
     val cache = fixture.getSUT()
 
@@ -401,6 +639,29 @@ class EnvelopeCacheTest {
   }
 
   @Test
+  fun `NativeCrashExit hint keeps persisted pending session as crashed`() {
+    val cache = fixture.getSUT()
+
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val session = createSession().apply { setPendingUnhandled(true) }
+    fixture.options.serializer.serialize(session, previousSessionFile.bufferedWriter())
+
+    val nativeCrashTimestamp = session.started!!.time + TimeUnit.HOURS.toMillis(1)
+    val envelope = SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null)
+    val hints = HintUtils.createWithTypeCheckHint(NativeCrashExit { nativeCrashTimestamp })
+    cache.storeEnvelope(envelope, hints)
+
+    val updatedSession =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )
+    assertEquals(State.Crashed, updatedSession!!.status)
+    assertEquals(nativeCrashTimestamp, updatedSession.timestamp!!.time)
+    assertFalse(updatedSession.isPendingUnhandled)
+  }
+
+  @Test
   fun `when NativeCrashExit happened before previous session start, does not mark as crashed`() {
     val cache = fixture.getSUT()
 
@@ -438,14 +699,17 @@ class EnvelopeCacheTest {
     assertFalse(didStore)
   }
 
-  private fun createSession(started: Date? = null): Session =
+  private fun createSession(
+    started: Date? = null,
+    sessionId: String? = SentryUUID.generateSentryId(),
+  ): Session =
     Session(
       Ok,
       started ?: DateUtils.getCurrentDateTime(),
       DateUtils.getCurrentDateTime(),
       0,
       "dis",
-      SentryUUID.generateSentryId(),
+      sessionId,
       true,
       null,
       null,

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -162,13 +162,13 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `delayed same SID SessionStart preserves newer pending snapshot`() {
+  fun `delayed same SID SessionStart preserves newer unhandled snapshot`() {
     val cache = fixture.getSUT()
     val sid = SentryUUID.generateSentryId()
     val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
     val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
     val newerSession = createSession(sessionId = sid)
-    newerSession.markPendingUnhandled()
+    newerSession.recordNonTerminatingUnhandledError()
     cache.persistCurrentSession(newerSession)
 
     val delayedStart = createSession(sessionId = sid)
@@ -181,7 +181,7 @@ class EnvelopeCacheTest {
         Session::class.java,
       )!!
     assertThat(persistedSession.sessionId).isEqualTo(sid)
-    assertThat(persistedSession.isPendingUnhandled).isTrue()
+    assertThat(persistedSession.hasNonTerminatingUnhandledError()).isTrue()
     assertThat(persistedSession.errorCount()).isEqualTo(1)
     assertThat(previousSessionFile.exists()).isFalse()
   }
@@ -206,7 +206,7 @@ class EnvelopeCacheTest {
         Session::class.java,
       )!!
     assertThat(persistedSession.sessionId).isEqualTo(sid)
-    assertThat(persistedSession.isPendingUnhandled).isFalse()
+    assertThat(persistedSession.hasNonTerminatingUnhandledError()).isFalse()
     assertThat(persistedSession.errorCount()).isEqualTo(1)
     assertThat(previousSessionFile.exists()).isFalse()
   }
@@ -280,11 +280,11 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `mismatching SessionEnd preserves newer pending current session`() {
+  fun `mismatching SessionEnd preserves newer unhandled current session`() {
     val cache = fixture.getSUT()
     val endingSession = createSession(started = Date(1_000))
     val currentSession = createSession(started = Date(2_000))
-    currentSession.markPendingUnhandled()
+    currentSession.recordNonTerminatingUnhandledError()
     cache.persistCurrentSession(currentSession)
 
     val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
@@ -300,10 +300,10 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `mismatching newer SessionEnd deletes stale pending current session`() {
+  fun `mismatching newer SessionEnd deletes stale unhandled current session`() {
     val cache = fixture.getSUT()
     val currentSession = createSession(started = Date(1_000))
-    currentSession.markPendingUnhandled()
+    currentSession.recordNonTerminatingUnhandledError()
     cache.persistCurrentSession(currentSession)
     val endingSession = createSession(started = Date(2_000))
 
@@ -315,7 +315,7 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `mismatching SessionEnd deletes non-pending current session`() {
+  fun `mismatching SessionEnd deletes current session without unhandled error`() {
     val cache = fixture.getSUT()
     val currentSession = createSession()
     cache.persistCurrentSession(currentSession)
@@ -555,11 +555,11 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `AbnormalExit hint keeps persisted pending session as abnormal`() {
+  fun `AbnormalExit hint keeps persisted unhandled session as abnormal`() {
     val cache = fixture.getSUT()
 
     val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
-    val session = createSession().apply { setPendingUnhandled(true) }
+    val session = createSession().apply { setNonTerminatingUnhandledError(true) }
     fixture.options.serializer.serialize(session, previousSessionFile.bufferedWriter())
 
     val envelope = SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null)
@@ -581,7 +581,7 @@ class EnvelopeCacheTest {
       )
     assertEquals(State.Abnormal, updatedSession!!.status)
     assertEquals("abnormal_mechanism", updatedSession.abnormalMechanism)
-    assertTrue(updatedSession.isPendingUnhandled)
+    assertTrue(updatedSession.hasNonTerminatingUnhandledError())
   }
 
   @Test
@@ -639,11 +639,11 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `NativeCrashExit hint keeps persisted pending session as crashed`() {
+  fun `NativeCrashExit hint keeps persisted unhandled session as crashed`() {
     val cache = fixture.getSUT()
 
     val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
-    val session = createSession().apply { setPendingUnhandled(true) }
+    val session = createSession().apply { setNonTerminatingUnhandledError(true) }
     fixture.options.serializer.serialize(session, previousSessionFile.bufferedWriter())
 
     val nativeCrashTimestamp = session.started!!.time + TimeUnit.HOURS.toMillis(1)
@@ -658,7 +658,7 @@ class EnvelopeCacheTest {
       )
     assertEquals(State.Crashed, updatedSession!!.status)
     assertEquals(nativeCrashTimestamp, updatedSession.timestamp!!.time)
-    assertFalse(updatedSession.isPendingUnhandled)
+    assertFalse(updatedSession.hasNonTerminatingUnhandledError())
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Unhandled Sessions)

- #5915 (collection)
- #5916
- #5917
- #5918

---

## :scroll: Description

Makes the session file cache aware of *which* session it is acting on.

Two paths in `EnvelopeCache.storeInternal` previously ignored session identity:

- **`SessionEnd`** deleted `session.json` unconditionally. A delayed `End(A)` arriving after a newer session B was persisted would delete B's file.
- **`SessionStart`** always rotated `session.json` into `previous_session.json` and overwrote it. A delayed `Start(A)` arriving after A's own state had already advanced on disk would overwrite the newer snapshot.

Both now compare session ids (and, for `SessionEnd`, start times) before deleting or rotating. A stale end only preserves the current file when the current session is genuinely newer — a different id **and** a later start time. Everything else keeps the existing behaviour, including malformed envelopes and unreadable session files, which still delete as before.

Also adds `EnvelopeCache.persistCurrentSession(Session)` so a caller can flush the active session to disk outside the envelope-store path, and extracts `readSessionFromEnvelope` / `readSessionFromDisk` helpers.

## :bulb: Motivation and Context

Needed by the next PR in the stack, which mutates the live session in place (marking it pending-unhandled) and persists it so the marker survives process death. Without session-id awareness, an unrelated in-flight `SessionEnd` or `SessionStart` could clobber that snapshot.

In practice this only changes observable behaviour for sessions carrying the pending-unhandled marker from PR 1 — the preserve branch requires `isPendingUnhandled()` — so existing SDK flows are unaffected.

## :green_heart: How did you test it?

`EnvelopeCacheTest` grew coverage for delayed same-id `SessionStart` preserving a newer pending or higher-error snapshot, different-id starts still rotating, matching and mismatching `SessionEnd`, null session ids on both paths, malformed envelopes, and unreadable session files. Also verified the pre-existing `AbnormalExit` and `NativeCrashExit` recovery paths still win over a pending marker. 36 tests, all passing.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

The capture API that sets the marker, in the next PR in this stack.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
