### PR TITLE
perf(core): Read the clock once per performance collection round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Performance
 
+- Read the clock once per performance collection round instead of once per in-flight transaction ([#5934](https://github.com/getsentry/sentry-java/pull/5934))
 - Reduce allocations while collecting cpu usage during transactions by reading the process cpu time via `Process.getElapsedCpuTime()` instead of parsing `/proc/self/stat` (33.6kB to 16 bytes per sample on a Pixel 3) ([#5926](https://github.com/getsentry/sentry-java/pull/5926))
 
 ### Dependencies

--- a/sentry/src/main/java/io/sentry/DefaultCompositePerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultCompositePerformanceCollector.java
@@ -124,7 +124,7 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
                 // Add the enriched tempData to all transactions/profiles/objects that collect data.
                 // Then Check if that object timed out.
                 for (CompositeData data : compositeDataMap.values()) {
-                  if (data.addDataAndCheckTimeout(tempData)) {
+                  if (data.addDataAndCheckTimeout(tempData, tempData.getNanoTimestamp())) {
                     // timed out
                     if (data.transaction != null) {
                       timedOutTransactions.add(data.transaction);
@@ -224,16 +224,19 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
      * Adds the data to the internal list of PerformanceCollectionData. Then it checks if data
      * collection timed out (for transactions only).
      *
+     * @param nowNanos the timestamp of the current collection, passed in so a single clock reading
+     *     is shared by every transaction in this collection round.
      * @return true if data collection timed out (for transactions only).
      */
-    boolean addDataAndCheckTimeout(final @NotNull PerformanceCollectionData data) {
+    boolean addDataAndCheckTimeout(
+        final @NotNull PerformanceCollectionData data, final long nowNanos) {
       // stop() hands dataList out while this timer thread may still be writing to it, so consumers
       // synchronize on the list while iterating. We must hold the same monitor here.
       synchronized (dataList) {
         dataList.add(data);
       }
       return transaction != null
-          && options.getDateProvider().now().nanoTimestamp()
+          && nowNanos
               > startTimestamp
                   + TimeUnit.MILLISECONDS.toNanos(TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
     }


### PR DESCRIPTION
## :scroll: Description

While a transaction is running, `DefaultCompositePerformanceCollector` collects performance data every 100ms for up to 30 seconds.

`CompositeData.addDataAndCheckTimeout` read the clock to check the 30s collection timeout once *per in-flight transaction*, allocating a `SentryNanotimeDate` (plus `System.currentTimeMillis()` + `System.nanoTime()`) each time — even though the enclosing timer task had just read the same clock for the sample it was distributing.

That reading is now passed in, so a collection round reads the clock once rather than once per transaction.

## :bulb: Motivation and Context

Perf improvement!

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps


