### PR TITLE
feat(logback): [Logs and Metrics Enable Flags 1] Add Logs opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add an explicit Logs opt-in to the Logback appender ([#5940](https://github.com/getsentry/sentry-java/pull/5940))
 - Make `ISpan.startChild` overloads with `SpanOptions` public ([#5927](https://github.com/getsentry/sentry-java/pull/5927))
 
 ### Improvements

--- a/sentry-logback/api/sentry-logback.api
+++ b/sentry-logback/api/sentry-logback.api
@@ -14,6 +14,8 @@ public class io/sentry/logback/SentryAppender : ch/qos/logback/core/Unsynchroniz
 	public fun getMinimumBreadcrumbLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumEventLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumLevel ()Lch/qos/logback/classic/Level;
+	public fun isEnableLogs ()Z
+	public fun setEnableLogs (Z)V
 	public fun setEncoder (Lch/qos/logback/core/encoder/Encoder;)V
 	public fun setMinimumBreadcrumbLevel (Lch/qos/logback/classic/Level;)V
 	public fun setMinimumEventLevel (Lch/qos/logback/classic/Level;)V

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -52,6 +52,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
   private @NotNull Level minimumEventLevel = Level.ERROR;
   private @NotNull Level minimumLevel = Level.INFO;
+  private boolean enableLogs = false;
   private @Nullable Encoder<ILoggingEvent> encoder;
 
   static {
@@ -87,7 +88,8 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
-    if (ScopesAdapter.getInstance().getOptions().getLogs().isEnabled()
+    if (enableLogs
+        && ScopesAdapter.getInstance().getOptions().getLogs().isEnabled()
         && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
       captureLog(eventObject);
     }
@@ -321,6 +323,14 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   public @NotNull Level getMinimumLevel() {
     return minimumLevel;
+  }
+
+  public void setEnableLogs(final boolean enableLogs) {
+    this.enableLogs = enableLogs;
+  }
+
+  public boolean isEnableLogs() {
+    return enableLogs;
   }
 
   @ApiStatus.Internal

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -38,6 +38,7 @@ import kotlin.test.assertTrue
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.slf4j.Logger
@@ -55,6 +56,7 @@ class SentryAppenderTest {
     encoder: Encoder<ILoggingEvent>? = null,
     sendDefaultPii: Boolean = false,
     enableLogs: Boolean = false,
+    enableGlobalLogs: Boolean = enableLogs,
     options: SentryOptions = SentryOptions(),
     startLater: Boolean = false,
   ) {
@@ -71,7 +73,7 @@ class SentryAppenderTest {
       this.encoder = encoder
       options.dsn = dsn
       options.isSendDefaultPii = sendDefaultPii
-      options.logs.isEnabled = enableLogs
+      options.logs.isEnabled = enableGlobalLogs
       options.logs.loggerBatchProcessorFactory = ILoggerBatchProcessorFactory { options, client ->
         LoggerBatchProcessor(options, client, ImmediateExecutorService())
       }
@@ -81,6 +83,7 @@ class SentryAppenderTest {
       appender.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
       appender.setMinimumEventLevel(minimumEventLevel)
       appender.setMinimumLevel(minimumLevel)
+      appender.setEnableLogs(enableLogs)
       appender.context = loggerContext
       appender.setTransportFactory(transportFactory)
       encoder?.context = loggerContext
@@ -320,6 +323,57 @@ class SentryAppenderTest {
         },
         anyOrNull(),
       )
+  }
+
+  @Test
+  fun `does not capture logs by default when aggregate logs are enabled`() {
+    fixture = Fixture(enableGlobalLogs = true)
+
+    assertFalse(fixture.appender.isEnableLogs)
+    fixture.logger.info("this should not be captured as a log")
+    Sentry.flush(10)
+
+    verify(fixture.transport, never()).send(checkLogs {})
+  }
+
+  @Test
+  fun `captures logs when local and aggregate logs are enabled`() {
+    fixture = Fixture(enableLogs = true)
+
+    assertTrue(fixture.appender.isEnableLogs)
+    fixture.logger.info("this should be captured as a log")
+    Sentry.flush(10)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          assertEquals("this should be captured as a log", logs.items.first().body)
+        }
+      )
+  }
+
+  @Test
+  fun `captures events and breadcrumbs when local logs are disabled`() {
+    fixture =
+      Fixture(
+        minimumBreadcrumbLevel = Level.INFO,
+        minimumEventLevel = Level.ERROR,
+        enableGlobalLogs = true,
+      )
+
+    fixture.logger.info("this should be a breadcrumb")
+    fixture.logger.error("this should be an event")
+    Sentry.flush(10)
+
+    verify(fixture.transport)
+      .send(
+        checkEvent { event ->
+          assertEquals("this should be an event", event.message?.formatted)
+          assertEquals("this should be a breadcrumb", event.breadcrumbs?.single()?.message)
+        },
+        anyOrNull(),
+      )
+    verify(fixture.transport, never()).send(checkLogs {})
   }
 
   @Test

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -17,12 +17,13 @@
         <enabled>true</enabled>
       </logs>
     </options>
+    <enableLogs>true</enableLogs>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->
     <minimumEventLevel>WARN</minimumEventLevel>
     <!-- Default for Breadcrumbs is INFO -->
     <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
-    <!-- Default for Breadcrumbs is INFO -->
+    <!-- Default for Logs is INFO -->
     <minimumLevel>INFO</minimumLevel>
   </appender>
 


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Adds a `logsEnabled` option to the Logback `SentryAppender`. The option defaults to `false` and can be configured through Java or Logback XML.

The appender now requires both this local opt-in and the existing aggregate core Logs flag before forwarding Logback records as Sentry Logs. Event and breadcrumb capture remain unchanged.

## :bulb: Motivation and Context

Logging integrations need explicit local opt-ins before the aggregate core Logs flag can be removed later in this stack. This prevents applications from unexpectedly forwarding framework logs when core Logs capture becomes available without a global enable flag.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry-logback:test`
- Added tests for the default-disabled behavior, explicit opt-in, and independent event/breadcrumb capture

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Continue adding integration-local Logs opt-ins before removing the aggregate core Logs flag.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


