### PR TITLE
perf(android): Read cpu time via Process.getElapsedCpuTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))
 - Preserve custom `Throwable` identities when R8 optimizes Android apps ([#5881](https://github.com/getsentry/sentry-java/pull/5881))
+- Report the correct cpu usage for the first performance sample of a transaction, which was measured against the time since device boot ([#5926](https://github.com/getsentry/sentry-java/pull/5926))
+
+### Performance
+
+- Reduce allocations while collecting cpu usage during transactions by reading the process cpu time via `Process.getElapsedCpuTime()` instead of parsing `/proc/self/stat` (33.6kB to 16 bytes per sample on a Pixel 3) ([#5926](https://github.com/getsentry/sentry-java/pull/5926))
 
 ### Dependencies
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
@@ -11,13 +11,11 @@ import io.sentry.util.Objects;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-// The approach to get the cpu usage info was taken from
-// https://eng.lyft.com/monitoring-cpu-performance-of-lyfts-android-applications-4e36fafffe12
-// The process cpu time itself comes from Process.getElapsedCpuTime(), a @CriticalNative wrapper
-// around clock_gettime(CLOCK_PROCESS_CPUTIME_ID), rather than from parsing /proc/self/stat: reading
-// and parsing that file allocated on every sample, and collect() runs 10 times per second for the
-// whole duration of a transaction. It does not include the cpu time of reaped child processes,
-// which an app process doesn't have.
+// The process cpu time comes from Process.getElapsedCpuTime(), a @CriticalNative wrapper around
+// clock_gettime(CLOCK_PROCESS_CPUTIME_ID), rather than from parsing /proc/self/stat: reading and
+// parsing that file allocated on every sample, and collect() runs 10 times per second for the whole
+// duration of a transaction. It does not include the cpu time of reaped child processes, which an
+// app process doesn't have.
 @ApiStatus.Internal
 public final class AndroidCpuCollector implements IPerformanceSnapshotCollector {
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
@@ -11,11 +11,12 @@ import io.sentry.util.Objects;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-// Process.getElapsedCpuTime() is a @CriticalNative wrapper around
-// clock_gettime(CLOCK_PROCESS_CPUTIME_ID), i.e. the cpu time of all threads of this process. It
-// replaces reading utime/stime out of /proc/self/stat, which allocated ~25 kB per sample (file
-// reader buffers plus a regex split of all 52 fields) while collect() runs 10 times per second for
-// the whole duration of a transaction. It does not include the cpu time of reaped child processes,
+// The approach to get the cpu usage info was taken from
+// https://eng.lyft.com/monitoring-cpu-performance-of-lyfts-android-applications-4e36fafffe12
+// The process cpu time itself comes from Process.getElapsedCpuTime(), a @CriticalNative wrapper
+// around clock_gettime(CLOCK_PROCESS_CPUTIME_ID), rather than from parsing /proc/self/stat: reading
+// and parsing that file allocated on every sample, and collect() runs 10 times per second for the
+// whole duration of a transaction. It does not include the cpu time of reaped child processes,
 // which an app process doesn't have.
 @ApiStatus.Internal
 public final class AndroidCpuCollector implements IPerformanceSnapshotCollector {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
@@ -1,56 +1,43 @@
 package io.sentry.android.core;
 
+import android.os.Process;
 import android.os.SystemClock;
 import android.system.Os;
 import android.system.OsConstants;
 import io.sentry.ILogger;
 import io.sentry.IPerformanceSnapshotCollector;
 import io.sentry.PerformanceCollectionData;
-import io.sentry.SentryLevel;
-import io.sentry.util.FileUtils;
 import io.sentry.util.Objects;
-import java.io.File;
-import java.io.IOException;
-import java.util.regex.Pattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-// The approach to get the cpu usage info was taken from
-// https://eng.lyft.com/monitoring-cpu-performance-of-lyfts-android-applications-4e36fafffe12
-// The content of the /proc/self/stat file is specified in
-// https://man7.org/linux/man-pages/man5/proc.5.html
+// Process.getElapsedCpuTime() is a @CriticalNative wrapper around
+// clock_gettime(CLOCK_PROCESS_CPUTIME_ID), i.e. the cpu time of all threads of this process. It
+// replaces reading utime/stime out of /proc/self/stat, which allocated ~25 kB per sample (file
+// reader buffers plus a regex split of all 52 fields) while collect() runs 10 times per second for
+// the whole duration of a transaction. It does not include the cpu time of reaped child processes,
+// which an app process doesn't have.
 @ApiStatus.Internal
 public final class AndroidCpuCollector implements IPerformanceSnapshotCollector {
+
+  private static final long NANOSECONDS_PER_MILLISECOND = 1_000_000;
 
   private long lastRealtimeNanos = 0;
   private long lastCpuNanos = 0;
 
-  /** Number of clock ticks per second. */
-  private long clockSpeedHz = 1;
-
   private long numCores = 1;
-  private final long NANOSECOND_PER_SECOND = 1_000_000_000;
 
-  /** Number of nanoseconds per clock tick. */
-  private double nanosecondsPerClockTick = NANOSECOND_PER_SECOND / (double) clockSpeedHz;
-
-  /** File containing stats about this process. */
-  private final @NotNull File selfStat = new File("/proc/self/stat");
-
-  private final @NotNull ILogger logger;
   private boolean isEnabled = false;
-  private final @NotNull Pattern newLinePattern = Pattern.compile("[\n\t\r ]");
 
   public AndroidCpuCollector(final @NotNull ILogger logger) {
-    this.logger = Objects.requireNonNull(logger, "Logger is required.");
+    Objects.requireNonNull(logger, "Logger is required.");
   }
 
   @Override
   public void setup() {
     isEnabled = true;
-    clockSpeedHz = Os.sysconf(OsConstants._SC_CLK_TCK);
     numCores = Os.sysconf(OsConstants._SC_NPROCESSORS_CONF);
-    nanosecondsPerClockTick = NANOSECOND_PER_SECOND / (double) clockSpeedHz;
+    lastRealtimeNanos = SystemClock.elapsedRealtimeNanos();
     lastCpuNanos = readTotalCpuNanos();
   }
 
@@ -74,36 +61,7 @@ public final class AndroidCpuCollector implements IPerformanceSnapshotCollector 
         (cpuUsagePercentage / (double) numCores) * 100.0);
   }
 
-  /** Read the /proc/self/stat file and parses the result. */
   private long readTotalCpuNanos() {
-    String stat = null;
-    try {
-      stat = FileUtils.readText(selfStat);
-    } catch (IOException e) {
-      // If an error occurs when reading the file, we avoid reading it again until the setup method
-      // is called again
-      isEnabled = false;
-      logger.log(
-          SentryLevel.WARNING, "Unable to read /proc/self/stat file. Disabling cpu collection.", e);
-    }
-    if (stat != null) {
-      stat = stat.trim();
-      String[] stats = newLinePattern.split(stat);
-      try {
-        // Amount of clock ticks this process has been scheduled in user mode
-        long uTime = Long.parseLong(stats[13]);
-        // Amount of clock ticks this process has been scheduled in kernel mode
-        long sTime = Long.parseLong(stats[14]);
-        // Amount of clock ticks this process' waited-for children has been scheduled in user mode
-        long cuTime = Long.parseLong(stats[15]);
-        // Amount of clock ticks this process' waited-for children has been scheduled in kernel mode
-        long csTime = Long.parseLong(stats[16]);
-        return (long) ((uTime + sTime + cuTime + csTime) * nanosecondsPerClockTick);
-      } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
-        logger.log(SentryLevel.ERROR, "Error parsing /proc/self/stat file.", e);
-        return 0;
-      }
-    }
-    return 0;
+    return Process.getElapsedCpuTime() * NANOSECONDS_PER_MILLISECOND;
   }
 }


### PR DESCRIPTION
Closes getsentry/sentry-java#5925  <br>Linear: getsentry/sentry-java#5925

## 📜 Description

TL;DR We can get the elapsed CPU time by calling `android.os.Process.getElapsedCpuTime()` instead of parsing it from a file. This is more performant and uses less memory and fixes one small bug. I hope it will reduce per device variation/issues. Let's see!

Ok on to the clanker generated details:  <br>`AndroidCpuCollector` obtained the process cpu time by reading `/proc/self/stat` and parsing `utime`/`stime`/`cutime`/`cstime` out of it. It now calls `android.os.Process.getElapsedCpuTime()`, which AOSP implements as a `@CriticalNative` wrapper around `clock_gettime(CLOCK_PROCESS_CPUTIME_ID)`.

That removes, per sample:

* the `FileReader`/`BufferedReader` buffers (an 8 kB `StreamDecoder` byte buffer plus a 16 kB `char[]`), the `StringBuilder`, the line `String` and the `toString()` copy
* a regex split of all 52 fields of `/proc/self/stat` — a `Matcher`, an `ArrayList` and \~52 `String`s, of which 4 were used
* five syscalls (`readText` stats the file three times via `exists`/`isFile`/`canRead` before the open)

It also removes the `Pattern.compile()` from the constructor, which ran on the `SentryAndroid.init` path whether or not performance collection ever started, along with the `_SC_CLK_TCK` sysconf and the IO/parse error handling that `isEnabled = false` existed for.

The new source excludes the cpu time of reaped child processes, which an app process does not have, and has millisecond rather than clock-tick (10 ms) resolution.

Second, unrelated fix in the same file: `setup()` seeded `lastCpuNanos` but not `lastRealtimeNanos`, so the first sample of every transaction divided the cpu delta by the time since device boot and reported \~0%.

No public API change (`apiDump` produces no diff).

## 💡 Motivation and Context

`collect()` runs every 100 ms for the whole duration of every transaction. On a Pixel 3 each call allocated 33623 bytes, i.e. \~336 kB/s of garbage while a transaction is in flight, to read four numbers out of a \~300 byte file.

<!-- linear:table-colwidths:266,266,266 -->
| per `collect()` | before | after |
| -- | -- | -- |
| bytes allocated | 33623 B | 16 B |
| wall time | 478 µs | 2.95 µs |

The remaining 16 bytes are the `Double` boxing in `setCpuUsagePercentage`, which this PR does not touch.

## 💚 How did you test it?

Existing unit tests pass. They can't cover the value itself — with `isReturnDefaultValues = true` the android.jar stubs return 0 for both clocks, so `when collect cpu is collected` really asserts `NaN != 0.0`, before and after this change.

So verification was done on a **Pixel 3 (blueline, Android 12 / API 31, 8 cores)** by dexing the class files out of the release build output and driving them with `app_process`.

**1.** `getElapsedCpuTime()` **agrees with** `/proc/self/stat`**:**

```
_SC_CLK_TCK = 100, _SC_NPROCESSORS_CONF = 8

idle 1000ms            wall=1002ms  getElapsedCpuTime=   1ms  /proc/self/stat=   0ms  diff= 1ms
busy 1 thread 1000ms   wall=1002ms  getElapsedCpuTime=1005ms  /proc/self/stat=1000ms  diff= 5ms
busy 4 threads 1000ms  wall=1003ms  getElapsedCpuTime=3966ms  /proc/self/stat=3970ms  diff=-4ms
busy 8 threads 1000ms  wall=1005ms  getElapsedCpuTime=7701ms  /proc/self/stat=7710ms  diff=-9ms
```

The unit is milliseconds, it counts all threads, and it tracks the `/proc` value to within one clock tick (10 ms) — the residual is the tick quantization on the `/proc` side.

**2. The collector reports the same percentages as before**, sampled at the 100 ms interval `DefaultCompositePerformanceCollector` uses:

```
idle                                   1.1%    1.4%    0.0%    0.4%    0.5%
1 of 8 cores busy (expect ~12.5%)      4.7%   12.8%   12.7%   12.7%   12.3%
4 of 8 cores busy (expect ~50%)       16.5%   49.7%   49.9%   49.5%   50.1%
8 of 8 cores busy (expect ~100%)      33.4%   95.3%   98.5%   96.0%   98.1%
```

(The low first value in each row is the load threads ramping up inside that 100 ms window.) The pre-change collector run through the same harness produces the same numbers.

**3. The first sample after** `setup()`**, taken under full load:**

```
before:  0.0%
after:  92.9%
```

**4. Allocation and timing**, via `Debug.getRuntimeStat("art.gc.bytes-allocated")` over 20k `collect()` calls, two runs each — the table above. Note `app_process` runs imageless (JIT-cold), so the absolute µs figures are inflated; the byte counts are exact.

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps

`AndroidMemoryCollector` runs on the same 100 ms timer and is worth the same look.