### PR TITLE
chore(android-sqlite): Remove experimental status from SentrySQLiteDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Make `ISpan.startChild` overloads with `SpanOptions` public ([#5927](https://github.com/getsentry/sentry-java/pull/5927))
 
+### Improvements
+
+- Remove `ApiStatus.Experimental` annotation from `SentrySQLiteDriver` ([#5938](https://github.com/getsentry/sentry-java/pull/5938))
+
 ### Fixes
 
 - Clear contexts when calling `Scope.clear()` ([#5902](https://github.com/getsentry/sentry-java/pull/5902))

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -53,10 +53,6 @@ android {
 
   buildFeatures { buildConfig = true }
 
-  // Needed b/c Kotlin 1.4.x would otherwise pull in an older version without the annotations we
-  // want.
-  configurations.all { resolutionStrategy.force(libs.jetbrains.annotations.get()) }
-
   androidComponents.beforeVariants {
     it.enable = !Config.Android.shouldSkipDebugVariant(it.buildType)
   }
@@ -75,14 +71,12 @@ dependencies {
   api(projects.sentry)
 
   compileOnly(libs.androidx.sqlite)
-  compileOnly(libs.jetbrains.annotations)
 
   implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
 
   // tests
   testImplementation(libs.androidx.sqlite)
   testImplementation(libs.kotlin.test.junit)
-  testImplementation(libs.androidx.test.ext.junit)
   testImplementation(libs.mockito.kotlin)
   testImplementation(libs.mockito.inline)
 }

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -3,9 +3,8 @@ package io.sentry.sqlite
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.SQLiteDriver
 import io.sentry.ScopesAdapter
-import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
-import org.jetbrains.annotations.ApiStatus
+import io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion
 
 /**
  * Wraps a [SQLiteDriver] and automatically adds spans for each SQL statement it executes.
@@ -23,16 +22,15 @@ import org.jetbrains.annotations.ApiStatus
  * ```
  *
  * If you're using the Sentry Android Gradle Plugin (SAGP) 6.13.0+, wrapping will be performed
- * automatically.
+ * automatically for Room.
  *
  * @param delegate The [SQLiteDriver] instance to delegate calls to.
  */
-@ApiStatus.Experimental
 public class SentrySQLiteDriver private constructor(private val delegate: SQLiteDriver) :
   SQLiteDriver {
 
   init {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("SQLiteDriver")
+    addIntegrationToSdkVersion("SQLiteDriver")
   }
 
   @Suppress("INAPPLICABLE_JVM_NAME")


### PR DESCRIPTION
## 📜 Description

Removes @ApiStatus.Experimental from SentrySQLiteDriver.

## 💡 Due Diligence

Crash review (Sentry sdk-crashes-java + Datadog SDK Crash Detection):

* Only a handful of events (\~10 over \~2 weeks) mention SentrySQLiteDriver / SentrySQLiteStatement. All are ordinary Android SQLite failures (disk I/O, full disk, read-only, can’t open) that pass through the wrapper — not instrumentation bugs.
* No ANRs, NPEs, or “Failed to instrument SQLite” failures on the io.sentry.sqlite path.
* Datadog Android crash rates for versions ogwith the driver (8.45+) look healthy (\~0.5–1.6 SDK crashes per 1K crashes excl. ANRs); no post-release spike attributable to the driver.
* Higher-volume “sqlite” noise in crash dashboards is almost entirely the older SentrySupportSQLite\* path (same false-positive pattern: customer DB errors with our frames as culprit).

## 💚 How did you test it?

## :pencil: Checklist

- [ ] I added GH Issue ID *&* Linear ID
- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.

## 🔮 Next steps