### PR TITLE
docs(agents): Forbid introducing new catch Throwable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,41 @@ The repository is organized into multiple modules:
 - **Formatting**: Enforced via Spotless - always run `./gradlew spotlessApply` before committing
 - **API Compatibility**: Binary compatibility is enforced - run `./gradlew apiDump` after API changes
 
+### Exception Handling
+
+**Never introduce a new `catch (Throwable)`.** Catch the narrowest type the guarded code can
+actually throw. The repository still contains many pre-existing broad catches; they are legacy,
+not a precedent to follow.
+
+A broad catch swallows `OutOfMemoryError`, `StackOverflowError`, `ThreadDeath` and `LinkageError` —
+conditions the JVM/ART cannot recover from and that leave the process in an undefined state — and
+it hides real bugs in our own code behind a log line.
+
+"The SDK must never crash the host application" is not a reason to catch `Throwable`. That goal is
+served by `io.sentry.util.ExceptionUtils.rethrowIfFatal`, which lets the non-recoverable throwables
+through while leaving everything else for the caller to log or ignore:
+
+```java
+try {
+  doSomethingRisky();
+} catch (Throwable t) {
+  ExceptionUtils.rethrowIfFatal(t);
+  options.getLogger().log(SentryLevel.ERROR, "Failed to do something risky", t);
+}
+```
+
+Apply that pattern only where a broad catch is genuinely unavoidable — an entry point that runs
+arbitrary user code or third-party callbacks. Everywhere else, name the exception types. Say in the
+PR description why the broad catch is necessary.
+
+Two related cases:
+- **Probing an optional `compileOnly` dependency**: a missing or version-mismatched class surfaces
+  as a `LinkageError` subclass (`NoClassDefFoundError`, `NoSuchMethodError`, `UnsatisfiedLinkError`),
+  which `rethrowIfFatal` deliberately rethrows. Catch the specific subclass locally *before*
+  delegating — see `SentrySQLiteDriver.hasConnectionPool` and `LoadClass`.
+- **`InterruptedException`**: never swallow it. Either let it propagate or restore the interrupt
+  with `Thread.currentThread().interrupt()`; `rethrowIfFatal` does the latter for you.
+
 ### Testing Requirements
 - Write comprehensive unit tests for new features
 - Android modules require both unit tests and instrumented tests where applicable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,14 +181,6 @@ Apply that pattern only where a broad catch is genuinely unavoidable — an entr
 arbitrary user code or third-party callbacks. Everywhere else, name the exception types. Say in the
 PR description why the broad catch is necessary.
 
-Two related cases:
-- **Probing an optional `compileOnly` dependency**: a missing or version-mismatched class surfaces
-  as a `LinkageError` subclass (`NoClassDefFoundError`, `NoSuchMethodError`, `UnsatisfiedLinkError`),
-  which `rethrowIfFatal` deliberately rethrows. Catch the specific subclass locally *before*
-  delegating — see `SentrySQLiteDriver.hasConnectionPool` and `LoadClass`.
-- **`InterruptedException`**: never swallow it. Either let it propagate or restore the interrupt
-  with `Thread.currentThread().interrupt()`; `rethrowIfFatal` does the latter for you.
-
 ### Testing Requirements
 - Write comprehensive unit tests for new features
 - Android modules require both unit tests and instrumented tests where applicable


### PR DESCRIPTION
## :scroll: Description

Adds an **Exception Handling** section to `AGENTS.md` to use the new `ExceptionUtils.rethrowIfFatal`. Please feel free to debate the proposal!

## :bulb: Motivation and Context

Writing the rule down in `AGENTS.md` stops the pattern from spreading into new code without touching any of the existing call sites.

## :green_heart: How did you test it?

Documentation-only change; no code paths affected. Verified that `ExceptionUtils.rethrowIfFatal` exists and behaves as the section describes.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
