### PR TITLE
docs(agents): Fold pr.mdc into the create-java-pr skill

### DIFF
--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -7,7 +7,8 @@ description: Create a pull request in sentry-java. Use when asked to "create pr"
 
 Prepare local changes and create a pull request for the sentry-java repo.
 
-**Required reading:** Before proceeding, read `.cursor/rules/pr.mdc` for the full PR and stacked PR workflow details. That file is the source of truth for PR conventions, stack comment format, branch naming, and merge strategy.
+**For stacked PRs:** read `references/stacked-prs.md` before proceeding. It is the source of truth for
+stack structure, branch and title naming, stack list format, and merge strategy.
 
 ## Step 0: Determine PR Type From Git Branch Context
 
@@ -66,7 +67,7 @@ git checkout -b <type>/<short-description>
 
 Derive the branch name from the changes being made. Use `feat/`, `fix/`, `ref/`, etc. matching the commit type conventions.
 
-**For stacked PRs:** For the first PR in a new stack, first create and push the collection branch (see `.cursor/rules/pr.mdc` § "Creating the Collection Branch"), then branch the PR off it. For subsequent PRs, branch off the previous stack branch. Use the naming conventions from `.cursor/rules/pr.mdc` § "Branch Naming".
+**For stacked PRs:** For the first PR in a new stack, first create and push the collection branch (see `references/stacked-prs.md` § "Creating the Collection Branch"), then branch the PR off it. For subsequent PRs, branch off the previous stack branch. Use the naming conventions from `references/stacked-prs.md` § "Branch Naming".
 
 **CRITICAL: Never merge, fast-forward, or push commits into the collection branch.** It stays at its initial position until the user merges stack PRs through GitHub. Updating it will auto-merge and destroy the entire PR stack.
 
@@ -88,7 +89,13 @@ Check for uncommitted changes:
 git status --porcelain
 ```
 
-If there are uncommitted changes, invoke the `sentry-skills:commit` skill to stage and commit them following Sentry conventions.
+If there are uncommitted changes, invoke the `sentry-skills:commit` skill to stage and commit them following [Sentry commit message conventions](https://develop.sentry.dev/engineering-practices/commit-messages/):
+
+```
+<type>(<scope>): <subject>
+```
+
+Allowed types: `feat`, `fix`, `ref`, `chore`, `docs`, `test`, `perf`, `build`, `ci`, `style`, `meta`, `license`
 
 **Important:** When staging, ignore changes that are only relevant for local testing and should not be part of the PR. Common examples:
 
@@ -114,39 +121,28 @@ If the push fails due to diverged history, ask the user how to proceed rather th
 
 ## Step 5: Create PR
 
-Invoke the `sentry-skills:create-pr` skill to create a draft PR. When providing the PR body, use the repo's PR template structure from `.github/pull_request_template.md`:
+Invoke the `sentry-skills:create-pr` skill to create a draft PR.
+
+Read `.github/pull_request_template.md` and use it as the PR body structure — it is the single source
+of truth for the sections and checklist, so never reproduce it from memory. Fill in each section based
+on the changes being PR'd, drop the HTML comment hints, and check any checklist items that apply.
+
+**PR title format** — same as the commit subject (Step 3):
 
 ```
-## :scroll: Description
-<Describe the changes in detail>
-
-## :bulb: Motivation and Context
-<Why is this change required? What problem does it solve?>
-
-## :green_heart: How did you test it?
-<Describe how you tested>
-
-## :pencil: Checklist
-- [ ] I added GH Issue ID _&_ Linear ID
-- [ ] I added tests to verify the changes.
-- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
-- [ ] I updated the docs if needed.
-- [ ] I updated the wizard if needed.
-- [ ] Review from the native team if needed.
-- [ ] No breaking change or entry added to the changelog.
-- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
-
-## :crystal_ball: Next steps
+<type>(<scope>): <Subject>
 ```
 
-Fill in each section based on the changes being PR'd. Check any checklist items that apply.
+Examples:
+- `feat(core): Add structured logging support`
+- `fix(android): Prevent crash on API 21 when registering receiver`
 
 **For stacked PRs:**
 
 - Pass `--base <previous-stack-branch>` so the PR targets the previous branch (first PR in a stack targets the collection branch).
-- Use the stacked PR title format: `<type>(<scope>): [<Topic> <N>] <Subject>` (see `.cursor/rules/pr.mdc` § "PR Title Naming").
-- Include the stack list at the top of the PR body, before the `## :scroll: Description` section (see `.cursor/rules/pr.mdc` § "Stack List in PR Description" for the format).
-- Add a merge method reminder at the very end of the PR body (see `.cursor/rules/pr.mdc` § "Stack List in PR Description" for the exact text). This only applies to stack PRs, not the collection branch PR.
+- Use the stacked PR title format: `<type>(<scope>): [<Topic> <N>] <Subject>` (see `references/stacked-prs.md` § "PR Title Naming").
+- Include the stack list at the top of the PR body, before the `## :scroll: Description` section (see `references/stacked-prs.md` § "Stack List in PR Description" for the format).
+- Add a merge method reminder at the very end of the PR body (see `references/stacked-prs.md` § "Stack List in PR Description" for the exact text). This only applies to stack PRs, not the collection branch PR.
 
 Then continue to Step 5.5 (stacked PRs only) or Step 6.
 
@@ -154,7 +150,7 @@ Then continue to Step 5.5 (stacked PRs only) or Step 6.
 
 Skip this step for standalone PRs.
 
-After creating the PR, update the PR description on **every other PR in the stack — including the collection branch PR** — so all PRs have the same up-to-date stack list. Follow the format and commands in `.cursor/rules/pr.mdc` § "Stack List in PR Description".
+After creating the PR, update the PR description on **every other PR in the stack — including the collection branch PR** — so all PRs have the same up-to-date stack list. Follow the format and commands in `references/stacked-prs.md` § "Stack List in PR Description".
 
 **Important:** When updating PR bodies, never use shell redirects (`>`, `>>`) or pipes (`|`) or compound commands (`&&`). These create compound shell expressions that won't match permission patterns. Instead:
 - Use `gh pr view <NUMBER> --json body --jq '.body'` to get the body (output returned directly)
@@ -189,6 +185,8 @@ Add an entry to `CHANGELOG.md` under the `## Unreleased` section.
 | Dependency update | `### Dependencies` |
 
 Create the subsection under `## Unreleased` if it does not already exist.
+
+**When rebasing:** A rebase onto `main` can land your branch after a release was cut, where the `## Unreleased` heading your entry lived under has since been renamed to that version number. If that happens, move your new entry into an `## Unreleased` section at the top of `CHANGELOG.md` (create the section if it no longer exists) so it is not left under an already-released version.
 
 #### Entry format
 

--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -8,7 +8,7 @@ description: Create a pull request in sentry-java. Use when asked to "create pr"
 Prepare local changes and create a pull request for the sentry-java repo.
 
 **For stacked PRs:** read `references/stacked-prs.md` before proceeding. It is the source of truth for
-stack structure, branch and title naming, stack list format, and merge strategy.
+stack structure, title naming, stack list format, and merge strategy.
 
 ## Step 0: Determine PR Type From Git Branch Context
 
@@ -152,11 +152,7 @@ Skip this step for standalone PRs.
 
 After creating the PR, update the PR description on **every other PR in the stack — including the collection branch PR** — so all PRs have the same up-to-date stack list. Follow the format and commands in `references/stacked-prs.md` § "Stack List in PR Description".
 
-**Important:** When updating PR bodies, never use shell redirects (`>`, `>>`) or pipes (`|`) or compound commands (`&&`). These create compound shell expressions that won't match permission patterns. Instead:
-- Use `gh pr view <NUMBER> --json body --jq '.body'` to get the body (output returned directly)
-- Use the `Write` tool to save it to a temp file
-- Use the `Edit` tool to modify the temp file
-- Use `gh pr edit <NUMBER> --body-file /tmp/pr-body.md` to update
+Edit each body using the procedure in § "Editing PR Descriptions" below.
 
 ## Step 6: Update Changelog
 
@@ -208,8 +204,14 @@ git push
 
 ### No changelog needed
 
-If no changelog entry is needed, add `#skip-changelog` to the PR description to disable the changelog CI check:
+If no changelog entry is needed, append `#skip-changelog` to the end of the PR description to disable
+the changelog CI check, using the procedure in § "Editing PR Descriptions" below.
 
-1. Get the current body: `gh pr view <PR_NUMBER> --json body --jq '.body'`
-2. Use the `Write` tool to save the output to `/tmp/pr-body.md`, appending `\n#skip-changelog\n` at the end
-3. Update: `gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md`
+## Editing PR Descriptions
+
+Do not use shell redirects (`>`, `>>`), pipes (`|`), or compound commands (`&&`, `||`). These create
+compound shell expressions that won't match permission patterns. Instead:
+
+1. Read the body with `gh pr view <PR_NUMBER> --json body --jq '.body'` (output is returned directly)
+2. Use the `Write` tool to save it to `/tmp/pr-body.md`, and the `Edit` tool to modify it
+3. Update with `gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md`

--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -67,7 +67,7 @@ git checkout -b <type>/<short-description>
 
 Derive the branch name from the changes being made. Use `feat/`, `fix/`, `ref/`, etc. matching the commit type conventions.
 
-**For stacked PRs:** For the first PR in a new stack, first create and push the collection branch (see `references/stacked-prs.md` § "Creating the Collection Branch"), then branch the PR off it. For subsequent PRs, branch off the previous stack branch. Use the naming conventions from `references/stacked-prs.md` § "Branch Naming".
+**For stacked PRs:** For the first PR in a new stack, first create and push the collection branch (see `references/stacked-prs.md` § "Why a Collection Branch"), then branch the PR off it. For subsequent PRs, branch off the previous stack branch. Give every branch in the stack a shared prefix naming the feature, with a descriptive suffix per PR.
 
 **CRITICAL: Never merge, fast-forward, or push commits into the collection branch.** It stays at its initial position until the user merges stack PRs through GitHub. Updating it will auto-merge and destroy the entire PR stack.
 

--- a/.claude/skills/create-java-pr/references/stacked-prs.md
+++ b/.claude/skills/create-java-pr/references/stacked-prs.md
@@ -1,30 +1,44 @@
 # Stacked PRs
 
-Stacked PRs split a large feature into small, easy-to-review PRs where each builds on the previous one. This follows the same concept as the [Graphite](https://graphite.dev/) stacking workflow.
+Stacked PRs split a large feature into small, easy-to-review PRs where each builds on the previous
+one. The general mechanics are the standard [Graphite](https://graphite.dev/) stacking workflow —
+this file covers only what is specific to sentry-java.
 
-## Structure
+## Why a Collection Branch
 
 ```
 main ← collection-branch ← stack-pr-1 ← stack-pr-2 ← stack-pr-3 ← ...
 ```
 
-- A **collection branch** is created from `main` and targets `main`. It serves as the base for the entire stack.
-- The first PR in the stack targets the collection branch (not `main`).
-- Each subsequent PR targets the previous stack PR's branch as its base.
-- Each PR contains only incremental changes on top of the previous one.
+A **collection branch** is created from `main` and targets `main`. The first stack PR targets it
+rather than `main`, and each later PR targets the previous stack PR's branch.
 
-The collection branch exists so that individual stack PRs can be **merge-committed** (not squashed). PRs targeting `main` use squash merging, but that causes repeated merge conflicts when syncing the stack. Merge commits on non-`main` branches avoid this. The collection branch itself is squash-merged into `main` at the end.
+It exists because PRs targeting `main` are **squash**-merged, which causes repeated merge conflicts
+when syncing a stack. Stack PRs are therefore **merge-committed** into the collection branch, and
+only the collection branch is squash-merged into `main` at the end — giving `main` one clean commit
+for the whole feature.
 
-## Branch Naming
+Create it with an empty commit, so GitHub allows opening a PR:
 
-Prefer a shared prefix for the feature, with descriptive suffixes per PR. The collection branch uses the shared prefix. The type prefix (`feat/`, `fix/`, etc.) may vary depending on the nature of each PR's changes:
-
+```bash
+git commit --allow-empty -m "collection: <topic>"
 ```
-feat/scope-attributes              # collection branch → targets main
-feat/scope-attributes-api          # PR 1 → targets collection branch
-feat/scope-attributes-logger       # PR 2 → targets PR 1
-fix/attribute-type-detection        # PR 3 (fix, different name — that's fine) → targets PR 2
-```
+
+## Rules That Will Destroy a Stack If Broken
+
+**Never update the collection branch yourself.** Never merge, fast-forward, or push stack branch
+commits into it. It stays at its initial position (the empty commit on `main`) until the user merges
+stack PRs through GitHub one by one. Fast-forwarding it makes GitHub auto-merge and delete every
+stack PR branch, destroying the entire stack.
+
+**Never amend or force-push a stack branch.** No `git commit --amend`, `--force`, or
+`--force-with-lease` on a branch that is part of a stack — a force-push can cause GitHub to
+auto-merge or auto-close the other PRs in the stack. If a commit needs fixing, add a fixup commit.
+
+**Sync only between adjacent stack branches**, by merging forward — never into the collection branch.
+Prefer merge over rebase; only rebase if explicitly requested.
+
+**Do not merge PRs.** Only the user merges them, bottom to top.
 
 ## PR Title Naming
 
@@ -37,56 +51,13 @@ Include the topic name and a sequential number in brackets:
 Examples:
 - `feat(core): [Global Attributes 1] Add scope-level attributes API`
 - `feat(core): [Global Attributes 2] Wire scope attributes into LoggerApi and MetricsApi`
-- `feat(samples): [Global Attributes 3] Showcase scope attributes in Spring Boot 4 sample`
-
-## Finding All PRs in a Stack
-
-Do **not** rely on branch name patterns — later PRs in a stack may use different prefixes or naming. Instead:
-
-1. Find the PR for the current branch:
-   ```bash
-   gh pr list --head "$(git branch --show-current)" --json number,title,baseRefName --jq '.[0]'
-   ```
-2. Read the PR description — the stack list is at the top of the body.
-3. If there is no stack list yet, walk the chain in both directions:
-   ```bash
-   # Find the PR whose head branch is the current PR's base (go up)
-   gh pr list --head <baseRefName> --json number,title,baseRefName
-
-   # Find PRs whose base branch is the current PR's head (go down)
-   gh pr list --base <currentBranch> --json number,title,headRefName
-   ```
-   Repeat until you reach the collection branch going up and find no more PRs going down.
-
-## Creating the Collection Branch
-
-Before the first stacked PR, create the collection branch with an empty commit (so GitHub allows opening a PR) and create the collection PR:
-
-```bash
-git checkout main
-git checkout -b feat/<topic>
-git commit --allow-empty -m "collection: <topic>"
-git push -u origin HEAD
-gh pr create --base main --draft --title "<type>(<scope>): <Topic>" --body "Collection PR for the <Topic> stack. Squash-merge this once all stack PRs are merged."
-```
-
-**CRITICAL: Do NOT manually update the collection branch.** Never merge, fast-forward, or push stack branch commits into the collection branch. The collection branch stays at its initial position (the empty commit on `main`) until the user merges individual stack PRs into it one by one through GitHub. If you fast-forward the collection branch to include stack commits, GitHub will auto-merge and delete all stack PR branches, destroying the entire stack.
-
-## Creating a New Stacked PR
-
-1. Start from the tip of the previous stack branch (or the collection branch for the first PR).
-2. Create a new branch, make changes, format, commit, and push.
-3. Create the PR with `--base <previous-branch>` (the collection branch for the first PR):
-   ```bash
-   gh pr create --base feat/previous-branch --draft --title "<type>(<scope>): [<Topic> <N>] <Subject>" --body "..."
-   ```
-4. Add the stack list to the top of the new PR's description and update it on all existing PRs in the stack (see below).
 
 ## Stack List in PR Description
 
-Every PR in the stack — **including the collection branch PR** — must have a stack list **at the top of its description** (before the `## :scroll: Description` section). When a new PR is added, update the description on **all** PRs in the stack and on the collection branch PR.
-
-Format:
+Every PR in the stack — **including the collection branch PR** — must have a stack list **at the top
+of its description**, before the `## :scroll: Description` section. When a PR is added, update the
+description on **all** PRs in the stack. The stack list is also how you enumerate a stack: read it
+off any PR body rather than guessing from branch names, which may use different prefixes.
 
 ```markdown
 ## PR Stack (<Topic>)
@@ -98,50 +69,20 @@ Format:
 ---
 ```
 
-No status column — GitHub already shows that. The `---` separates the stack list from the rest of the PR description.
+No status column — GitHub already shows that. The `---` separates the stack list from the rest of
+the description.
 
-**Merge method reminder:** On stack PRs (not the collection branch PR), add the following line at the very end of the PR description:
+**Merge method reminder:** on stack PRs (not the collection branch PR), end the description with:
 
 ```markdown
 > ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
 ```
 
-This does not apply to standalone PRs or the collection branch PR.
+## Editing PR Descriptions
 
-To update the PR description, use `--body-file` to avoid shell quoting issues with special characters in the body.
+Do not use shell redirects (`>`, `>>`), pipes (`|`), or compound commands (`&&`, `||`). These create
+compound shell expressions that won't match permission patterns. Instead:
 
-**Important:** Do not use shell redirects (`>`, `>>`, `|`) or compound commands (`&&`, `||`). These create compound shell expressions that won't match permission patterns. Instead, use the `Write` and `Edit` tools for file manipulation:
-
-1. Read the current body with `gh pr view <PR_NUMBER> --json body --jq '.body'` (the output is returned directly — use the `Write` tool to save it to `/tmp/pr-body.md`)
-2. Use the `Edit` tool to prepend or replace the stack list section in `/tmp/pr-body.md`
-3. Update the description: `gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md`
-
-## Merging Stacked PRs (done by the user, not the agent)
-
-Individual stack PRs are merged in order from bottom to top (PR 1 first, then PR 2, etc.) using **merge commits** (not squash). After each merge, the next PR's base automatically becomes the merged branch's target. GitHub handles rebasing onto the new base.
-
-Once all stack PRs are merged into the collection branch, the collection PR is **squash-merged** into `main`. This gives `main` a clean single commit for the entire feature.
-
-**Do not merge PRs.** Only the user merges PRs.
-
-## Syncing the Stack
-
-When a base PR changes (e.g. after addressing review feedback on PR 1), merge the changes forward through the stack **between adjacent stack PR branches only**:
-
-```bash
-# On the branch for PR 2
-git checkout feat/scope-attributes-logger
-git merge feat/scope-attributes-api
-git push
-
-# On the branch for PR 3
-git checkout feat/scope-attributes-sample
-git merge feat/scope-attributes-logger
-git push
-```
-
-**Never merge into the collection branch.** Syncing only happens between stack PR branches. The collection branch is untouched until the user merges PRs through GitHub.
-
-Prefer merge over rebase — it preserves commit history, doesn't invalidate existing review comments, and avoids the need for force-pushing. Only rebase if explicitly requested.
-
-**Never amend or force-push stack branches.** Do not use `git commit --amend`, `--force`, or `--force-with-lease` on branches that are part of a stack. Amending a pushed commit requires a force-push, which can cause GitHub to auto-merge or auto-close other PRs in the stack. If a commit needs fixing, add a new fixup commit instead.
+1. Read the body with `gh pr view <PR_NUMBER> --json body --jq '.body'` (output is returned directly)
+2. Use the `Write` tool to save it to `/tmp/pr-body.md`, and the `Edit` tool to modify it
+3. Update with `gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md`

--- a/.claude/skills/create-java-pr/references/stacked-prs.md
+++ b/.claude/skills/create-java-pr/references/stacked-prs.md
@@ -1,125 +1,8 @@
----
-alwaysApply: false
-description: Pull request creation, stacked PRs, and PR workflow
----
-
-# Pull Request Rules
-
-## Creating a Pull Request
-
-### Step 1: Ensure Feature Branch
-
-If on `main`, create and switch to a new branch:
-
-```bash
-git checkout -b <type>/<short-description>
-```
-
-Branch names use `feat/`, `fix/`, `ref/`, etc. matching the commit type.
-
-### Step 2: Format Code and Regenerate API Files
-
-```bash
-./gradlew spotlessApply apiDump
-```
-
-This is **required** before every PR. Fix any failures before continuing.
-
-### Step 3: Commit Changes
-
-Use `git status --porcelain` to review changes. Ignore files only relevant for local testing (hardcoded debug toggles, sample app config, `.env` files). Restore those with `git checkout -- <file>`.
-
-Follow [Sentry commit message conventions](https://develop.sentry.dev/engineering-practices/commit-messages/):
-
-```
-<type>(<scope>): <subject>
-```
-
-Allowed types: `feat`, `fix`, `ref`, `chore`, `docs`, `test`, `perf`, `build`, `ci`, `style`, `meta`, `license`
-
-- Use imperative present tense ("add" not "added")
-- Capitalize subject, no trailing period
-- Keep under 100 characters
-
-### Step 4: Push
-
-```bash
-git push -u origin HEAD
-```
-
-If push fails due to diverged history, ask the user — do not force-push.
-
-### Step 5: Create PR
-
-Create a draft PR using the repo's PR template:
-
-```markdown
-## :scroll: Description
-<Describe the changes in detail>
-
-## :bulb: Motivation and Context
-<Why is this change required? What problem does it solve?>
-
-## :green_heart: How did you test it?
-<Describe how you tested>
-
-## :pencil: Checklist
-- [ ] I added GH Issue ID _&_ Linear ID
-- [ ] I added tests to verify the changes.
-- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
-- [ ] I updated the docs if needed.
-- [ ] I updated the wizard if needed.
-- [ ] Review from the native team if needed.
-- [ ] No breaking change or entry added to the changelog.
-- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
-
-## :crystal_ball: Next steps
-```
-
-### Step 6: Update Changelog
-
-Add an entry to `CHANGELOG.md` under `## Unreleased` in the appropriate subsection:
-
-| Change Type | Subsection |
-|---|---|
-| New feature | `### Features` |
-| Bug fix | `### Fixes` |
-| Refactoring, internal cleanup | `### Internal` |
-| Dependency update | `### Dependencies` |
-
-Entry format:
-
-```markdown
-- <Short description> ([#<PR_NUMBER>](https://github.com/getsentry/sentry-java/pull/<PR_NUMBER>))
-```
-
-**When rebasing:** A rebase onto `main` can land your branch after a release was cut, where the `## Unreleased` heading your entry lived under has since been renamed to that version number. If that happens, move your new entry into an `## Unreleased` section at the top of `CHANGELOG.md` (create the section if it no longer exists) so it is not left under an already-released version.
-
-Commit changelog separately:
-
-```bash
-git add CHANGELOG.md && git commit -m "changelog" && git push
-```
-
-### PR Title Format
-
-Follow the commit message format:
-
-```
-<type>(<scope>): <Subject>
-```
-
-Examples:
-- `feat(core): Add structured logging support`
-- `fix(android): Prevent crash on API 21 when registering receiver`
-
----
-
-## Stacked PRs
+# Stacked PRs
 
 Stacked PRs split a large feature into small, easy-to-review PRs where each builds on the previous one. This follows the same concept as the [Graphite](https://graphite.dev/) stacking workflow.
 
-### Structure
+## Structure
 
 ```
 main ← collection-branch ← stack-pr-1 ← stack-pr-2 ← stack-pr-3 ← ...
@@ -132,7 +15,7 @@ main ← collection-branch ← stack-pr-1 ← stack-pr-2 ← stack-pr-3 ← ...
 
 The collection branch exists so that individual stack PRs can be **merge-committed** (not squashed). PRs targeting `main` use squash merging, but that causes repeated merge conflicts when syncing the stack. Merge commits on non-`main` branches avoid this. The collection branch itself is squash-merged into `main` at the end.
 
-### Branch Naming
+## Branch Naming
 
 Prefer a shared prefix for the feature, with descriptive suffixes per PR. The collection branch uses the shared prefix. The type prefix (`feat/`, `fix/`, etc.) may vary depending on the nature of each PR's changes:
 
@@ -143,7 +26,7 @@ feat/scope-attributes-logger       # PR 2 → targets PR 1
 fix/attribute-type-detection        # PR 3 (fix, different name — that's fine) → targets PR 2
 ```
 
-### PR Title Naming
+## PR Title Naming
 
 Include the topic name and a sequential number in brackets:
 
@@ -156,7 +39,7 @@ Examples:
 - `feat(core): [Global Attributes 2] Wire scope attributes into LoggerApi and MetricsApi`
 - `feat(samples): [Global Attributes 3] Showcase scope attributes in Spring Boot 4 sample`
 
-### Finding All PRs in a Stack
+## Finding All PRs in a Stack
 
 Do **not** rely on branch name patterns — later PRs in a stack may use different prefixes or naming. Instead:
 
@@ -175,7 +58,7 @@ Do **not** rely on branch name patterns — later PRs in a stack may use differe
    ```
    Repeat until you reach the collection branch going up and find no more PRs going down.
 
-### Creating the Collection Branch
+## Creating the Collection Branch
 
 Before the first stacked PR, create the collection branch with an empty commit (so GitHub allows opening a PR) and create the collection PR:
 
@@ -189,7 +72,7 @@ gh pr create --base main --draft --title "<type>(<scope>): <Topic>" --body "Coll
 
 **CRITICAL: Do NOT manually update the collection branch.** Never merge, fast-forward, or push stack branch commits into the collection branch. The collection branch stays at its initial position (the empty commit on `main`) until the user merges individual stack PRs into it one by one through GitHub. If you fast-forward the collection branch to include stack commits, GitHub will auto-merge and delete all stack PR branches, destroying the entire stack.
 
-### Creating a New Stacked PR
+## Creating a New Stacked PR
 
 1. Start from the tip of the previous stack branch (or the collection branch for the first PR).
 2. Create a new branch, make changes, format, commit, and push.
@@ -199,7 +82,7 @@ gh pr create --base main --draft --title "<type>(<scope>): <Topic>" --body "Coll
    ```
 4. Add the stack list to the top of the new PR's description and update it on all existing PRs in the stack (see below).
 
-### Stack List in PR Description
+## Stack List in PR Description
 
 Every PR in the stack — **including the collection branch PR** — must have a stack list **at the top of its description** (before the `## :scroll: Description` section). When a new PR is added, update the description on **all** PRs in the stack and on the collection branch PR.
 
@@ -233,7 +116,7 @@ To update the PR description, use `--body-file` to avoid shell quoting issues wi
 2. Use the `Edit` tool to prepend or replace the stack list section in `/tmp/pr-body.md`
 3. Update the description: `gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md`
 
-### Merging Stacked PRs (done by the user, not the agent)
+## Merging Stacked PRs (done by the user, not the agent)
 
 Individual stack PRs are merged in order from bottom to top (PR 1 first, then PR 2, etc.) using **merge commits** (not squash). After each merge, the next PR's base automatically becomes the merged branch's target. GitHub handles rebasing onto the new base.
 
@@ -241,7 +124,7 @@ Once all stack PRs are merged into the collection branch, the collection PR is *
 
 **Do not merge PRs.** Only the user merges PRs.
 
-### Syncing the Stack
+## Syncing the Stack
 
 When a base PR changes (e.g. after addressing review feedback on PR 1), merge the changes forward through the stack **between adjacent stack PR branches only**:
 

--- a/.claude/skills/create-java-pr/references/stacked-prs.md
+++ b/.claude/skills/create-java-pr/references/stacked-prs.md
@@ -24,6 +24,10 @@ Create it with an empty commit, so GitHub allows opening a PR:
 git commit --allow-empty -m "collection: <topic>"
 ```
 
+Push it and open its PR against `main` right away — it is the PR the whole stack is eventually
+squash-merged through, and it carries the stack list like every other PR. Give it a plain title
+(`<type>(<scope>): <Topic>`, no `[<Topic> <N>]` bracket) and no merge method reminder.
+
 ## Rules That Will Destroy a Stack If Broken
 
 **Never update the collection branch yourself.** Never merge, fast-forward, or push stack branch
@@ -78,11 +82,5 @@ the description.
 > ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
 ```
 
-## Editing PR Descriptions
-
-Do not use shell redirects (`>`, `>>`), pipes (`|`), or compound commands (`&&`, `||`). These create
-compound shell expressions that won't match permission patterns. Instead:
-
-1. Read the body with `gh pr view <PR_NUMBER> --json body --jq '.body'` (output is returned directly)
-2. Use the `Write` tool to save it to `/tmp/pr-body.md`, and the `Edit` tool to modify it
-3. Update with `gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md`
+Updating every PR's stack list means editing several descriptions — follow the procedure in
+`SKILL.md` § "Editing PR Descriptions".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,6 @@ rule file in `.cursor/rules/`:
 | `continuous_profiling_jvm` | `sentry-async-profiler`, `IContinuousProfiler`, `ProfileChunk`, JFR files, `ProfileLifecycle` |
 | `opentelemetry` | `sentry-opentelemetry-*`, agent vs agentless, span processing, sampling, context propagation |
 | `new_module` | Adding a new integration or sample module |
-| `pr` | Creating pull requests, stacked PRs, changelog entries |
 | `e2e_tests` | System tests, sample applications, `system-test-runner.py`, mock Sentry server |
 
 Rules can be combined — a tracing scope issue may need both `scopes` and `opentelemetry`.
@@ -225,7 +224,9 @@ gh pr view --json url -q '.url'
 
 ### Changelog
 
-User-facing changes get an entry under the `## Unreleased` section of `CHANGELOG.md`. When rebasing onto `main`, a release may have renamed the `## Unreleased` heading your entry was under to a version number — if so, move your entry back into an `## Unreleased` section at the top of the file (create it if it no longer exists). See `.cursor/rules/pr.mdc` for the full changelog and PR workflow.
+User-facing changes get an entry under the `## Unreleased` section of `CHANGELOG.md`. The
+`create-java-pr` skill is the source of truth for the full changelog and PR workflow, including
+subsection selection and the rebase caveat when a release renames `## Unreleased`.
 
 ## Useful Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ make systemTest
 4. **High-level communication**: Give high-level explanations of changes made, not step-by-step descriptions
 5. **Simplicity first**: Make every task and code change as simple as possible. Avoid massive or complex changes. Impact as little code as possible.
 6. **Format and regenerate**: Once done, format code and regenerate .api files: `./gradlew spotlessApply apiDump`
-7. **Propose commit**: As final step, git stage relevant files and propose (but not execute) a single git commit command
+7. **Propose commit**: As final step, git stage relevant files and propose (but not execute) a single git commit command. This applies to implementation work; when the task is to open a PR, the `create-java-pr` skill takes over from here and does commit, push, and open it.
 
 ## Repository Skills
 


### PR DESCRIPTION
## :scroll: Description

Deletes `.cursor/rules/pr.mdc` (264 lines) and gives its content a single home each:

- **Conventions the skill was missing** → `create-java-pr/SKILL.md`: allowed commit types, PR title format, changelog rebase caveat.
- **Stacked-PR workflow** (~150 lines) → `create-java-pr/references/stacked-prs.md`, loaded on demand. Git tracks this as a rename.
- **Everything else** → already duplicated in the skill, so dropped.

The skill now reads `.github/pull_request_template.md` for the PR body instead of reproducing it, with an explicit instruction never to write it from memory. `AGENTS.md` drops the `pr` row from the rule table and points its Changelog section at the skill.

### Fixes found by dry-running the result

Agents were run against the deduped docs for "create a PR" and "create a stacked PR", stopping before the first mutating action. Both paths loaded the intended files — the standalone run never opened `stacked-prs.md` — and surfaced four defects, now fixed:

- `SKILL.md` named `stacked-prs.md` the source of truth for **branch** naming, which it never covered. Claim corrected to title naming.
- Four passages referenced "the collection branch PR"; no step ever opened it. Added, with its title and merge-reminder exceptions.
- The PR-description editing rule was stated three times and had already drifted (`&&` vs `&&`/`||`). Now stated once in `SKILL.md`, which both paths read.
- `AGENTS.md` step 7 ("propose but not execute a commit") contradicted the skill, which commits, pushes, and opens the PR. Scoped to implementation work.

## :bulb: Motivation and Context

`pr.mdc` and the skill described the same six-step workflow. The skill opened by declaring `pr.mdc` "required reading … the source of truth," then re-implemented every step anyway. Both inlined the PR template and the changelog subsection table.

Nobody on the team uses Cursor, so the split bought nothing — it just doubled the surface that had to stay in sync. And it hadn't: **both** inlined templates were missing a checklist item `.github/pull_request_template.md` has since gained:

```
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented
      according to the develop docs spec
```

Every PR created through the skill silently dropped it. Pointing at the template file makes that class of drift impossible.

## :green_heart: How did you test it?

Docs-only — no code paths affected.

- Dry-ran both PR flows with fresh agents; verified the file sets read, and that every fix above resolves a defect an agent actually hit.
- No references to `pr.mdc` remain.
- The PR template's section headers appear in exactly one file.
- The `AGENTS.md` rule table matches `.cursor/rules/` exactly (12 rules, 12 rows).
- Spotless covers only Java/Kotlin, so no formatting run applies.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Remaining duplication, in order of payoff:

- `AGENTS.md` repeats `./gradlew spotlessApply apiDump` across nine lines; the `Makefile` is the source of truth. (`CONTRIBUTING.md` also documents a `make format` target that doesn't exist — one-line fix held back for its own PR, which this one should follow.)
- Changelog rules still live in both `AGENTS.md` and the skill.
- Test invocation appears in `AGENTS.md`, `test/SKILL.md`, and `e2e_tests.mdc`; the skill's module→task table is the accurate one.
- Step 0 of the skill has no branch for "this branch already has an open PR" — four dry runs produced four different plans for that case.
- The 12 remaining `.cursor/rules/` files are arguably misfiled if nobody uses Cursor, but rehoming them touches every rule reference.

#skip-changelog
