### PR TITLE
feat(core): Add timestamped child spans to ISpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Allow child spans to use explicit start timestamps through `ISpan` ([#5929](https://github.com/getsentry/sentry-java/pull/5929))
+
 ### Fixes
 
 - Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/api/sentry-opentelemetry-bootstrap.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/api/sentry-opentelemetry-bootstrap.api
@@ -85,6 +85,7 @@ public final class io/sentry/opentelemetry/OtelStrongRefSpanWrapper : io/sentry/
 	public fun startChild (Lio/sentry/SpanContext;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   testImplementation(projects.sentryTestSupport)
   testImplementation(kotlin(Config.kotlinStdLib))
   testImplementation(libs.awaitility.kotlin)
+  testImplementation(libs.google.truth)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.mockito.kotlin)
 

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/OtelStrongRefSpanWrapper.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/OtelStrongRefSpanWrapper.java
@@ -127,6 +127,12 @@ public final class OtelStrongRefSpanWrapper implements IOtelSpanWrapper {
 
   @Override
   public @NotNull ISpan startChild(
+      @NotNull String operation, @Nullable String description, @Nullable SentryDate timestamp) {
+    return delegate.startChild(operation, description, timestamp);
+  }
+
+  @Override
+  public @NotNull ISpan startChild(
       @NotNull String operation,
       @Nullable String description,
       @Nullable SentryDate timestamp,

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/test/kotlin/io/sentry/opentelemetry/OtelStrongRefSpanWrapperTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/test/kotlin/io/sentry/opentelemetry/OtelStrongRefSpanWrapperTest.kt
@@ -1,0 +1,26 @@
+package io.sentry.opentelemetry
+
+import com.google.common.truth.Truth.assertThat
+import io.opentelemetry.api.trace.Span
+import io.sentry.ISpan
+import io.sentry.SentryLongDate
+import kotlin.test.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class OtelStrongRefSpanWrapperTest {
+  @Test
+  fun `startChild with timestamp forwards to delegate`() {
+    val delegate = mock<IOtelSpanWrapper>()
+    val wrapper = OtelStrongRefSpanWrapper(mock<Span>(), delegate)
+    val timestamp = SentryLongDate(1234)
+    val expectedChild = mock<ISpan>()
+    whenever(delegate.startChild("child-op", "description", timestamp)).thenReturn(expectedChild)
+
+    val child = wrapper.startChild("child-op", "description", timestamp)
+
+    verify(delegate).startChild("child-op", "description", timestamp)
+    assertThat(child).isSameInstanceAs(expectedChild)
+  }
+}

--- a/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
@@ -99,6 +99,7 @@ public final class io/sentry/opentelemetry/OtelSpanWrapper : io/sentry/opentelem
 	public fun startChild (Lio/sentry/SpanContext;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;

--- a/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   testImplementation(projects.sentryTestSupport)
   testImplementation(kotlin(Config.kotlinStdLib))
   testImplementation(libs.awaitility.kotlin)
+  testImplementation(libs.google.truth)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.mockito.kotlin)
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelSpanWrapper.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelSpanWrapper.java
@@ -143,6 +143,12 @@ public final class OtelSpanWrapper implements IOtelSpanWrapper {
 
   @Override
   public @NotNull ISpan startChild(
+      @NotNull String operation, @Nullable String description, @Nullable SentryDate timestamp) {
+    return startChild(operation, description, timestamp, Instrumenter.SENTRY);
+  }
+
+  @Override
+  public @NotNull ISpan startChild(
       @NotNull String operation,
       @Nullable String description,
       @Nullable SentryDate timestamp,

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OtelSpanWrapperTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OtelSpanWrapperTest.kt
@@ -1,0 +1,60 @@
+package io.sentry.opentelemetry
+
+import com.google.common.truth.Truth.assertThat
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.sentry.IScopes
+import io.sentry.ISpan
+import io.sentry.ISpanFactory
+import io.sentry.Instrumenter
+import io.sentry.SentryLongDate
+import io.sentry.SentryOptions
+import io.sentry.SpanOptions
+import kotlin.test.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class OtelSpanWrapperTest {
+  @Test
+  fun `startChild with timestamp forwards timestamp and Sentry instrumenter`() {
+    val otelSpan = mock<ReadWriteSpan>()
+    whenever(otelSpan.spanContext)
+      .thenReturn(
+        SpanContext.create(
+          "2722d9f6ec019ade60c776169d9a8904",
+          "cedf5b7571cb4972",
+          TraceFlags.getSampled(),
+          TraceState.getDefault(),
+        )
+      )
+    whenever(otelSpan.name).thenReturn("parent")
+
+    val spanFactory = mock<ISpanFactory>()
+    val options = SentryOptions().apply { this.spanFactory = spanFactory }
+    val scopes = mock<IScopes>()
+    whenever(scopes.options).thenReturn(options)
+
+    val parent = OtelSpanWrapper(otelSpan, scopes, SentryLongDate(0), null, null, null, null)
+    val expectedChild = mock<ISpan>()
+    whenever(spanFactory.createSpan(eq(scopes), any(), any(), eq(parent))).thenReturn(expectedChild)
+    val timestamp = SentryLongDate(1234)
+
+    val child = parent.startChild("child-op", "description", timestamp)
+
+    val spanOptions = argumentCaptor<SpanOptions>()
+    val spanContext = argumentCaptor<io.sentry.SpanContext>()
+    verify(spanFactory)
+      .createSpan(eq(scopes), spanOptions.capture(), spanContext.capture(), eq(parent))
+    assertThat(child).isSameInstanceAs(expectedChild)
+    assertThat(spanOptions.firstValue.startTimestamp).isSameInstanceAs(timestamp)
+    assertThat(spanContext.firstValue.operation).isEqualTo("child-op")
+    assertThat(spanContext.firstValue.description).isEqualTo("description")
+    assertThat(spanContext.firstValue.instrumenter).isEqualTo(Instrumenter.SENTRY)
+  }
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1197,6 +1197,7 @@ public abstract interface class io/sentry/ISpan {
 	public abstract fun startChild (Lio/sentry/SpanContext;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public abstract fun startChild (Ljava/lang/String;)Lio/sentry/ISpan;
 	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;)Lio/sentry/ISpan;
 	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;)Lio/sentry/ISpan;
 	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
@@ -1223,7 +1224,6 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 	public abstract fun scheduleFinish ()V
 	public abstract fun setName (Ljava/lang/String;)V
 	public abstract fun setName (Ljava/lang/String;Lio/sentry/protocol/TransactionNameSource;)V
-	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;)Lio/sentry/ISpan;
 }
 
 public abstract interface class io/sentry/ITransactionProfiler {
@@ -1939,6 +1939,7 @@ public final class io/sentry/NoOpSpan : io/sentry/ISpan {
 	public fun startChild (Lio/sentry/SpanContext;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
@@ -4375,6 +4376,7 @@ public final class io/sentry/Span : io/sentry/ISpan {
 	public fun startChild (Lio/sentry/SpanContext;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SentryDate;Lio/sentry/Instrumenter;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanOptions;)Lio/sentry/ISpan;

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -54,6 +54,20 @@ public interface ISpan {
   ISpan startChild(@NotNull String operation, @Nullable String description);
 
   /**
+   * Starts a child Span.
+   *
+   * @param operation - new span operation name
+   * @param description - the span description
+   * @param timestamp - the start timestamp of the span
+   * @return a new transaction span
+   */
+  @NotNull
+  default ISpan startChild(
+      @NotNull String operation, @Nullable String description, @Nullable SentryDate timestamp) {
+    return startChild(operation, description, timestamp, Instrumenter.SENTRY);
+  }
+
+  /**
    * Returns the trace information that could be sent as a sentry-trace header.
    *
    * @return SentryTraceHeader.

--- a/sentry/src/main/java/io/sentry/ITransaction.java
+++ b/sentry/src/main/java/io/sentry/ITransaction.java
@@ -41,18 +41,6 @@ public interface ITransaction extends ISpan {
   List<Span> getSpans();
 
   /**
-   * Starts a child Span.
-   *
-   * @param operation - new span operation name
-   * @param description - the span description
-   * @param timestamp - the start timestamp of the span
-   * @return a new transaction span
-   */
-  @NotNull
-  ISpan startChild(
-      @NotNull String operation, @Nullable String description, @Nullable SentryDate timestamp);
-
-  /**
    * Returns if the profile of a transaction is sampled.
    *
    * @return profile is sampled

--- a/sentry/src/main/java/io/sentry/NoOpSpan.java
+++ b/sentry/src/main/java/io/sentry/NoOpSpan.java
@@ -59,6 +59,12 @@ public final class NoOpSpan implements ISpan {
   }
 
   @Override
+  public @NotNull ISpan startChild(
+      @NotNull String operation, @Nullable String description, @Nullable SentryDate timestamp) {
+    return NoOpSpan.getInstance();
+  }
+
+  @Override
   public @NotNull SentryTraceHeader toSentryTrace() {
     return new SentryTraceHeader(SentryId.EMPTY_ID, SpanId.EMPTY_ID, false);
   }

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -120,6 +120,12 @@ public final class Span implements ISpan {
 
   @Override
   public @NotNull ISpan startChild(
+      @NotNull String operation, @Nullable String description, @Nullable SentryDate timestamp) {
+    return startChild(operation, description, timestamp, Instrumenter.SENTRY);
+  }
+
+  @Override
+  public @NotNull ISpan startChild(
       final @NotNull String operation, final @Nullable String description) {
     if (finished) {
       return NoOpSpan.getInstance();

--- a/sentry/src/test/java/io/sentry/NoOpSpanTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpSpanTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
@@ -13,6 +14,11 @@ class NoOpSpanTest {
   fun `startChild does not return null`() {
     assertNotNull(span.startChild("op"))
     assertNotNull(span.startChild("op", "desc"))
+  }
+
+  @Test
+  fun `startChild with timestamp returns no-op span`() {
+    assertThat(span.startChild("op", "desc", SentryLongDate(1234))).isSameInstanceAs(span)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.protocol.SentryId
 import io.sentry.test.injectForField
 import kotlin.test.Test
@@ -92,6 +93,19 @@ class SpanTest {
     assertEquals(span.spanId, child.parentSpanId)
     assertEquals("child-op", child.operation)
     assertEquals("description", child.description)
+  }
+
+  @Test
+  fun `starting a child with timestamp uses exact timestamp`() {
+    val parent: ISpan = fixture.getSut()
+    val timestamp = SentryLongDate(1234)
+
+    val child = parent.startChild("child-op", "description", timestamp) as Span
+
+    assertThat(child.parentSpanId).isEqualTo(parent.spanContext.spanId)
+    assertThat(child.operation).isEqualTo("child-op")
+    assertThat(child.description).isEqualTo("description")
+    assertThat(child.startDate).isSameInstanceAs(timestamp)
   }
 
   @Test


### PR DESCRIPTION
## 📜 Description

Expose `ISpan.startChild(operation, description, timestamp)` as public API so nested spans can use an explicit start timestamp.

Move the existing timestamped contract from `ITransaction` to `ISpan` as a default method, preserving compatibility with external implementations. Forward the timestamp through core spans, no-ops, and OpenTelemetry wrappers.

## 💡 Motivation and Context

Nested spans, including children of Android's extended app-start span, previously had no stable public API for setting their actual start time. Deferred instrumentation therefore stamped spans when `startChild` was called and could report skewed durations.

Fixes getsentry/sentry-java#5896

## 💚 How did you test it?

* `./gradlew spotlessApply apiDump`
* `./gradlew :sentry:check :sentry-opentelemetry:sentry-opentelemetry-core:check :sentry-opentelemetry:sentry-opentelemetry-bootstrap:check`
* Focused core and OpenTelemetry tests for timestamp propagation and no-op/delegating implementations

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.

## 🔮 Next steps

None.