### PR TITLE
feat(android): [Logs and Metrics Enable Flags 5] Add Logcat Logs opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add an explicit Logs opt-in to the Android Logcat integration ([#5945](https://github.com/getsentry/sentry-java/pull/5945))
 - Add an explicit Logs opt-in to the Android Timber integration ([#5943](https://github.com/getsentry/sentry-java/pull/5943))
 - Add an explicit Logs opt-in to the JUL handler ([#5942](https://github.com/getsentry/sentry-java/pull/5942))
 - Add an explicit Logs opt-in to the Log4j2 appender ([#5941](https://github.com/getsentry/sentry-java/pull/5941))

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -430,6 +430,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isEnableAutoActivityLifecycleTracing ()Z
 	public fun isEnableAutoTraceIdGeneration ()Z
 	public fun isEnableFramesTracking ()Z
+	public fun isEnableLogcatLogs ()Z
 	public fun isEnableNdk ()Z
 	public fun isEnableNdkAppHangTracking ()Z
 	public fun isEnableNetworkEventBreadcrumbs ()Z
@@ -464,6 +465,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableAutoActivityLifecycleTracing (Z)V
 	public fun setEnableAutoTraceIdGeneration (Z)V
 	public fun setEnableFramesTracking (Z)V
+	public fun setEnableLogcatLogs (Z)V
 	public fun setEnableNdk (Z)V
 	public fun setEnableNdkAppHangTracking (Z)V
 	public fun setEnableNetworkEventBreadcrumbs (Z)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -165,6 +165,8 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_TIMBER_LOGS = "io.sentry.timber.logs.enabled";
 
+  static final String ENABLE_LOGCAT_LOGS = "io.sentry.logcat.logs.enabled";
+
   static final String ENABLE_METRICS = "io.sentry.metrics.enabled";
 
   static final String ENABLE_AUTO_TRACE_ID_GENERATION =
@@ -710,6 +712,9 @@ final class ManifestMetadataReader {
 
         options.setEnableTimberLogs(
             readBool(metadata, logger, ENABLE_TIMBER_LOGS, options.isEnableTimberLogs()));
+
+        options.setEnableLogcatLogs(
+            readBool(metadata, logger, ENABLE_LOGCAT_LOGS, options.isEnableLogcatLogs()));
 
         options
             .getMetrics()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -74,6 +74,9 @@ public final class SentryAndroidOptions extends SentryOptions {
   /** Enable or disable automatic Sentry Logs capture from Timber. Default is disabled. */
   private boolean enableTimberLogs = false;
 
+  /** Enable or disable automatic Sentry Logs capture from Logcat. Default is disabled. */
+  private boolean enableLogcatLogs = false;
+
   /**
    * Enables the Auto instrumentation for Activity lifecycle tracing.
    *
@@ -466,6 +469,14 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   public void setEnableTimberLogs(boolean enableTimberLogs) {
     this.enableTimberLogs = enableTimberLogs;
+  }
+
+  public boolean isEnableLogcatLogs() {
+    return enableLogcatLogs;
+  }
+
+  public void setEnableLogcatLogs(boolean enableLogcatLogs) {
+    this.enableLogcatLogs = enableLogcatLogs;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryLogcatAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryLogcatAdapter.java
@@ -6,6 +6,7 @@ import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.SentryLogLevel;
+import io.sentry.SentryOptions;
 import io.sentry.logger.SentryLogParameters;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -52,8 +53,10 @@ public final class SentryLogcatAdapter {
       @Nullable final String msg,
       @Nullable final Throwable tr) {
     final @NotNull ScopesAdapter scopes = ScopesAdapter.getInstance();
-    // Check if logs are enabled before doing expensive operations
-    if (!scopes.getOptions().getLogs().isEnabled()) {
+    final @NotNull SentryOptions options = scopes.getOptions();
+    if (!(options instanceof SentryAndroidOptions)
+        || !((SentryAndroidOptions) options).isEnableLogcatLogs()
+        || !options.getLogs().isEnabled()) {
       return;
     }
     final @Nullable String trMessage = tr != null ? tr.getMessage() : null;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.FilterString
 import io.sentry.ILogger
 import io.sentry.ProfileLifecycle
@@ -1984,6 +1985,36 @@ class ManifestMetadataReaderTest {
     ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
     assertTrue(fixture.options.isEnableTimberLogs)
+  }
+
+  @Test
+  fun `applyMetadata keeps Logcat logs disabled if not found`() {
+    val context = fixture.getContext()
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    assertThat(fixture.options.isEnableLogcatLogs).isFalse()
+  }
+
+  @Test
+  fun `applyMetadata reads Logcat logs enabled to options`() {
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_LOGCAT_LOGS to true)
+    val context = fixture.getContext(metaData = bundle)
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    assertThat(fixture.options.isEnableLogcatLogs).isTrue()
+  }
+
+  @Test
+  fun `applyMetadata reads Logcat logs disabled to options`() {
+    fixture.options.isEnableLogcatLogs = true
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_LOGCAT_LOGS to false)
+    val context = fixture.getContext(metaData = bundle)
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    assertThat(fixture.options.isEnableLogcatLogs).isFalse()
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.core
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.ITransactionProfiler
 import io.sentry.NoOpTransactionProfiler
 import io.sentry.protocol.DebugImage
@@ -106,6 +107,19 @@ class SentryAndroidOptionsTest {
     sentryOptions.isEnableTimberLogs = true
 
     assertTrue(sentryOptions.isEnableTimberLogs)
+  }
+
+  @Test
+  fun `Logcat logs are disabled by default`() {
+    assertThat(SentryAndroidOptions().isEnableLogcatLogs).isFalse()
+  }
+
+  @Test
+  fun `Logcat logs can be enabled`() {
+    val sentryOptions = SentryAndroidOptions()
+    sentryOptions.isEnableLogcatLogs = true
+
+    assertThat(sentryOptions.isEnableLogcatLogs).isTrue()
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryLogcatAdapterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryLogcatAdapterTest.kt
@@ -2,6 +2,7 @@ package io.sentry.android.core
 
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryLevel
@@ -15,6 +16,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowLog
 
 @RunWith(AndroidJUnit4::class)
 class SentryLogcatAdapterTest {
@@ -26,9 +28,12 @@ class SentryLogcatAdapterTest {
     val breadcrumbs = mutableListOf<Breadcrumb>()
     val logs = mutableListOf<SentryLogEvent>()
 
-    fun initSut(options: Sentry.OptionsConfiguration<SentryAndroidOptions>? = null) {
-      val metadata =
-        Bundle().apply { putString(ManifestMetadataReader.DSN, "https://key@sentry.io/123") }
+    fun initSut(
+      enableLogcatLogs: Boolean? = true,
+      metadata: Bundle = Bundle(),
+      options: Sentry.OptionsConfiguration<SentryAndroidOptions>? = null,
+    ) {
+      metadata.putString(ManifestMetadataReader.DSN, "https://key@sentry.io/123")
       val mockContext = ContextUtilsTestHelper.mockMetaData(metaData = metadata)
       initForTest(mockContext) {
         it.beforeBreadcrumb = SentryOptions.BeforeBreadcrumbCallback { breadcrumb, _ ->
@@ -36,6 +41,9 @@ class SentryLogcatAdapterTest {
           breadcrumb
         }
         it.logs.isEnabled = true
+        if (enableLogcatLogs != null) {
+          it.isEnableLogcatLogs = enableLogcatLogs
+        }
         it.logs.beforeSend =
           SentryOptions.Logs.BeforeSendLogCallback { logEvent ->
             logs.add(logEvent)
@@ -55,6 +63,37 @@ class SentryLogcatAdapterTest {
     Sentry.close()
     fixture.breadcrumbs.clear()
     fixture.logs.clear()
+    ShadowLog.clear()
+  }
+
+  @Test
+  fun `Logcat logs are disabled by default while breadcrumbs and Android Log remain enabled`() {
+    fixture.initSut(enableLogcatLogs = null)
+
+    SentryLogcatAdapter.d(tag, commonMsg)
+
+    assertThat(fixture.logs).isEmpty()
+    assertThat(fixture.breadcrumbs).hasSize(1)
+    assertThat(ShadowLog.getLogs().any { it.tag == tag && it.msg == commonMsg }).isTrue()
+  }
+
+  @Test
+  fun `Logcat logs can be enabled through Android options`() {
+    fixture.initSut(enableLogcatLogs = true)
+
+    SentryLogcatAdapter.d(tag, commonMsg)
+
+    assertThat(fixture.logs).hasSize(1)
+  }
+
+  @Test
+  fun `Logcat logs can be enabled through manifest metadata`() {
+    val metadata = Bundle().apply { putBoolean(ManifestMetadataReader.ENABLE_LOGCAT_LOGS, true) }
+    fixture.initSut(enableLogcatLogs = null, metadata = metadata)
+
+    SentryLogcatAdapter.d(tag, commonMsg)
+
+    assertThat(fixture.logs).hasSize(1)
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Adds `SentryAndroidOptions.logcatLogsEnabled`, defaulting to `false`, and the `io.sentry.logcat.logs.enabled` Android manifest key.

`SentryLogcatAdapter` now requires both this local opt-in and the existing aggregate core Logs flag before forwarding Logcat calls as Sentry Logs. The local check runs before throwable and message processing. Breadcrumb creation and the original Android `Log` invocation remain unchanged.

## :bulb: Motivation and Context

Automatic Logcat instrumentation needs an explicit local opt-in before the aggregate core Logs flag can be removed. This prevents instrumented Android applications from unexpectedly forwarding Logcat output when core Logs capture becomes available without a global enable flag.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry-android-core:testReleaseUnitTest`
- Added tests for Java and manifest opt-in, default-disabled behavior, and independent breadcrumb and Android Log calls
- Preserved coverage for Logcat levels, throwable bodies, and origin

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add the Spring Boot Logback opt-in before removing the aggregate core Logs flag.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


