### PR TITLE
feat(spring): [Logs and Metrics Enable Flags 6] Add logging Logs opt-in for Spring Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add an explicit Logs opt-in to Spring Boot logging auto-configuration ([#5946](https://github.com/getsentry/sentry-java/pull/5946))
 - Add an explicit Logs opt-in to the Android Logcat integration ([#5945](https://github.com/getsentry/sentry-java/pull/5945))
 - Add an explicit Logs opt-in to the Android Timber integration ([#5943](https://github.com/getsentry/sentry-java/pull/5943))
 - Add an explicit Logs opt-in to the JUL handler ([#5942](https://github.com/getsentry/sentry-java/pull/5942))

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/src/main/resources/application.properties
@@ -16,6 +16,7 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/src/main/resources/application.properties
@@ -16,6 +16,7 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/src/main/resources/application.properties
@@ -17,6 +17,7 @@ sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.in-app-includes="io.sentry.samples"
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces
 sentry.profile-lifecycle=TRACE

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/src/main/resources/application.properties
@@ -11,6 +11,7 @@ sentry.reactive.thread-local-accessor-enabled=true
 sentry.traces-sample-rate=1.0
 sentry.enable-backpressure-handling=true
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.enable-spotlight=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-4/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4/src/main/resources/application.properties
@@ -17,6 +17,7 @@ sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.in-app-includes="io.sentry.samples"
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces
 sentry.profile-lifecycle=TRACE

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application.properties
@@ -16,6 +16,7 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application.properties
@@ -16,6 +16,7 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -17,6 +17,7 @@ sentry.enable-spotlight=false
 sentry.enablePrettySerializationOutput=false
 sentry.in-app-includes="io.sentry.samples"
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces
 sentry.profile-lifecycle=TRACE

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/src/main/resources/application.properties
@@ -15,6 +15,7 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/src/main/resources/application.properties
@@ -15,6 +15,7 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/resources/application.properties
@@ -11,6 +11,7 @@ sentry.reactive.thread-local-accessor-enabled=true
 sentry.traces-sample-rate=1.0
 sentry.enable-backpressure-handling=true
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.enable-spotlight=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-webflux/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/src/main/resources/application.properties
@@ -13,6 +13,7 @@ spring.graphql.websocket.path=/graphql
 spring.graphql.schema.printer.enabled=true
 sentry.enable-backpressure-handling=true
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.enable-spotlight=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
@@ -15,6 +15,7 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.logs.enabled=true
+sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-spring-boot-4/api/sentry-spring-boot-4.api
+++ b/sentry-spring-boot-4/api/sentry-spring-boot-4.api
@@ -60,7 +60,9 @@ public class io/sentry/spring/boot4/SentryProperties$Logging {
 	public fun getMinimumBreadcrumbLevel ()Lorg/slf4j/event/Level;
 	public fun getMinimumEventLevel ()Lorg/slf4j/event/Level;
 	public fun getMinimumLevel ()Lorg/slf4j/event/Level;
+	public fun isEnableLogs ()Z
 	public fun isEnabled ()Z
+	public fun setEnableLogs (Z)V
 	public fun setEnabled (Z)V
 	public fun setLoggers (Ljava/util/List;)V
 	public fun setMinimumBreadcrumbLevel (Lorg/slf4j/event/Level;)V

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryLogbackInitializer.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryLogbackInitializer.java
@@ -45,6 +45,7 @@ public class SentryLogbackInitializer implements GenericApplicationListener {
           if (!isSentryAppenderRegistered(logger)) {
             final SentryAppender sentryAppender = getSentryAppender();
 
+            sentryAppender.setEnableLogs(sentryProperties.getLogging().isEnableLogs());
             Optional.ofNullable(sentryProperties.getLogging().getMinimumBreadcrumbLevel())
                 .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
                 .ifPresent(sentryAppender::setMinimumBreadcrumbLevel);

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryProperties.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryProperties.java
@@ -129,6 +129,9 @@ public class SentryProperties extends SentryOptions {
     /** Enable/Disable logging auto-configuration. */
     private boolean enabled = true;
 
+    /** Enable/Disable Sentry Logs capture from the auto-configured appender. */
+    private boolean enableLogs = false;
+
     /** Minimum logging level for recording breadcrumbs. */
     private @Nullable Level minimumBreadcrumbLevel;
 
@@ -147,6 +150,14 @@ public class SentryProperties extends SentryOptions {
 
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
+    }
+
+    public boolean isEnableLogs() {
+      return enableLogs;
+    }
+
+    public void setEnableLogs(boolean enableLogs) {
+      this.enableLogs = enableLogs;
     }
 
     public @Nullable Level getMinimumBreadcrumbLevel() {

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -244,6 +244,7 @@ class SentryAutoConfigurationTest {
         "sentry.cron.default-failure-issue-threshold=40",
         "sentry.cron.default-recovery-threshold=50",
         "sentry.logs.enabled=true",
+        "sentry.logging.enable-logs=true",
         "sentry.strict-trace-continuation=true",
         "sentry.org-id=12345",
       )
@@ -301,6 +302,7 @@ class SentryAutoConfigurationTest {
         assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
         assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
         assertThat(options.logs.isEnabled).isEqualTo(true)
+        assertThat(options.logging.isEnableLogs).isTrue()
         assertThat(options.isStrictTraceContinuation).isEqualTo(true)
         assertThat(options.orgId).isEqualTo("12345")
       }

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryLogbackAppenderAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryLogbackAppenderAutoConfigurationTest.kt
@@ -112,6 +112,7 @@ class SentryLogbackAppenderAutoConfigurationTest {
         "sentry.logging.minimum-event-level=info",
         "sentry.logging.minimum-breadcrumb-level=debug",
         "sentry.logging.minimum-level=error",
+        "sentry.logging.enable-logs=true",
       )
       .run {
         val appenders = rootLogger.getAppenders(SentryAppender::class.java)
@@ -121,7 +122,17 @@ class SentryLogbackAppenderAutoConfigurationTest {
         assertThat(sentryAppender.minimumBreadcrumbLevel).isEqualTo(Level.DEBUG)
         assertThat(sentryAppender.minimumEventLevel).isEqualTo(Level.INFO)
         assertThat(sentryAppender.minimumLevel).isEqualTo(Level.ERROR)
+        assertThat(sentryAppender.isEnableLogs).isTrue()
       }
+  }
+
+  @Test
+  fun `SentryAppender Logs are disabled by default`() {
+    dsnEnabledRunner.run {
+      val sentryAppender = rootLogger.getAppenders(SentryAppender::class.java).single()
+
+      assertThat((sentryAppender as SentryAppender).isEnableLogs).isFalse()
+    }
   }
 
   @Test

--- a/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
+++ b/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
@@ -60,7 +60,9 @@ public class io/sentry/spring/boot/jakarta/SentryProperties$Logging {
 	public fun getMinimumBreadcrumbLevel ()Lorg/slf4j/event/Level;
 	public fun getMinimumEventLevel ()Lorg/slf4j/event/Level;
 	public fun getMinimumLevel ()Lorg/slf4j/event/Level;
+	public fun isEnableLogs ()Z
 	public fun isEnabled ()Z
+	public fun setEnableLogs (Z)V
 	public fun setEnabled (Z)V
 	public fun setLoggers (Ljava/util/List;)V
 	public fun setMinimumBreadcrumbLevel (Lorg/slf4j/event/Level;)V

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryLogbackInitializer.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryLogbackInitializer.java
@@ -45,6 +45,7 @@ public class SentryLogbackInitializer implements GenericApplicationListener {
           if (!isSentryAppenderRegistered(logger)) {
             final SentryAppender sentryAppender = getSentryAppender();
 
+            sentryAppender.setEnableLogs(sentryProperties.getLogging().isEnableLogs());
             Optional.ofNullable(sentryProperties.getLogging().getMinimumBreadcrumbLevel())
                 .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
                 .ifPresent(sentryAppender::setMinimumBreadcrumbLevel);

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
@@ -129,6 +129,9 @@ public class SentryProperties extends SentryOptions {
     /** Enable/Disable logging auto-configuration. */
     private boolean enabled = true;
 
+    /** Enable/Disable Sentry Logs capture from the auto-configured appender. */
+    private boolean enableLogs = false;
+
     /** Minimum logging level for recording breadcrumbs. */
     private @Nullable Level minimumBreadcrumbLevel;
 
@@ -147,6 +150,14 @@ public class SentryProperties extends SentryOptions {
 
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
+    }
+
+    public boolean isEnableLogs() {
+      return enableLogs;
+    }
+
+    public void setEnableLogs(boolean enableLogs) {
+      this.enableLogs = enableLogs;
     }
 
     public @Nullable Level getMinimumBreadcrumbLevel() {

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -246,6 +246,7 @@ class SentryAutoConfigurationTest {
         "sentry.cron.default-failure-issue-threshold=40",
         "sentry.cron.default-recovery-threshold=50",
         "sentry.logs.enabled=true",
+        "sentry.logging.enable-logs=true",
         "sentry.profile-session-sample-rate=1.0",
         "sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces",
         "sentry.profile-lifecycle=TRACE",
@@ -305,6 +306,7 @@ class SentryAutoConfigurationTest {
         assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
         assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
         assertThat(options.logs.isEnabled).isEqualTo(true)
+        assertThat(options.logging.isEnableLogs).isTrue()
         assertThat(options.profileSessionSampleRate).isEqualTo(1.0)
         assertThat(options.profilingTracesDirPath)
           .startsWith(File("tmp/sentry/profiling-traces").absolutePath)

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryLogbackAppenderAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryLogbackAppenderAutoConfigurationTest.kt
@@ -112,6 +112,7 @@ class SentryLogbackAppenderAutoConfigurationTest {
         "sentry.logging.minimum-event-level=info",
         "sentry.logging.minimum-breadcrumb-level=debug",
         "sentry.logging.minimum-level=error",
+        "sentry.logging.enable-logs=true",
       )
       .run {
         val appenders = rootLogger.getAppenders(SentryAppender::class.java)
@@ -121,7 +122,17 @@ class SentryLogbackAppenderAutoConfigurationTest {
         assertThat(sentryAppender.minimumBreadcrumbLevel).isEqualTo(Level.DEBUG)
         assertThat(sentryAppender.minimumEventLevel).isEqualTo(Level.INFO)
         assertThat(sentryAppender.minimumLevel).isEqualTo(Level.ERROR)
+        assertThat(sentryAppender.isEnableLogs).isTrue()
       }
+  }
+
+  @Test
+  fun `SentryAppender Logs are disabled by default`() {
+    dsnEnabledRunner.run {
+      val sentryAppender = rootLogger.getAppenders(SentryAppender::class.java).single()
+
+      assertThat((sentryAppender as SentryAppender).isEnableLogs).isFalse()
+    }
   }
 
   @Test

--- a/sentry-spring-boot/api/sentry-spring-boot.api
+++ b/sentry-spring-boot/api/sentry-spring-boot.api
@@ -56,7 +56,9 @@ public class io/sentry/spring/boot/SentryProperties$Logging {
 	public fun getMinimumBreadcrumbLevel ()Lorg/slf4j/event/Level;
 	public fun getMinimumEventLevel ()Lorg/slf4j/event/Level;
 	public fun getMinimumLevel ()Lorg/slf4j/event/Level;
+	public fun isEnableLogs ()Z
 	public fun isEnabled ()Z
+	public fun setEnableLogs (Z)V
 	public fun setEnabled (Z)V
 	public fun setLoggers (Ljava/util/List;)V
 	public fun setMinimumBreadcrumbLevel (Lorg/slf4j/event/Level;)V

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
@@ -45,6 +45,7 @@ public class SentryLogbackInitializer implements GenericApplicationListener {
           if (!isSentryAppenderRegistered(logger)) {
             final SentryAppender sentryAppender = getSentryAppender();
 
+            sentryAppender.setEnableLogs(sentryProperties.getLogging().isEnableLogs());
             Optional.ofNullable(sentryProperties.getLogging().getMinimumBreadcrumbLevel())
                 .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
                 .ifPresent(sentryAppender::setMinimumBreadcrumbLevel);

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryProperties.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryProperties.java
@@ -103,6 +103,9 @@ public class SentryProperties extends SentryOptions {
     /** Enable/Disable logging auto-configuration. */
     private boolean enabled = true;
 
+    /** Enable/Disable Sentry Logs capture from the auto-configured appender. */
+    private boolean enableLogs = false;
+
     /** Minimum logging level for recording breadcrumbs. */
     private @Nullable Level minimumBreadcrumbLevel;
 
@@ -121,6 +124,14 @@ public class SentryProperties extends SentryOptions {
 
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
+    }
+
+    public boolean isEnableLogs() {
+      return enableLogs;
+    }
+
+    public void setEnableLogs(boolean enableLogs) {
+      this.enableLogs = enableLogs;
     }
 
     public @Nullable Level getMinimumBreadcrumbLevel() {

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -244,6 +244,7 @@ class SentryAutoConfigurationTest {
         "sentry.cron.default-failure-issue-threshold=40",
         "sentry.cron.default-recovery-threshold=50",
         "sentry.logs.enabled=true",
+        "sentry.logging.enable-logs=true",
         "sentry.profile-session-sample-rate=1.0",
         "sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces",
         "sentry.profile-lifecycle=TRACE",
@@ -303,6 +304,7 @@ class SentryAutoConfigurationTest {
         assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
         assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
         assertThat(options.logs.isEnabled).isEqualTo(true)
+        assertThat(options.logging.isEnableLogs).isTrue()
         assertThat(options.profileSessionSampleRate).isEqualTo(1.0)
         assertThat(options.profilingTracesDirPath)
           .startsWith(File("tmp/sentry/profiling-traces").absolutePath)

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
@@ -112,6 +112,7 @@ class SentryLogbackAppenderAutoConfigurationTest {
         "sentry.logging.minimum-event-level=info",
         "sentry.logging.minimum-breadcrumb-level=debug",
         "sentry.logging.minimum-level=error",
+        "sentry.logging.enable-logs=true",
       )
       .run {
         val appenders = rootLogger.getAppenders(SentryAppender::class.java)
@@ -121,7 +122,17 @@ class SentryLogbackAppenderAutoConfigurationTest {
         assertThat(sentryAppender.minimumBreadcrumbLevel).isEqualTo(Level.DEBUG)
         assertThat(sentryAppender.minimumEventLevel).isEqualTo(Level.INFO)
         assertThat(sentryAppender.minimumLevel).isEqualTo(Level.ERROR)
+        assertThat(sentryAppender.isEnableLogs).isTrue()
       }
+  }
+
+  @Test
+  fun `SentryAppender Logs are disabled by default`() {
+    dsnEnabledRunner.run {
+      val sentryAppender = rootLogger.getAppenders(SentryAppender::class.java).single()
+
+      assertThat((sentryAppender as SentryAppender).isEnableLogs).isFalse()
+    }
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Adds `SentryProperties.Logging.logsEnabled`, defaulting to `false`, to all three Spring Boot integrations and binds it as `sentry.logging.logs-enabled`.

Each auto-configured Logback appender receives the property. The broader `sentry.logging.enabled` property continues to control whether the appender is installed, while event and breadcrumb levels remain independent from Sentry Logs forwarding.

Spring Boot samples now set the new local opt-in alongside the existing aggregate `sentry.logs.enabled` property, which remains required until it is removed later in this stack.

## :bulb: Motivation and Context

Auto-configured Logback appenders need the same explicit local Logs opt-in as manually configured Logback appenders. This prevents Spring Boot applications from unexpectedly forwarding framework logs after the aggregate core Logs flag is removed.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry-spring-boot:test :sentry-spring-boot-jakarta:test :sentry-spring-boot-4:test`
- Added property binding and appender propagation tests for all three Spring Boot variants
- Verified the appender remains installed with Logs disabled by default

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Remove the aggregate core Logs enable flag and migrate remaining samples and fixtures.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


