### PR TITLE
feat(android): [Unhandled Sessions 3] Add internal non-terminating envelope capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   - Scopes that are explicitly made current, e.g. via `Sentry.setCurrentScopes` or the `SentryContext` coroutine integration, are now also honoured when `globalHubMode` is enabled
   - `Sentry.pushScope`, `Sentry.pushIsolationScope` and `Sentry.popScope` remain no-ops when `globalHubMode` is enabled
 
+### Internal
+
+- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
+
 ## 8.54.0
 
 ### Features
@@ -49,10 +53,6 @@
 - Bump Native SDK from v0.16.2 to v0.16.4 ([#5962](https://github.com/getsentry/sentry-java/pull/5962), [#5996](https://github.com/getsentry/sentry-java/pull/5996))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0164)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.16.2...0.16.4)
-
-### Internal
-
-- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
 
 ## 8.53.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 
 ### Internal
 
-- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5918](https://github.com/getsentry/sentry-java/pull/5918))
+- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
 
 ## 8.52.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0164)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.16.2...0.16.4)
 
+### Internal
+
+- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
+
 ## 8.53.0
 
 ### Features
@@ -81,10 +85,6 @@
 - Bump Native SDK from v0.16.1 to v0.16.2 ([#5910](https://github.com/getsentry/sentry-java/pull/5910))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0162)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.16.1...0.16.2)
-
-### Internal
-
-- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
 
 ## 8.52.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0162)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.16.1...0.16.2)
 
+### Internal
+
+- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5918](https://github.com/getsentry/sentry-java/pull/5918))
+
 ## 8.52.0
 
 ### Fixes

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -318,6 +318,7 @@ public abstract interface class io/sentry/android/core/IDebugImagesLoader {
 public final class io/sentry/android/core/InternalSentrySdk {
 	public fun <init> ()V
 	public static fun captureEnvelope ([BZ)Lio/sentry/protocol/SentryId;
+	public static fun captureEnvelopeNonTerminating ([B)Lio/sentry/protocol/SentryId;
 	public static fun getAppStartMeasurement ()Ljava/util/Map;
 	public static fun getCurrentScope ()Lio/sentry/IScope;
 	public static fun serializeScope (Landroid/content/Context;Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/IScope;)Ljava/util/Map;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -203,8 +203,8 @@ public final class InternalSentrySdk {
       final SentryEnvelope repackagedEnvelope =
           new SentryEnvelope(envelope.getHeader(), envelopeItems);
       return scopes.captureEnvelope(repackagedEnvelope);
-    } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
+    } catch (Throwable t) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
     }
     return null;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -175,39 +174,45 @@ public final class InternalSentrySdk {
       return null;
     }
 
+    final @NotNull ISerializer serializer = options.getSerializer();
+    final @NotNull EnvelopeEventState eventState;
     try {
-      final @NotNull ISerializer serializer = options.getSerializer();
-      final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
-
-      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
-      for (SentryEnvelopeItem item : envelope.getItems()) {
-        envelopeItems.add(item);
-      }
-
-      // update session and add it to envelope if necessary
-      final @Nullable Session.State status =
-          eventState == EnvelopeEventState.UNHANDLED ? Session.State.Crashed : null;
-      final @Nullable Session session =
-          updateSession(scopes, options, status, eventState != EnvelopeEventState.NONE);
-      if (session != null) {
-        final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
-        envelopeItems.add(sessionItem);
-        deleteCurrentSessionFile(
-            options,
-            // should be sync if going to crash or already not a main thread
-            !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
-        if (maybeStartNewSession) {
-          scopes.startSession();
-        }
-      }
-
-      final SentryEnvelope repackagedEnvelope =
-          new SentryEnvelope(envelope.getHeader(), envelopeItems);
-      return scopes.captureEnvelope(repackagedEnvelope);
-    } catch (Throwable t) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+      eventState = eventStateOf(envelope, serializer);
+    } catch (Exception e) {
+      // getEvent reads through a Callable, whose call() declares Exception
+      options.getLogger().log(SentryLevel.ERROR, "Failed to inspect envelope events", e);
+      return null;
     }
-    return null;
+
+    final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
+    for (SentryEnvelopeItem item : envelope.getItems()) {
+      envelopeItems.add(item);
+    }
+
+    // update session and add it to envelope if necessary
+    final @Nullable Session.State status =
+        eventState == EnvelopeEventState.UNHANDLED ? Session.State.Crashed : null;
+    final @Nullable Session session =
+        updateSession(scopes, options, status, eventState != EnvelopeEventState.NONE);
+    if (session != null) {
+      try {
+        envelopeItems.add(SentryEnvelopeItem.fromSession(serializer, session));
+      } catch (IOException e) {
+        options.getLogger().log(SentryLevel.ERROR, "Failed to add session to envelope", e);
+        return null;
+      }
+      deleteCurrentSessionFile(
+          options,
+          // should be sync if going to crash or already not a main thread
+          !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
+      if (maybeStartNewSession) {
+        scopes.startSession();
+      }
+    }
+
+    final SentryEnvelope repackagedEnvelope =
+        new SentryEnvelope(envelope.getHeader(), envelopeItems);
+    return scopes.captureEnvelope(repackagedEnvelope);
   }
 
   /**
@@ -262,7 +267,11 @@ public final class InternalSentrySdk {
   }
 
   /**
-   * Flags and persists the current session for a non-terminating hybrid error.
+   * Flags the current session for a non-terminating hybrid error and persists it before returning,
+   * so the marker survives an immediate process death.
+   *
+   * <p>The write stays inside {@code withSession}: the scope's session lock is what keeps the
+   * session from being ended or replaced mid-write.
    *
    * @param unhandled {@code true} if the error was unhandled ({@code mechanism.handled=false})
    */
@@ -287,30 +296,10 @@ public final class InternalSentrySdk {
                       unhandled
                           ? session.recordNonTerminatingUnhandledError()
                           : session.update(null, null, true, null);
-                  if (recorded) {
-                    schedulePersistSession(options, session.clone());
+                  if (recorded && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                    ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
                   }
                 }));
-  }
-
-  /**
-   * This function is mostly called from Flutter where capturing envelope is run in a background
-   * thread.
-   *
-   * <p>Nonetheless we should run this in the same executor service as the deleteCurrentSessionFile
-   * function for consistency.
-   */
-  private static void schedulePersistSession(
-      final @NotNull SentryOptions options, final @NotNull Session session) {
-    if (!(options.getEnvelopeDiskCache() instanceof EnvelopeCache)) {
-      return;
-    }
-    final @NotNull EnvelopeCache cache = (EnvelopeCache) options.getEnvelopeDiskCache();
-    try {
-      options.getExecutorService().submit(() -> cache.persistCurrentSession(session));
-    } catch (RejectedExecutionException e) {
-      options.getLogger().log(WARNING, "Submission of session persisting rejected.", e);
-    }
   }
 
   /** What the events inside an envelope amount to, from the session's point of view. */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -294,7 +294,6 @@ public final class InternalSentrySdk {
             });
       }
 
-      // Capture the original envelope as-is (no session item attached).
       return scopes.captureEnvelope(envelope);
     } catch (Exception e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -176,27 +176,18 @@ public final class InternalSentrySdk {
 
     try {
       final @NotNull ISerializer serializer = options.getSerializer();
-      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
+      final @NotNull EnvelopeEvents events = scanEvents(envelope, serializer);
 
-      // determine session state based on events inside envelope
-      @Nullable Session.State status = null;
-      boolean crashedOrErrored = false;
+      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
       for (SentryEnvelopeItem item : envelope.getItems()) {
         envelopeItems.add(item);
-
-        final SentryEvent event = item.getEvent(serializer);
-        if (event != null) {
-          if (event.isCrashed()) {
-            status = Session.State.Crashed;
-          }
-          if (event.isCrashed() || event.isErrored()) {
-            crashedOrErrored = true;
-          }
-        }
       }
 
       // update session and add it to envelope if necessary
-      final @Nullable Session session = updateSession(scopes, options, status, crashedOrErrored);
+      final @Nullable Session.State status =
+          events == EnvelopeEvents.UNHANDLED ? Session.State.Crashed : null;
+      final @Nullable Session session =
+          updateSession(scopes, options, status, events != EnvelopeEvents.NONE);
       if (session != null) {
         final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
         envelopeItems.add(sessionItem);
@@ -255,32 +246,18 @@ public final class InternalSentrySdk {
 
     try {
       final @NotNull ISerializer serializer = options.getSerializer();
-      boolean hasUnhandled = false;
-      boolean addErrorsCount = false;
-      for (SentryEnvelopeItem item : envelope.getItems()) {
-        final SentryEvent event = item.getEvent(serializer);
-        if (event != null) {
-          if (event.getUnhandledException() != null) {
-            hasUnhandled = true;
-            addErrorsCount = true;
-          } else if (event.isErrored()) {
-            addErrorsCount = true;
-          }
-        }
-      }
+      final @NotNull EnvelopeEvents events = scanEvents(envelope, serializer);
 
-      if (hasUnhandled || addErrorsCount) {
-        final boolean unhandled = hasUnhandled;
-        final boolean addErrors = addErrorsCount;
+      if (events != EnvelopeEvents.NONE) {
         scopes.configureScope(
             scope -> {
               scope.withSession(
                   session -> {
                     if (session != null) {
                       final boolean updated =
-                          unhandled
+                          events == EnvelopeEvents.UNHANDLED
                               ? session.recordNonTerminatingUnhandledError()
-                              : session.update(null, null, addErrors, null);
+                              : session.update(null, null, true, null);
                       if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
                         ((EnvelopeCache) options.getEnvelopeDiskCache())
                             .persistCurrentSession(session);
@@ -299,6 +276,38 @@ public final class InternalSentrySdk {
       options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
+  }
+
+  /** What the events inside an envelope amount to, from the session's point of view. */
+  private enum EnvelopeEvents {
+    /** No event carried an exception. */
+    NONE,
+    /** At least one event carried an exception, none of them unhandled. */
+    ERRORED,
+    /** At least one event carried an unhandled exception. */
+    UNHANDLED
+  }
+
+  private static @NotNull EnvelopeEvents scanEvents(
+      final @NotNull SentryEnvelope envelope, final @NotNull ISerializer serializer)
+      throws Exception {
+    boolean unhandled = false;
+    boolean errored = false;
+    for (SentryEnvelopeItem item : envelope.getItems()) {
+      final SentryEvent event = item.getEvent(serializer);
+      if (event != null) {
+        if (event.isCrashed()) {
+          unhandled = true;
+        }
+        if (event.isCrashed() || event.isErrored()) {
+          errored = true;
+        }
+      }
+    }
+    if (unhandled) {
+      return EnvelopeEvents.UNHANDLED;
+    }
+    return errored ? EnvelopeEvents.ERRORED : EnvelopeEvents.NONE;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -174,45 +174,39 @@ public final class InternalSentrySdk {
       return null;
     }
 
-    final @NotNull ISerializer serializer = options.getSerializer();
-    final @NotNull EnvelopeEventState eventState;
     try {
-      eventState = eventStateOf(envelope, serializer);
-    } catch (Exception e) {
-      // getEvent reads through a Callable, whose call() declares Exception
-      options.getLogger().log(SentryLevel.ERROR, "Failed to inspect envelope events", e);
-      return null;
-    }
+      final @NotNull ISerializer serializer = options.getSerializer();
+      final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
 
-    final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
-    for (SentryEnvelopeItem item : envelope.getItems()) {
-      envelopeItems.add(item);
-    }
-
-    // update session and add it to envelope if necessary
-    final @Nullable Session.State status =
-        eventState == EnvelopeEventState.UNHANDLED ? Session.State.Crashed : null;
-    final @Nullable Session session =
-        updateSession(scopes, options, status, eventState != EnvelopeEventState.NONE);
-    if (session != null) {
-      try {
-        envelopeItems.add(SentryEnvelopeItem.fromSession(serializer, session));
-      } catch (IOException e) {
-        options.getLogger().log(SentryLevel.ERROR, "Failed to add session to envelope", e);
-        return null;
+      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
+      for (SentryEnvelopeItem item : envelope.getItems()) {
+        envelopeItems.add(item);
       }
-      deleteCurrentSessionFile(
-          options,
-          // should be sync if going to crash or already not a main thread
-          !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
-      if (maybeStartNewSession) {
-        scopes.startSession();
-      }
-    }
 
-    final SentryEnvelope repackagedEnvelope =
-        new SentryEnvelope(envelope.getHeader(), envelopeItems);
-    return scopes.captureEnvelope(repackagedEnvelope);
+      // update session and add it to envelope if necessary
+      final @Nullable Session.State status =
+          eventState == EnvelopeEventState.UNHANDLED ? Session.State.Crashed : null;
+      final @Nullable Session session =
+          updateSession(scopes, options, status, eventState != EnvelopeEventState.NONE);
+      if (session != null) {
+        final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
+        envelopeItems.add(sessionItem);
+        deleteCurrentSessionFile(
+            options,
+            // should be sync if going to crash or already not a main thread
+            !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
+        if (maybeStartNewSession) {
+          scopes.startSession();
+        }
+      }
+
+      final SentryEnvelope repackagedEnvelope =
+          new SentryEnvelope(envelope.getHeader(), envelopeItems);
+      return scopes.captureEnvelope(repackagedEnvelope);
+    } catch (Throwable t) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+    }
+    return null;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -314,15 +314,15 @@ public final class InternalSentrySdk {
   }
 
   /**
-   * Reads an envelope from the given bytes. Besides the declared {@link IOException}, {@link
-   * io.sentry.IEnvelopeReader#read(InputStream)} also rejects malformed payloads with an unchecked
-   * {@link IllegalArgumentException}, hence the broader catch.
+   * Reads an envelope from the given bytes. {@link io.sentry.IEnvelopeReader#read(InputStream)}
+   * declares {@link IOException} and additionally rejects malformed payloads with an unchecked
+   * {@link IllegalArgumentException}.
    */
   private static @Nullable SentryEnvelope readEnvelope(
       final @NotNull SentryOptions options, final @NotNull byte[] envelopeData) {
     try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
       return options.getEnvelopeReader().read(envelopeInputStream);
-    } catch (Exception e) {
+    } catch (IOException | IllegalArgumentException e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to read envelope", e);
       return null;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -249,29 +249,7 @@ public final class InternalSentrySdk {
       final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
 
       if (eventState != EnvelopeEventState.NONE) {
-        scopes.configureScope(
-            scope -> {
-              // the write stays inside the callback so the mutation and the persist are one
-              // critical section. Persisting outside it lets a concurrent caller's older snapshot
-              // land last and drop the unhandled marker.
-              scope.withSession(
-                  session -> {
-                    if (session != null) {
-                      final boolean updated =
-                          eventState == EnvelopeEventState.UNHANDLED
-                              ? session.recordNonTerminatingUnhandledError()
-                              : session.update(null, null, true, null);
-                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
-                        ((EnvelopeCache) options.getEnvelopeDiskCache())
-                            .persistCurrentSession(session);
-                      }
-                    } else {
-                      options
-                          .getLogger()
-                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
-                    }
-                  });
-            });
+        updateSessionNonTerminating(eventState == EnvelopeEventState.UNHANDLED);
       }
 
       return scopes.captureEnvelope(envelope);
@@ -279,6 +257,35 @@ public final class InternalSentrySdk {
       options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
+  }
+
+  /**
+   * Mutates and persists the current session for a non-terminating hybrid error. The write stays
+   * inside {@code withSession} so the mutation and the persist are one critical section. Persisting
+   * outside it lets a concurrent caller's older snapshot land last and drop the unhandled marker.
+   *
+   * @param crashed {@code true} if the error was unhandled ({@code mechanism.handled=false})
+   */
+  private static void updateSessionNonTerminating(final boolean crashed) {
+    final @NotNull IScopes scopes = ScopesAdapter.getInstance();
+    final @NotNull SentryOptions options = scopes.getOptions();
+    scopes.configureScope(
+        scope -> {
+          scope.withSession(
+              session -> {
+                if (session != null) {
+                  final boolean updated =
+                      crashed
+                          ? session.recordNonTerminatingUnhandledError()
+                          : session.update(null, null, true, null);
+                  if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                    ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
+                  }
+                } else {
+                  options.getLogger().log(INFO, "Session is null on updateSessionNonTerminating");
+                }
+              });
+        });
   }
 
   /** What the events inside an envelope amount to, from the session's point of view. */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -176,7 +176,7 @@ public final class InternalSentrySdk {
 
     try {
       final @NotNull ISerializer serializer = options.getSerializer();
-      final @NotNull EnvelopeEvents events = scanEvents(envelope, serializer);
+      final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
 
       final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
       for (SentryEnvelopeItem item : envelope.getItems()) {
@@ -185,9 +185,9 @@ public final class InternalSentrySdk {
 
       // update session and add it to envelope if necessary
       final @Nullable Session.State status =
-          events == EnvelopeEvents.UNHANDLED ? Session.State.Crashed : null;
+          eventState == EnvelopeEventState.UNHANDLED ? Session.State.Crashed : null;
       final @Nullable Session session =
-          updateSession(scopes, options, status, events != EnvelopeEvents.NONE);
+          updateSession(scopes, options, status, eventState != EnvelopeEventState.NONE);
       if (session != null) {
         final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
         envelopeItems.add(sessionItem);
@@ -246,16 +246,16 @@ public final class InternalSentrySdk {
 
     try {
       final @NotNull ISerializer serializer = options.getSerializer();
-      final @NotNull EnvelopeEvents events = scanEvents(envelope, serializer);
+      final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
 
-      if (events != EnvelopeEvents.NONE) {
+      if (eventState != EnvelopeEventState.NONE) {
         scopes.configureScope(
             scope -> {
               scope.withSession(
                   session -> {
                     if (session != null) {
                       final boolean updated =
-                          events == EnvelopeEvents.UNHANDLED
+                          eventState == EnvelopeEventState.UNHANDLED
                               ? session.recordNonTerminatingUnhandledError()
                               : session.update(null, null, true, null);
                       if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
@@ -279,7 +279,7 @@ public final class InternalSentrySdk {
   }
 
   /** What the events inside an envelope amount to, from the session's point of view. */
-  private enum EnvelopeEvents {
+  private enum EnvelopeEventState {
     /** No event carried an exception. */
     NONE,
     /** At least one event carried an exception, none of them unhandled. */
@@ -288,7 +288,7 @@ public final class InternalSentrySdk {
     UNHANDLED
   }
 
-  private static @NotNull EnvelopeEvents scanEvents(
+  private static @NotNull EnvelopeEventState eventStateOf(
       final @NotNull SentryEnvelope envelope, final @NotNull ISerializer serializer)
       throws Exception {
     boolean unhandled = false;
@@ -305,9 +305,9 @@ public final class InternalSentrySdk {
       }
     }
     if (unhandled) {
-      return EnvelopeEvents.UNHANDLED;
+      return EnvelopeEventState.UNHANDLED;
     }
-    return errored ? EnvelopeEvents.ERRORED : EnvelopeEvents.NONE;
+    return errored ? EnvelopeEventState.ERRORED : EnvelopeEventState.NONE;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -225,8 +225,8 @@ public final class InternalSentrySdk {
    * </ul>
    *
    * <p>The session is finalized later by normal lifecycle ({@code endSession} / background /
-   * previous-session recovery) as {@code unhandled}, unless a native crash escalates it to {@code
-   * crashed}.
+   * previous-session recovery) as {@code unhandled}, unless a terminal status takes over first,
+   * such as {@code crashed} for a native crash or {@code abnormal} for an ANR.
    *
    * <p>Same as {@link #captureEnvelope(byte[], boolean)}, this method will not enrich events, run
    * {@code beforeSend}, or sample — the caller is responsible for that.
@@ -251,6 +251,9 @@ public final class InternalSentrySdk {
       if (eventState != EnvelopeEventState.NONE) {
         scopes.configureScope(
             scope -> {
+              // the write stays inside the callback so the mutation and the persist are one
+              // critical section. Persisting outside it lets a concurrent caller's older snapshot
+              // land last and drop the unhandled marker.
               scope.withSession(
                   session -> {
                     if (session != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -251,23 +251,18 @@ public final class InternalSentrySdk {
       if (eventState != EnvelopeEventState.NONE) {
         scopes.configureScope(
             scope -> {
-              scope.withSession(
-                  session -> {
-                    if (session != null) {
-                      final boolean updated =
-                          eventState == EnvelopeEventState.UNHANDLED
-                              ? session.recordNonTerminatingUnhandledError()
-                              : session.update(null, null, true, null);
-                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
-                        ((EnvelopeCache) options.getEnvelopeDiskCache())
-                            .persistCurrentSession(session);
-                      }
-                    } else {
-                      options
-                          .getLogger()
-                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
-                    }
-                  });
+              final @Nullable Session session = scope.getSession();
+              if (session != null) {
+                final boolean updated =
+                    eventState == EnvelopeEventState.UNHANDLED
+                        ? session.recordNonTerminatingUnhandledError()
+                        : session.update(null, null, true, null);
+                if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                  ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
+                }
+              } else {
+                options.getLogger().log(INFO, "Session is null on captureEnvelopeNonTerminating");
+              }
             });
       }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -251,18 +251,23 @@ public final class InternalSentrySdk {
       if (eventState != EnvelopeEventState.NONE) {
         scopes.configureScope(
             scope -> {
-              final @Nullable Session session = scope.getSession();
-              if (session != null) {
-                final boolean updated =
-                    eventState == EnvelopeEventState.UNHANDLED
-                        ? session.recordNonTerminatingUnhandledError()
-                        : session.update(null, null, true, null);
-                if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
-                  ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
-                }
-              } else {
-                options.getLogger().log(INFO, "Session is null on captureEnvelopeNonTerminating");
-              }
+              scope.withSession(
+                  session -> {
+                    if (session != null) {
+                      final boolean updated =
+                          eventState == EnvelopeEventState.UNHANDLED
+                              ? session.recordNonTerminatingUnhandledError()
+                              : session.update(null, null, true, null);
+                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                        ((EnvelopeCache) options.getEnvelopeDiskCache())
+                            .persistCurrentSession(session);
+                      }
+                    } else {
+                      options
+                          .getLogger()
+                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
+                    }
+                  });
             });
       }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -244,48 +245,72 @@ public final class InternalSentrySdk {
       return null;
     }
 
+    final @NotNull EnvelopeEventState eventState;
     try {
-      final @NotNull ISerializer serializer = options.getSerializer();
-      final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
-
-      if (eventState != EnvelopeEventState.NONE) {
-        updateSessionNonTerminating(eventState == EnvelopeEventState.UNHANDLED);
-      }
-
-      return scopes.captureEnvelope(envelope);
+      eventState = eventStateOf(envelope, options.getSerializer());
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
+      // getEvent reads through a Callable, whose call() declares Exception
+      options.getLogger().log(SentryLevel.ERROR, "Failed to inspect envelope events", e);
+      return null;
     }
-    return null;
+
+    if (eventState != EnvelopeEventState.NONE) {
+      updateSessionNonTerminating(eventState == EnvelopeEventState.UNHANDLED);
+    }
+
+    return scopes.captureEnvelope(envelope);
   }
 
   /**
-   * Mutates and persists the current session for a non-terminating hybrid error. The write stays
-   * inside {@code withSession} so the mutation and the persist are one critical section. Persisting
-   * outside it lets a concurrent caller's older snapshot land last and drop the unhandled marker.
+   * Flags and persists the current session for a non-terminating hybrid error.
    *
-   * @param crashed {@code true} if the error was unhandled ({@code mechanism.handled=false})
+   * @param unhandled {@code true} if the error was unhandled ({@code mechanism.handled=false})
    */
-  private static void updateSessionNonTerminating(final boolean crashed) {
+  private static void updateSessionNonTerminating(final boolean unhandled) {
     final @NotNull IScopes scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
     scopes.configureScope(
-        scope -> {
-          scope.withSession(
-              session -> {
-                if (session != null) {
-                  final boolean updated =
-                      crashed
+        scope ->
+            scope.withSession(
+                session -> {
+                  if (session == null) {
+                    options.getLogger().log(INFO, "Session is null on updateSessionNonTerminating");
+                    return;
+                  }
+                  if (session.isTerminated()) {
+                    options
+                        .getLogger()
+                        .log(INFO, "Session already terminated, not recording the error.");
+                    return;
+                  }
+                  final boolean recorded =
+                      unhandled
                           ? session.recordNonTerminatingUnhandledError()
                           : session.update(null, null, true, null);
-                  if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
-                    ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
+                  if (recorded) {
+                    schedulePersistSession(options, session.clone());
                   }
-                } else {
-                  options.getLogger().log(INFO, "Session is null on updateSessionNonTerminating");
-                }
-              });
-        });
+                }));
+  }
+
+  /**
+   * This function is mostly called from Flutter where capturing envelope is run in a background
+   * thread.
+   *
+   * <p>Nonetheless we should run this in the same executor service as the deleteCurrentSessionFile
+   * function for consistency.
+   */
+  private static void schedulePersistSession(
+      final @NotNull SentryOptions options, final @NotNull Session session) {
+    if (!(options.getEnvelopeDiskCache() instanceof EnvelopeCache)) {
+      return;
+    }
+    final @NotNull EnvelopeCache cache = (EnvelopeCache) options.getEnvelopeDiskCache();
+    try {
+      options.getExecutorService().submit(() -> cache.persistCurrentSession(session));
+    } catch (RejectedExecutionException e) {
+      options.getLogger().log(WARNING, "Submission of session persisting rejected.", e);
+    }
   }
 
   /** What the events inside an envelope amount to, from the session's point of view. */
@@ -320,11 +345,6 @@ public final class InternalSentrySdk {
     return errored ? EnvelopeEventState.ERRORED : EnvelopeEventState.NONE;
   }
 
-  /**
-   * Reads an envelope from the given bytes. {@link io.sentry.IEnvelopeReader#read(InputStream)}
-   * declares {@link IOException} and additionally rejects malformed payloads with an unchecked
-   * {@link IllegalArgumentException}.
-   */
   private static @Nullable SentryEnvelope readEnvelope(
       final @NotNull SentryOptions options, final @NotNull byte[] envelopeData) {
     try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
@@ -427,22 +447,26 @@ public final class InternalSentrySdk {
     final @NotNull AtomicReference<Session> sessionRef = new AtomicReference<>();
     scopes.configureScope(
         scope -> {
-          final @Nullable Session session = scope.getSession();
-          if (session != null) {
-            final boolean updated = session.update(status, null, crashedOrErrored, null);
-            // if we have an uncaughtExceptionHint we can end the session.
-            if (updated) {
-              if (session.getStatus() == Session.State.Crashed) {
-                session.end();
-                // Session needs to be removed from the scope, otherwise it will be send twice
-                // standalone and with the crash event
-                scope.clearSession();
-              }
-              sessionRef.set(session);
-            }
-          } else {
-            options.getLogger().log(INFO, "Session is null on updateSession");
-          }
+          scope.withSession(
+              session -> {
+                if (session != null) {
+                  final boolean updated = session.update(status, null, crashedOrErrored, null);
+                  // if we have an uncaughtExceptionHint we can end the session.
+                  if (updated) {
+                    if (session.getStatus() == Session.State.Crashed) {
+                      session.end();
+                      // Session needs to be removed from the scope, otherwise it will be send twice
+                      // standalone and with the crash event
+                      scope.clearSession();
+                    }
+                    // fromSession serializes lazily, on the transport thread, so handing out the
+                    // live session would race a later mutation
+                    sessionRef.set(session.clone());
+                  }
+                } else {
+                  options.getLogger().log(INFO, "Session is null on updateSession");
+                }
+              });
         });
     return sessionRef.get();
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -225,11 +225,12 @@ public final class InternalSentrySdk {
    * treat {@code handled=false} as a crash that ends the session. Instead it:
    *
    * <ul>
-   *   <li>marks the current session as pending-unhandled and increments the error count
+   *   <li>flags the current session with a non-terminating unhandled error and increments the error
+   *       count
    *   <li>keeps session status {@code Ok} and the same session id on the scope
    *   <li>does not attach a session update item to this envelope
    *   <li>does not start a new session
-   *   <li>persists the current session so pending-unhandled survives process death
+   *   <li>persists the current session so the flag survives process death
    * </ul>
    *
    * <p>The session is finalized later by normal lifecycle ({@code endSession} / background /
@@ -254,13 +255,13 @@ public final class InternalSentrySdk {
 
     try {
       final @NotNull ISerializer serializer = options.getSerializer();
-      boolean markPendingUnhandled = false;
+      boolean hasUnhandled = false;
       boolean addErrorsCount = false;
       for (SentryEnvelopeItem item : envelope.getItems()) {
         final SentryEvent event = item.getEvent(serializer);
         if (event != null) {
           if (event.getUnhandledException() != null) {
-            markPendingUnhandled = true;
+            hasUnhandled = true;
             addErrorsCount = true;
           } else if (event.isErrored()) {
             addErrorsCount = true;
@@ -268,8 +269,8 @@ public final class InternalSentrySdk {
         }
       }
 
-      if (markPendingUnhandled || addErrorsCount) {
-        final boolean pending = markPendingUnhandled;
+      if (hasUnhandled || addErrorsCount) {
+        final boolean unhandled = hasUnhandled;
         final boolean addErrors = addErrorsCount;
         scopes.configureScope(
             scope -> {
@@ -277,8 +278,8 @@ public final class InternalSentrySdk {
                   session -> {
                     if (session != null) {
                       final boolean updated =
-                          pending
-                              ? session.markPendingUnhandled()
+                          unhandled
+                              ? session.recordNonTerminatingUnhandledError()
                               : session.update(null, null, addErrors, null);
                       if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
                         ((EnvelopeCache) options.getEnvelopeDiskCache())

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -34,6 +34,7 @@ import io.sentry.util.MapObjectWriter;
 import io.sentry.util.TracingUtils;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -153,7 +154,12 @@ public final class InternalSentrySdk {
    * - will not perform any sampling: it's up to the caller to take care of this<br>
    * - will enrich the envelope with a Session update if applicable<br>
    *
+   * <p>Unhandled events ({@code handled=false}) end the session as {@code crashed}. Prefer {@link
+   * #captureEnvelopeNonTerminating(byte[])} for hybrid runtimes where the process is expected to
+   * continue (e.g. Flutter).
+   *
    * @param envelopeData the serialized envelope data
+   * @param maybeStartNewSession if true, starts a new session after a crashed session is cleared
    * @return The Id (SentryId object) of the event, or null in case the envelope could not be
    *     captured
    */
@@ -163,14 +169,13 @@ public final class InternalSentrySdk {
     final @NotNull IScopes scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
 
-    try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
-      final @NotNull ISerializer serializer = options.getSerializer();
-      final @Nullable SentryEnvelope envelope =
-          options.getEnvelopeReader().read(envelopeInputStream);
-      if (envelope == null) {
-        return null;
-      }
+    final @Nullable SentryEnvelope envelope = readEnvelope(options, envelopeData);
+    if (envelope == null) {
+      return null;
+    }
 
+    try {
+      final @NotNull ISerializer serializer = options.getSerializer();
       final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
 
       // determine session state based on events inside envelope
@@ -207,10 +212,108 @@ public final class InternalSentrySdk {
       final SentryEnvelope repackagedEnvelope =
           new SentryEnvelope(envelope.getHeader(), envelopeItems);
       return scopes.captureEnvelope(repackagedEnvelope);
-    } catch (Throwable t) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+    } catch (Exception e) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
+  }
+
+  /**
+   * Captures the provided envelope for a non-terminating hybrid exception (e.g. Flutter).
+   *
+   * <p>Compared to {@link #captureEnvelope(byte[], boolean)} this method does <strong>not</strong>
+   * treat {@code handled=false} as a crash that ends the session. Instead it:
+   *
+   * <ul>
+   *   <li>marks the current session as pending-unhandled and increments the error count
+   *   <li>keeps session status {@code Ok} and the same session id on the scope
+   *   <li>does not attach a session update item to this envelope
+   *   <li>does not start a new session
+   *   <li>persists the current session so pending-unhandled survives process death
+   * </ul>
+   *
+   * <p>The session is finalized later by normal lifecycle ({@code endSession} / background /
+   * previous-session recovery) as {@code unhandled}, unless a native crash escalates it to {@code
+   * crashed}.
+   *
+   * <p>Same as {@link #captureEnvelope(byte[], boolean)}, this method will not enrich events, run
+   * {@code beforeSend}, or sample — the caller is responsible for that.
+   *
+   * @param envelopeData the serialized envelope data
+   * @return the id of the captured envelope, or null if capture failed
+   */
+  @Nullable
+  public static SentryId captureEnvelopeNonTerminating(final @NotNull byte[] envelopeData) {
+    final @NotNull IScopes scopes = ScopesAdapter.getInstance();
+    final @NotNull SentryOptions options = scopes.getOptions();
+
+    final @Nullable SentryEnvelope envelope = readEnvelope(options, envelopeData);
+    if (envelope == null) {
+      return null;
+    }
+
+    try {
+      final @NotNull ISerializer serializer = options.getSerializer();
+      boolean markPendingUnhandled = false;
+      boolean addErrorsCount = false;
+      for (SentryEnvelopeItem item : envelope.getItems()) {
+        final SentryEvent event = item.getEvent(serializer);
+        if (event != null) {
+          if (event.getUnhandledException() != null) {
+            markPendingUnhandled = true;
+            addErrorsCount = true;
+          } else if (event.isErrored()) {
+            addErrorsCount = true;
+          }
+        }
+      }
+
+      if (markPendingUnhandled || addErrorsCount) {
+        final boolean pending = markPendingUnhandled;
+        final boolean addErrors = addErrorsCount;
+        scopes.configureScope(
+            scope -> {
+              scope.withSession(
+                  session -> {
+                    if (session != null) {
+                      final boolean updated =
+                          pending
+                              ? session.markPendingUnhandled()
+                              : session.update(null, null, addErrors, null);
+                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                        ((EnvelopeCache) options.getEnvelopeDiskCache())
+                            .persistCurrentSession(session);
+                      }
+                    } else {
+                      options
+                          .getLogger()
+                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
+                    }
+                  });
+            });
+      }
+
+      // Capture the original envelope as-is (no session item attached).
+      return scopes.captureEnvelope(envelope);
+    } catch (Exception e) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
+    }
+    return null;
+  }
+
+  /**
+   * Reads an envelope from the given bytes. Besides the declared {@link IOException}, {@link
+   * io.sentry.IEnvelopeReader#read(InputStream)} also rejects malformed payloads with an unchecked
+   * {@link IllegalArgumentException}, hence the broader catch.
+   */
+  private static @Nullable SentryEnvelope readEnvelope(
+      final @NotNull SentryOptions options, final @NotNull byte[] envelopeData) {
+    try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
+      return options.getEnvelopeReader().read(envelopeInputStream);
+    } catch (Exception e) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to read envelope", e);
+      return null;
+    }
   }
 
   public static Map<String, Object> getAppStartMeasurement() {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -250,10 +249,26 @@ public final class InternalSentrySdk {
       final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
 
       if (eventState != EnvelopeEventState.NONE) {
-        final @Nullable Session session = recordSessionError(scopes, options, eventState);
-        if (session != null && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
-          ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
-        }
+        scopes.configureScope(
+            scope -> {
+              scope.withSession(
+                  session -> {
+                    if (session != null) {
+                      final boolean updated =
+                          eventState == EnvelopeEventState.UNHANDLED
+                              ? session.recordNonTerminatingUnhandledError()
+                              : session.update(null, null, true, null);
+                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                        ((EnvelopeCache) options.getEnvelopeDiskCache())
+                            .persistCurrentSession(session);
+                      }
+                    } else {
+                      options
+                          .getLogger()
+                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
+                    }
+                  });
+            });
       }
 
       return scopes.captureEnvelope(envelope);
@@ -261,40 +276,6 @@ public final class InternalSentrySdk {
       options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
-  }
-
-  /**
-   * Records the envelope's error on the current session under the scope lock and returns the
-   * snapshot taken while holding it, so the caller can persist it without keeping the lock during
-   * disk I/O. Returns null when there is no session or it had already reached a terminal state.
-   */
-  private static @Nullable Session recordSessionError(
-      final @NotNull IScopes scopes,
-      final @NotNull SentryOptions options,
-      final @NotNull EnvelopeEventState eventState) {
-    final @NotNull AtomicReference<Session> snapshotRef = new AtomicReference<>();
-    scopes.configureScope(
-        scope -> {
-          final @NotNull AtomicBoolean updated = new AtomicBoolean(false);
-          final @Nullable Session snapshot =
-              scope.withSession(
-                  session -> {
-                    if (session != null) {
-                      updated.set(
-                          eventState == EnvelopeEventState.UNHANDLED
-                              ? session.recordNonTerminatingUnhandledError()
-                              : session.update(null, null, true, null));
-                    } else {
-                      options
-                          .getLogger()
-                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
-                    }
-                  });
-          if (updated.get()) {
-            snapshotRef.set(snapshot);
-          }
-        });
-    return snapshotRef.get();
   }
 
   /** What the events inside an envelope amount to, from the session's point of view. */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -227,8 +227,12 @@ public final class InternalSentrySdk {
    *   <li>keeps session status {@code Ok} and the same session id on the scope
    *   <li>does not attach a session update item to this envelope
    *   <li>does not start a new session
-   *   <li>persists the current session so the flag survives process death
+   *   <li>persists the current session before returning, so the flag survives process death
    * </ul>
+   *
+   * <p>Persisting is a blocking disk write on the calling thread, so call this off the main thread
+   * as the hybrid SDKs do. It is synchronous on purpose: a deferred write would not be on disk yet
+   * if the process dies right after this returns.
    *
    * <p>The session is finalized later by normal lifecycle ({@code endSession} / background /
    * previous-session recovery) as {@code unhandled}, unless a terminal status takes over first,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -249,26 +250,10 @@ public final class InternalSentrySdk {
       final @NotNull EnvelopeEventState eventState = eventStateOf(envelope, serializer);
 
       if (eventState != EnvelopeEventState.NONE) {
-        scopes.configureScope(
-            scope -> {
-              scope.withSession(
-                  session -> {
-                    if (session != null) {
-                      final boolean updated =
-                          eventState == EnvelopeEventState.UNHANDLED
-                              ? session.recordNonTerminatingUnhandledError()
-                              : session.update(null, null, true, null);
-                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
-                        ((EnvelopeCache) options.getEnvelopeDiskCache())
-                            .persistCurrentSession(session);
-                      }
-                    } else {
-                      options
-                          .getLogger()
-                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
-                    }
-                  });
-            });
+        final @Nullable Session session = recordSessionError(scopes, options, eventState);
+        if (session != null && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+          ((EnvelopeCache) options.getEnvelopeDiskCache()).persistCurrentSession(session);
+        }
       }
 
       return scopes.captureEnvelope(envelope);
@@ -276,6 +261,40 @@ public final class InternalSentrySdk {
       options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
+  }
+
+  /**
+   * Records the envelope's error on the current session under the scope lock and returns the
+   * snapshot taken while holding it, so the caller can persist it without keeping the lock during
+   * disk I/O. Returns null when there is no session or it had already reached a terminal state.
+   */
+  private static @Nullable Session recordSessionError(
+      final @NotNull IScopes scopes,
+      final @NotNull SentryOptions options,
+      final @NotNull EnvelopeEventState eventState) {
+    final @NotNull AtomicReference<Session> snapshotRef = new AtomicReference<>();
+    scopes.configureScope(
+        scope -> {
+          final @NotNull AtomicBoolean updated = new AtomicBoolean(false);
+          final @Nullable Session snapshot =
+              scope.withSession(
+                  session -> {
+                    if (session != null) {
+                      updated.set(
+                          eventState == EnvelopeEventState.UNHANDLED
+                              ? session.recordNonTerminatingUnhandledError()
+                              : session.update(null, null, true, null));
+                    } else {
+                      options
+                          .getLogger()
+                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
+                    }
+                  });
+          if (updated.get()) {
+            snapshotRef.set(snapshot);
+          }
+        });
+    return snapshotRef.get();
   }
 
   /** What the events inside an envelope amount to, from the session's point of view. */

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -495,7 +495,7 @@ class InternalSentrySdkTest {
     assertThat(scopeSession.get().hasNonTerminatingUnhandledError()).isTrue()
     assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
 
-    // and it is persisted so pending survives process death
+    // and it is persisted so the flag survives process death
     val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
     val persistedSession =
       fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
@@ -541,10 +541,10 @@ class InternalSentrySdkTest {
     fixture.captureEnvelopeNonTerminatingWithEvent(
       fixture.createSentryEventWithUnhandledException()
     )
-    val pendingSession = AtomicReference<Session>()
-    Sentry.configureScope { scope -> pendingSession.set(scope.session) }
-    val oldSid = pendingSession.get().sessionId
-    assertThat(pendingSession.get().hasNonTerminatingUnhandledError()).isTrue()
+    val unhandledSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> unhandledSession.set(scope.session) }
+    val oldSid = unhandledSession.get().sessionId
+    assertThat(unhandledSession.get().hasNonTerminatingUnhandledError()).isTrue()
     fixture.capturedEnvelopes.clear()
 
     // when a subsequent hard crash is captured through the existing terminating API

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -30,7 +30,6 @@ import io.sentry.protocol.Contexts
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
-import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.createTestScopes
 import io.sentry.transport.ITransport
 import io.sentry.transport.RateLimiter
@@ -62,8 +61,6 @@ class InternalSentrySdkTest {
       initForTest(context) { options ->
         this@Fixture.options = options
         options.dsn = "https://key@host/proj"
-        // the non-terminating path persists the session off the calling thread
-        options.executorService = ImmediateExecutorService()
         options.setTransportFactory { _, _ ->
           object : ITransport {
             override fun close(isRestarting: Boolean) {
@@ -509,7 +506,8 @@ class InternalSentrySdkTest {
     assertThat(scopeSession.get().hasNonTerminatingUnhandledError()).isTrue()
     assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
 
-    // and it is persisted so the flag survives process death
+    // and it is persisted so the flag survives process death. The fixture leaves the real executor
+    // service in place, so this only holds if the write happened on the calling thread.
     val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
     val persistedSession =
       fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -470,7 +470,7 @@ class InternalSentrySdkTest {
   }
 
   @Test
-  fun `captureEnvelopeNonTerminating keeps the session Ok and marks it pending unhandled`() {
+  fun `captureEnvelopeNonTerminating keeps the session Ok and flags the unhandled error`() {
     val fixture = Fixture()
     fixture.init(context)
 
@@ -488,11 +488,11 @@ class InternalSentrySdkTest {
     assertThat(capturedEnvelopeItems).hasSize(1)
     assertThat(capturedEnvelopeItems[0].header.type).isEqualTo(SentryItemType.Event)
 
-    // and the session stays alive on the scope, same id, marked pending unhandled
+    // and the session stays alive on the scope, same id, flagged with the unhandled error
     val scopeSession = AtomicReference<Session>()
     Sentry.configureScope { scope -> scopeSession.set(scope.session) }
     assertThat(scopeSession.get().status).isEqualTo(Session.State.Ok)
-    assertThat(scopeSession.get().isPendingUnhandled).isTrue()
+    assertThat(scopeSession.get().hasNonTerminatingUnhandledError()).isTrue()
     assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
 
     // and it is persisted so pending survives process death
@@ -500,7 +500,7 @@ class InternalSentrySdkTest {
     val persistedSession =
       fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
     assertThat(persistedSession.status).isEqualTo(Session.State.Ok)
-    assertThat(persistedSession.isPendingUnhandled).isTrue()
+    assertThat(persistedSession.hasNonTerminatingUnhandledError()).isTrue()
     assertThat(persistedSession.sessionId).isEqualTo(originalSid.get())
   }
 
@@ -544,7 +544,7 @@ class InternalSentrySdkTest {
     val pendingSession = AtomicReference<Session>()
     Sentry.configureScope { scope -> pendingSession.set(scope.session) }
     val oldSid = pendingSession.get().sessionId
-    assertThat(pendingSession.get().isPendingUnhandled).isTrue()
+    assertThat(pendingSession.get().hasNonTerminatingUnhandledError()).isTrue()
     fixture.capturedEnvelopes.clear()
 
     // when a subsequent hard crash is captured through the existing terminating API
@@ -562,14 +562,14 @@ class InternalSentrySdkTest {
         Session::class.java,
       )!!
     assertThat(crashedSession.status).isEqualTo(Session.State.Crashed)
-    assertThat(crashedSession.isPendingUnhandled).isFalse()
+    assertThat(crashedSession.hasNonTerminatingUnhandledError()).isFalse()
     assertThat(crashedSession.sessionId).isEqualTo(oldSid)
 
     // and a new Ok session with a different id is active
     val activeSession = AtomicReference<Session>()
     Sentry.configureScope { scope -> activeSession.set(scope.session) }
     assertThat(activeSession.get().status).isEqualTo(Session.State.Ok)
-    assertThat(activeSession.get().isPendingUnhandled).isFalse()
+    assertThat(activeSession.get().hasNonTerminatingUnhandledError()).isFalse()
     assertThat(activeSession.get().sessionId).isNotEqualTo(oldSid)
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -30,6 +30,7 @@ import io.sentry.protocol.Contexts
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.createTestScopes
 import io.sentry.transport.ITransport
 import io.sentry.transport.RateLimiter
@@ -61,6 +62,8 @@ class InternalSentrySdkTest {
       initForTest(context) { options ->
         this@Fixture.options = options
         options.dsn = "https://key@host/proj"
+        // the non-terminating path persists the session off the calling thread
+        options.executorService = ImmediateExecutorService()
         options.setTransportFactory { _, _ ->
           object : ITransport {
             override fun close(isRestarting: Boolean) {
@@ -133,6 +136,17 @@ class InternalSentrySdkTest {
         val sentryExceptions =
           factory.getSentryExceptions(ExceptionMechanismException(mechanism, Throwable(), Thread()))
         exceptions = sentryExceptions
+      }
+    }
+
+    fun createSentryEventWithHandledException(): SentryEvent {
+      return SentryEvent(RuntimeException()).apply {
+        val mechanism = Mechanism()
+        mechanism.isHandled = true
+
+        val factory = SentryExceptionFactory(mock())
+        exceptions =
+          factory.getSentryExceptions(ExceptionMechanismException(mechanism, Throwable(), Thread()))
       }
     }
 
@@ -502,6 +516,33 @@ class InternalSentrySdkTest {
     assertThat(persistedSession.status).isEqualTo(Session.State.Ok)
     assertThat(persistedSession.hasNonTerminatingUnhandledError()).isTrue()
     assertThat(persistedSession.sessionId).isEqualTo(originalSid.get())
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating does not record onto an already terminated session`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    // given a session already finalized on the scope, as an ANR leaves it
+    val terminatedSession = AtomicReference<Session>()
+    Sentry.configureScope { scope ->
+      scope.withSession { session ->
+        session!!.update(Session.State.Abnormal, null, false, "anr_foreground")
+        session.end()
+      }
+      terminatedSession.set(scope.session)
+    }
+    val errorCountBefore = terminatedSession.get().errorCount()
+    val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    sessionFile.delete()
+
+    // when a handled error arrives through the non-terminating API
+    fixture.captureEnvelopeNonTerminatingWithEvent(fixture.createSentryEventWithHandledException())
+
+    // then the finalized session is left alone and never written back to the session file
+    assertThat(terminatedSession.get().status).isEqualTo(Session.State.Abnormal)
+    assertThat(terminatedSession.get().errorCount()).isEqualTo(errorCountBefore)
+    assertThat(sessionFile.exists()).isFalse()
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -5,6 +5,7 @@ import android.content.ContentProvider
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.Breadcrumb
 import io.sentry.Hint
 import io.sentry.IScope
@@ -22,6 +23,7 @@ import io.sentry.Session
 import io.sentry.SpanId
 import io.sentry.android.core.performance.ActivityLifecycleTimeSpan
 import io.sentry.android.core.performance.AppStartMetrics
+import io.sentry.cache.EnvelopeCache
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.App
 import io.sentry.protocol.Contexts
@@ -105,6 +107,21 @@ class InternalSentrySdkTest {
       val data = outputStream.toByteArray()
 
       InternalSentrySdk.captureEnvelope(data, maybeStartNewSession)
+    }
+
+    fun captureEnvelopeNonTerminatingWithEvent(event: SentryEvent = SentryEvent()) {
+      val options = Sentry.getCurrentScopes().options
+      val eventId = SentryId()
+      val header = SentryEnvelopeHeader(eventId)
+      val eventItem = SentryEnvelopeItem.fromEvent(options.serializer, event)
+
+      val envelope = SentryEnvelope(header, listOf(eventItem))
+
+      val outputStream = ByteArrayOutputStream()
+      options.serializer.serialize(envelope, outputStream)
+      val data = outputStream.toByteArray()
+
+      InternalSentrySdk.captureEnvelopeNonTerminating(data)
     }
 
     fun createSentryEventWithUnhandledException(): SentryEvent {
@@ -450,6 +467,110 @@ class InternalSentrySdkTest {
 
     // and the local session should be a new session
     assertNotEquals(capturedSession.sessionId, scopeRef.get().session!!.sessionId)
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating keeps the session Ok and marks it pending unhandled`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    val originalSid = AtomicReference<String>()
+    Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }
+
+    // when capture envelope is called with an unhandled event through the non-terminating API
+    fixture.captureEnvelopeNonTerminatingWithEvent(
+      fixture.createSentryEventWithUnhandledException()
+    )
+
+    // then only the original event envelope is captured, without a session item
+    assertThat(fixture.capturedEnvelopes).hasSize(1)
+    val capturedEnvelopeItems = fixture.capturedEnvelopes.first().items.toList()
+    assertThat(capturedEnvelopeItems).hasSize(1)
+    assertThat(capturedEnvelopeItems[0].header.type).isEqualTo(SentryItemType.Event)
+
+    // and the session stays alive on the scope, same id, marked pending unhandled
+    val scopeSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> scopeSession.set(scope.session) }
+    assertThat(scopeSession.get().status).isEqualTo(Session.State.Ok)
+    assertThat(scopeSession.get().isPendingUnhandled).isTrue()
+    assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
+
+    // and it is persisted so pending survives process death
+    val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val persistedSession =
+      fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
+    assertThat(persistedSession.status).isEqualTo(Session.State.Ok)
+    assertThat(persistedSession.isPendingUnhandled).isTrue()
+    assertThat(persistedSession.sessionId).isEqualTo(originalSid.get())
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating then endSession finalizes the session as unhandled`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    fixture.captureEnvelopeNonTerminatingWithEvent(
+      fixture.createSentryEventWithUnhandledException()
+    )
+    fixture.capturedEnvelopes.clear()
+
+    // when the session is ended by normal lifecycle
+    Sentry.endSession()
+
+    // then the ended session is captured as unhandled
+    val sessionItems =
+      fixture.capturedEnvelopes
+        .flatMap { it.items.toList() }
+        .filter {
+          it.header.type == SentryItemType.Session
+        }
+    assertThat(sessionItems).hasSize(1)
+    val endedSession =
+      fixture.options.serializer.deserialize(
+        InputStreamReader(ByteArrayInputStream(sessionItems[0].data)),
+        Session::class.java,
+      )!!
+    assertThat(endedSession.status).isEqualTo(Session.State.Unhandled)
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating then a crash finalizes old session and starts a new one`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    fixture.captureEnvelopeNonTerminatingWithEvent(
+      fixture.createSentryEventWithUnhandledException()
+    )
+    val pendingSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> pendingSession.set(scope.session) }
+    val oldSid = pendingSession.get().sessionId
+    assertThat(pendingSession.get().isPendingUnhandled).isTrue()
+    fixture.capturedEnvelopes.clear()
+
+    // when a subsequent hard crash is captured through the existing terminating API
+    fixture.captureEnvelopeWithEvent(fixture.createSentryEventWithUnhandledException(), true)
+
+    // then the crash envelope contains the finalized old session
+    assertThat(fixture.capturedEnvelopes).hasSize(2)
+    val crashEnvelopeItems = fixture.capturedEnvelopes.last().items.toList()
+    assertThat(crashEnvelopeItems).hasSize(2)
+    assertThat(crashEnvelopeItems[0].header.type).isEqualTo(SentryItemType.Event)
+    assertThat(crashEnvelopeItems[1].header.type).isEqualTo(SentryItemType.Session)
+    val crashedSession =
+      fixture.options.serializer.deserialize(
+        InputStreamReader(ByteArrayInputStream(crashEnvelopeItems[1].data)),
+        Session::class.java,
+      )!!
+    assertThat(crashedSession.status).isEqualTo(Session.State.Crashed)
+    assertThat(crashedSession.isPendingUnhandled).isFalse()
+    assertThat(crashedSession.sessionId).isEqualTo(oldSid)
+
+    // and a new Ok session with a different id is active
+    val activeSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> activeSession.set(scope.session) }
+    assertThat(activeSession.get().status).isEqualTo(Session.State.Ok)
+    assertThat(activeSession.get().isPendingUnhandled).isFalse()
+    assertThat(activeSession.get().sessionId).isNotEqualTo(oldSid)
   }
 
   @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2517,6 +2517,10 @@ public abstract interface class io/sentry/Scope$IWithPropagationContext {
 	public abstract fun accept (Lio/sentry/PropagationContext;)V
 }
 
+public abstract interface class io/sentry/Scope$IWithSession {
+	public abstract fun accept (Lio/sentry/Session;)V
+}
+
 public abstract interface class io/sentry/Scope$IWithTransaction {
 	public abstract fun accept (Lio/sentry/ITransaction;)V
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2517,10 +2517,6 @@ public abstract interface class io/sentry/Scope$IWithPropagationContext {
 	public abstract fun accept (Lio/sentry/PropagationContext;)V
 }
 
-public abstract interface class io/sentry/Scope$IWithSession {
-	public abstract fun accept (Lio/sentry/Session;)V
-}
-
 public abstract interface class io/sentry/Scope$IWithTransaction {
 	public abstract fun accept (Lio/sentry/ITransaction;)V
 }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1018,6 +1018,7 @@ public final class Scope implements IScope {
   }
 
   /** The IWithSession callback */
+  @ApiStatus.Internal
   public interface IWithSession {
 
     /**

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1018,7 +1018,6 @@ public final class Scope implements IScope {
   }
 
   /** The IWithSession callback */
-  @ApiStatus.Internal
   public interface IWithSession {
 
     /**

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1018,7 +1018,8 @@ public final class Scope implements IScope {
   }
 
   /** The IWithSession callback */
-  interface IWithSession {
+  @ApiStatus.Internal
+  public interface IWithSession {
 
     /**
      * The accept method of the callback

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1018,7 +1018,7 @@ public final class Scope implements IScope {
   }
 
   /** The IWithSession callback */
-  public interface IWithSession {
+  interface IWithSession {
 
     /**
      * The accept method of the callback

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -311,8 +311,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
       boolean sessionHasBeenUpdated = false;
       if (status != null) {
         this.status = status;
-        // the flag only decides how an Ok session is finalized, so an explicit terminal status
-        // such as a crash or an ANR takes precedence over a non-terminating error.
+        // a terminal status makes the flag meaningless, so drop it rather than serialize a crashed
+        // session that claims it did not terminate
         if (status != State.Ok) {
           hasNonTerminatingUnhandledError = false;
         }

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -307,6 +307,7 @@ public final class Session implements JsonUnknown, JsonSerializable {
       final boolean addErrorsCount,
       final @Nullable String abnormalMechanism) {
     try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+      // TODO(buenaflor): should we reject updates if we are already in a terminal status?
       boolean sessionHasBeenUpdated = false;
       if (status != null) {
         this.status = status;


### PR DESCRIPTION
## PR Stack (Unhandled Sessions)

- #5915 (collection)
- #5919
- #5920
- #5921
- #5990

---

## :scroll: Description

Adds `InternalSentrySdk.captureEnvelopeNonTerminating(byte[])` for hybrid runtimes where an unhandled exception does **not** terminate the process.

Unlike `captureEnvelope(byte[], boolean)`, it does not treat `handled=false` as a crash. Instead it:

- flags the current session and increments its error count,
- keeps the session `Ok` with the same session id on the scope,
- attaches no session item and starts no new session,
- persists the session so the flag survives process death.

The session is finalized later by normal lifecycle (`endSession`, background, or previous-session recovery) as `unhandled`, unless a terminal status takes over first, such as `crashed` for a native crash or `abnormal` for an ANR. `captureEnvelope(byte[], boolean)` is unchanged.

Also in this PR:

- `Scope.IWithSession` becomes public so `InternalSentrySdk` can mutate the session under the scope lock; it is the only consumer. It carries `@ApiStatus.Internal` like `IWithTransaction` and `IWithPropagationContext`, so it is not supported API despite being public.
- A shared `eventStateOf` returning `EnvelopeEventState`, replacing two loops that computed the same booleans by different routes, plus a shared `readEnvelope`.
- The code added here catches `Exception` rather than `Throwable`, so `OutOfMemoryError` and friends propagate instead of being swallowed. The existing `captureEnvelope` keeps its `catch (Throwable)`.

## :bulb: Motivation and Context

Flutter forwards `handled=false` events through the terminating hybrid capture path. That marks the session `crashed` and may start a replacement session even though the Flutter process keeps running, incorrectly lowering crash-free session rates.

## :green_heart: How did you test it?

New `InternalSentrySdkTest` coverage: the session staying `Ok` with the same id and the flag persisted to disk; `endSession` afterwards finalizing as `unhandled`; and a later hard crash finalizing the old session as `crashed` and starting a fresh `Ok` session. Existing `captureEnvelope` tests confirm that path is unchanged.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Update the Flutter Android bridge to use `captureEnvelopeNonTerminating` for non-terminating unhandled events.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
