### PR TITLE
feat(android): Forward logs.enabled to sentry-native

### DIFF
--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -76,6 +76,8 @@ public final class SentryNdk {
         ndkOptions.setEnableAppHangTracking(options.isEnableNdkAppHangTracking());
         ndkOptions.setAppHangTimeoutMillis(options.getNdkAppHangTimeoutIntervalMillis());
 
+        ndkOptions.setEnableLogs(options.getLogs().isEnabled());
+
         //noinspection UnstableApiUsage
         io.sentry.ndk.SentryNdk.init(ndkOptions);
 


### PR DESCRIPTION
## Summary

* Forwards `SentryOptions.Logs.isEnabled()` to `NdkOptions.setEnableLogs()` during NDK init
* Unblocks `sentry_log_*()` / `sentry_log()` calls from native code on Android

**Depends on** [https://github.com/getsentry/sentry-native/pull/1971](<https://github.com/getsentry/sentry-native/pull/1971>) — needs a `sentry-native-ndk` release with the new `NdkOptions.enableLogs` field before this can merge.

Fixes getsentry/sentry-java#5911

## Test plan

- [ ] Bump `sentry-native-ndk` version once the dependency PR is released
- [ ] Verify native logs reach Sentry when `logs.enabled = true`
- [ ] Verify native logs are dropped when `logs.enabled = false` (default)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)