### PR TITLE
feat(core): [Logs and Metrics Enable Flags 7] Remove Logs enable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Remove the aggregate Sentry Logs enable flag; manual `Sentry.logger()` calls now capture Logs by default ([#5947](https://github.com/getsentry/sentry-java/pull/5947))
 - Add an explicit Logs opt-in to Spring Boot logging auto-configuration ([#5946](https://github.com/getsentry/sentry-java/pull/5946))
 - Add an explicit Logs opt-in to the Android Logcat integration ([#5945](https://github.com/getsentry/sentry-java/pull/5945))
 - Add an explicit Logs opt-in to the Android Timber integration ([#5943](https://github.com/getsentry/sentry-java/pull/5943))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -706,10 +706,6 @@ final class ManifestMetadataReader {
           }
         }
 
-        options
-            .getLogs()
-            .setEnabled(readBool(metadata, logger, ENABLE_LOGS, options.getLogs().isEnabled()));
-
         options.setEnableTimberLogs(
             readBool(metadata, logger, ENABLE_TIMBER_LOGS, options.isEnableTimberLogs()));
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryLogcatAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryLogcatAdapter.java
@@ -55,8 +55,7 @@ public final class SentryLogcatAdapter {
     final @NotNull ScopesAdapter scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
     if (!(options instanceof SentryAndroidOptions)
-        || !((SentryAndroidOptions) options).isEnableLogcatLogs()
-        || !options.getLogs().isEnabled()) {
+        || !((SentryAndroidOptions) options).isEnableLogcatLogs()) {
       return;
     }
     final @Nullable String trMessage = tr != null ? tr.getMessage() : null;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1944,31 +1944,6 @@ class ManifestMetadataReaderTest {
   }
 
   @Test
-  fun `applyMetadata reads logs enabled and keep default value if not found`() {
-    // Arrange
-    val context = fixture.getContext()
-
-    // Act
-    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
-
-    // Assert
-    assertFalse(fixture.options.logs.isEnabled)
-  }
-
-  @Test
-  fun `applyMetadata reads logs enabled to options`() {
-    // Arrange
-    val bundle = bundleOf(ManifestMetadataReader.ENABLE_LOGS to true)
-    val context = fixture.getContext(metaData = bundle)
-
-    // Act
-    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
-
-    // Assert
-    assertTrue(fixture.options.logs.isEnabled)
-  }
-
-  @Test
   fun `applyMetadata keeps Timber logs disabled if not found`() {
     val context = fixture.getContext()
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryLogcatAdapterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryLogcatAdapterTest.kt
@@ -14,7 +14,6 @@ import java.lang.RuntimeException
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.shadows.ShadowLog
 
@@ -40,7 +39,6 @@ class SentryLogcatAdapterTest {
           breadcrumbs.add(breadcrumb)
           breadcrumb
         }
-        it.logs.isEnabled = true
         if (enableLogcatLogs != null) {
           it.isEnableLogcatLogs = enableLogcatLogs
         }
@@ -203,26 +201,6 @@ class SentryLogcatAdapterTest {
     fixture.logs
       .first()
       .assert("$commonMsg wtf exception\n${throwable.message}", SentryLogLevel.FATAL)
-  }
-
-  @Test
-  fun `do not send logs if logs is disabled`() {
-    fixture.initSut { it.logs.isEnabled = false }
-
-    SentryLogcatAdapter.v(tag, "$commonMsg verbose")
-    SentryLogcatAdapter.i(tag, "$commonMsg info")
-    SentryLogcatAdapter.d(tag, "$commonMsg debug")
-    SentryLogcatAdapter.w(tag, "$commonMsg warning")
-    SentryLogcatAdapter.e(tag, "$commonMsg error")
-    SentryLogcatAdapter.wtf(tag, "$commonMsg wtf")
-    SentryLogcatAdapter.e(tag, "$commonMsg error exception", throwable)
-    SentryLogcatAdapter.v(tag, "$commonMsg verbose exception", throwable)
-    SentryLogcatAdapter.i(tag, "$commonMsg info exception", throwable)
-    SentryLogcatAdapter.d(tag, "$commonMsg debug exception", throwable)
-    SentryLogcatAdapter.w(tag, "$commonMsg warning exception", throwable)
-    SentryLogcatAdapter.wtf(tag, "$commonMsg wtf exception", throwable)
-
-    assertTrue(fixture.logs.isEmpty())
   }
 
   @Test

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -114,9 +114,7 @@ public class SentryHandler extends Handler {
       return;
     }
     try {
-      if (enableLogs
-          && ScopesAdapter.getInstance().getOptions().getLogs().isEnabled()
-          && record.getLevel().intValue() >= minimumLevel.intValue()) {
+      if (enableLogs && record.getLevel().intValue() >= minimumLevel.intValue()) {
         captureLog(record);
       }
       if (record.getLevel().intValue() >= minimumEventLevel.intValue()) {

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -42,7 +42,6 @@ class SentryHandlerTest {
     contextTags: List<String>? = null,
     printfStyle: Boolean? = null,
     enableLogs: Boolean? = true,
-    enableGlobalLogs: Boolean = true,
   ) {
     var logger: Logger
     var handler: SentryHandler
@@ -51,7 +50,6 @@ class SentryHandlerTest {
       val options = SentryOptions()
       options.dsn = "http://key@localhost/proj"
       options.setTransportFactory { _, _ -> transport }
-      options.logs.isEnabled = enableGlobalLogs
       options.logs.loggerBatchProcessorFactory = ILoggerBatchProcessorFactory { options, client ->
         LoggerBatchProcessor(options, client, ImmediateExecutorService())
       }
@@ -438,7 +436,7 @@ class SentryHandlerTest {
 
   @Test
   fun `does not capture logs by default`() {
-    fixture = Fixture(enableLogs = null, enableGlobalLogs = true)
+    fixture = Fixture(enableLogs = null)
 
     assertFalse(fixture.handler.isEnableLogs)
     fixture.logger.info("this should not be captured as a log")
@@ -449,7 +447,7 @@ class SentryHandlerTest {
 
   @Test
   fun `captures logs when enabled through Java`() {
-    fixture = Fixture(enableLogs = true, enableGlobalLogs = true)
+    fixture = Fixture(enableLogs = true)
 
     assertTrue(fixture.handler.isEnableLogs)
     fixture.logger.info("this should be captured as a log")
@@ -470,7 +468,6 @@ class SentryHandlerTest {
         minimumBreadcrumbLevel = Level.INFO,
         minimumEventLevel = Level.SEVERE,
         enableLogs = false,
-        enableGlobalLogs = true,
       )
 
     fixture.logger.info("this should be a breadcrumb")

--- a/sentry-jul/src/test/resources/sentry.properties
+++ b/sentry-jul/src/test/resources/sentry.properties
@@ -1,2 +1,1 @@
 release=release from sentry.properties
-logs.enabled=true

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -257,9 +257,7 @@ public class SentryAppender extends AbstractAppender {
 
   @Override
   public void append(final @NotNull LogEvent eventObject) {
-    if (enableLogs
-        && scopes.getOptions().getLogs().isEnabled()
-        && eventObject.getLevel().isMoreSpecificThan(minimumLevel)) {
+    if (enableLogs && eventObject.getLevel().isMoreSpecificThan(minimumLevel)) {
       captureLog(eventObject);
     }
     if (eventObject.getLevel().isMoreSpecificThan(minimumEventLevel)) {

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -63,7 +63,6 @@ class SentryAppenderTest {
       debug: Boolean? = null,
       contextTags: List<String>? = null,
       enableLogs: Boolean = true,
-      enableGlobalLogs: Boolean = true,
     ): ExtendedLogger {
       if (transportFactory != null) {
         this.transportFactory = transportFactory
@@ -106,7 +105,6 @@ class SentryAppenderTest {
 
       appender.start(
         appender.getOptionsConfiguration { options ->
-          options.logs.isEnabled = enableGlobalLogs
           options.logs.loggerBatchProcessorFactory =
             ILoggerBatchProcessorFactory { options, client ->
               LoggerBatchProcessor(options, client, ImmediateExecutorService())
@@ -264,7 +262,7 @@ class SentryAppenderTest {
 
   @Test
   fun `does not capture logs when local logs are disabled`() {
-    val logger = fixture.getSut(enableLogs = false, enableGlobalLogs = true)
+    val logger = fixture.getSut(enableLogs = false)
 
     logger.info("this should not be captured as a log")
     Sentry.flush(10)
@@ -273,8 +271,8 @@ class SentryAppenderTest {
   }
 
   @Test
-  fun `captures logs when local and aggregate logs are enabled`() {
-    val logger = fixture.getSut(enableLogs = true, enableGlobalLogs = true)
+  fun `captures logs when local logs are enabled`() {
+    val logger = fixture.getSut(enableLogs = true)
 
     logger.info("this should be captured as a log")
     Sentry.flush(10)
@@ -294,7 +292,6 @@ class SentryAppenderTest {
         minimumBreadcrumbLevel = Level.INFO,
         minimumEventLevel = Level.ERROR,
         enableLogs = false,
-        enableGlobalLogs = true,
       )
 
     logger.info("this should be a breadcrumb")
@@ -397,7 +394,6 @@ class SentryAppenderTest {
   fun `plugin attribute enables logs with explicit opt in`() {
     initForTest {
       it.dsn = "http://key@localhost/proj"
-      it.logs.isEnabled = true
     }
     val event = mock<LogEvent>()
     whenever(event.level).thenReturn(Level.INFO)

--- a/sentry-log4j2/src/test/resources/sentry.properties
+++ b/sentry-log4j2/src/test/resources/sentry.properties
@@ -1,4 +1,3 @@
 release=release from sentry.properties
-logs.enabled=true
 shutdown-timeout-millis=0
 session-flush-timeout-millis=0

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -88,9 +88,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
-    if (enableLogs
-        && ScopesAdapter.getInstance().getOptions().getLogs().isEnabled()
-        && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
+    if (enableLogs && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
       captureLog(eventObject);
     }
     if (eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -56,7 +56,6 @@ class SentryAppenderTest {
     encoder: Encoder<ILoggingEvent>? = null,
     sendDefaultPii: Boolean = false,
     enableLogs: Boolean = false,
-    enableGlobalLogs: Boolean = enableLogs,
     options: SentryOptions = SentryOptions(),
     startLater: Boolean = false,
   ) {
@@ -73,7 +72,6 @@ class SentryAppenderTest {
       this.encoder = encoder
       options.dsn = dsn
       options.isSendDefaultPii = sendDefaultPii
-      options.logs.isEnabled = enableGlobalLogs
       options.logs.loggerBatchProcessorFactory = ILoggerBatchProcessorFactory { options, client ->
         LoggerBatchProcessor(options, client, ImmediateExecutorService())
       }
@@ -326,8 +324,8 @@ class SentryAppenderTest {
   }
 
   @Test
-  fun `does not capture logs by default when aggregate logs are enabled`() {
-    fixture = Fixture(enableGlobalLogs = true)
+  fun `does not capture logs by default`() {
+    fixture = Fixture(enableLogs = false)
 
     assertFalse(fixture.appender.isEnableLogs)
     fixture.logger.info("this should not be captured as a log")
@@ -337,7 +335,7 @@ class SentryAppenderTest {
   }
 
   @Test
-  fun `captures logs when local and aggregate logs are enabled`() {
+  fun `captures logs when local logs are enabled`() {
     fixture = Fixture(enableLogs = true)
 
     assertTrue(fixture.appender.isEnableLogs)
@@ -358,7 +356,7 @@ class SentryAppenderTest {
       Fixture(
         minimumBreadcrumbLevel = Level.INFO,
         minimumEventLevel = Level.ERROR,
-        enableGlobalLogs = true,
+        enableLogs = false,
       )
 
     fixture.logger.info("this should be a breadcrumb")

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -131,9 +131,14 @@
       android:name="io.sentry.debug"
       android:value="${sentryDebug}" />
 
-    <!--    how to enable Sentry Logs (Sentry.logger() calls are dropped unless this is on)-->
+    <!--    how to enable Sentry Logs capture from Timber-->
     <meta-data
-      android:name="io.sentry.logs.enabled"
+      android:name="io.sentry.timber.logs.enabled"
+      android:value="true" />
+
+    <!--    how to enable Sentry Logs capture from Logcat-->
+    <meta-data
+      android:name="io.sentry.logcat.logs.enabled"
       android:value="true" />
 
     <!--    how to disable verbose logging of the session replay feature-->

--- a/sentry-samples/sentry-samples-console-otlp/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console-otlp/src/main/java/io/sentry/samples/console/Main.java
@@ -133,7 +133,6 @@ public class Main {
           //                }
           //              });
 
-          options.getLogs().setEnabled(true);
         });
 
     Sentry.addBreadcrumb(

--- a/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
+++ b/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
@@ -4,4 +4,3 @@ debug=true
 environment=staging
 in-app-includes=io.sentry.samples
 context-tags=userId,requestId
-logs.enabled=true

--- a/sentry-samples/sentry-samples-log4j2/src/main/resources/sentry.properties
+++ b/sentry-samples/sentry-samples-log4j2/src/main/resources/sentry.properties
@@ -1,3 +1,2 @@
 in-app-includes="io.sentry.samples"
-logs.enabled=true
 debug=true

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -13,9 +13,6 @@
       <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
       <contextTag>userId</contextTag>
       <contextTag>requestId</contextTag>
-      <logs>
-        <enabled>true</enabled>
-      </logs>
     </options>
     <enableLogs>true</enableLogs>
     <!-- Demonstrates how to modify the minimum values -->

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/src/main/resources/application.properties
@@ -15,7 +15,6 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/src/main/resources/application.properties
@@ -15,7 +15,6 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/src/main/resources/application.properties
@@ -16,7 +16,6 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.in-app-includes="io.sentry.samples"
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/src/main/resources/application.properties
@@ -10,7 +10,6 @@ sentry.logging.minimum-breadcrumb-level=debug
 sentry.reactive.thread-local-accessor-enabled=true
 sentry.traces-sample-rate=1.0
 sentry.enable-backpressure-handling=true
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.enable-spotlight=true
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-4/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-4/src/main/resources/application.properties
@@ -16,7 +16,6 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
 sentry.in-app-includes="io.sentry.samples"
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application.properties
@@ -15,7 +15,6 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application.properties
@@ -15,7 +15,6 @@ sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
 sentry.enablePrettySerializationOutput=false
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -16,7 +16,6 @@ sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=false
 sentry.enablePrettySerializationOutput=false
 sentry.in-app-includes="io.sentry.samples"
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/src/main/resources/application.properties
@@ -14,7 +14,6 @@ sentry.debug=true
 sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/src/main/resources/application.properties
@@ -14,7 +14,6 @@ sentry.debug=true
 sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/resources/application.properties
@@ -10,7 +10,6 @@ sentry.logging.minimum-breadcrumb-level=debug
 sentry.reactive.thread-local-accessor-enabled=true
 sentry.traces-sample-rate=1.0
 sentry.enable-backpressure-handling=true
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.enable-spotlight=true
 sentry.in-app-includes="io.sentry.samples"

--- a/sentry-samples/sentry-samples-spring-boot-webflux/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/src/main/resources/application.properties
@@ -12,7 +12,6 @@ spring.graphql.graphiql.enabled=true
 spring.graphql.websocket.path=/graphql
 spring.graphql.schema.printer.enabled=true
 sentry.enable-backpressure-handling=true
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.enable-spotlight=true
 sentry.in-app-includes="io.sentry.samples"

--- a/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
@@ -14,7 +14,6 @@ sentry.debug=true
 sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 sentry.enable-backpressure-handling=true
 sentry.enable-spotlight=true
-sentry.logs.enabled=true
 sentry.logging.enable-logs=true
 sentry.in-app-includes="io.sentry.samples"
 sentry.profile-session-sample-rate=1.0

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -243,7 +243,6 @@ class SentryAutoConfigurationTest {
         "sentry.cron.default-timezone=America/New_York",
         "sentry.cron.default-failure-issue-threshold=40",
         "sentry.cron.default-recovery-threshold=50",
-        "sentry.logs.enabled=true",
         "sentry.logging.enable-logs=true",
         "sentry.strict-trace-continuation=true",
         "sentry.org-id=12345",
@@ -301,7 +300,6 @@ class SentryAutoConfigurationTest {
         assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
         assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
         assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
-        assertThat(options.logs.isEnabled).isEqualTo(true)
         assertThat(options.logging.isEnableLogs).isTrue()
         assertThat(options.isStrictTraceContinuation).isEqualTo(true)
         assertThat(options.orgId).isEqualTo("12345")

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -245,7 +245,6 @@ class SentryAutoConfigurationTest {
         "sentry.cron.default-timezone=America/New_York",
         "sentry.cron.default-failure-issue-threshold=40",
         "sentry.cron.default-recovery-threshold=50",
-        "sentry.logs.enabled=true",
         "sentry.logging.enable-logs=true",
         "sentry.profile-session-sample-rate=1.0",
         "sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces",
@@ -305,7 +304,6 @@ class SentryAutoConfigurationTest {
         assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
         assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
         assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
-        assertThat(options.logs.isEnabled).isEqualTo(true)
         assertThat(options.logging.isEnableLogs).isTrue()
         assertThat(options.profileSessionSampleRate).isEqualTo(1.0)
         assertThat(options.profilingTracesDirPath)

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -243,7 +243,6 @@ class SentryAutoConfigurationTest {
         "sentry.cron.default-timezone=America/New_York",
         "sentry.cron.default-failure-issue-threshold=40",
         "sentry.cron.default-recovery-threshold=50",
-        "sentry.logs.enabled=true",
         "sentry.logging.enable-logs=true",
         "sentry.profile-session-sample-rate=1.0",
         "sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces",
@@ -303,7 +302,6 @@ class SentryAutoConfigurationTest {
         assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
         assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
         assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
-        assertThat(options.logs.isEnabled).isEqualTo(true)
         assertThat(options.logging.isEnableLogs).isTrue()
         assertThat(options.profileSessionSampleRate).isEqualTo(1.0)
         assertThat(options.profilingTracesDirPath)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3964,9 +3964,7 @@ public final class io/sentry/SentryOptions$Logs {
 	public fun <init> ()V
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$Logs$BeforeSendLogCallback;
 	public fun getLoggerBatchProcessorFactory ()Lio/sentry/logger/ILoggerBatchProcessorFactory;
-	public fun isEnabled ()Z
 	public fun setBeforeSend (Lio/sentry/SentryOptions$Logs$BeforeSendLogCallback;)V
-	public fun setEnabled (Z)V
 	public fun setLoggerBatchProcessorFactory (Lio/sentry/logger/ILoggerBatchProcessorFactory;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -9,7 +9,6 @@ import io.sentry.hints.Cached;
 import io.sentry.hints.DiskFlushNotification;
 import io.sentry.hints.TransactionEnd;
 import io.sentry.logger.ILoggerBatchProcessor;
-import io.sentry.logger.NoOpLoggerBatchProcessor;
 import io.sentry.metrics.IMetricsBatchProcessor;
 import io.sentry.metrics.NoOpMetricsBatchProcessor;
 import io.sentry.protocol.Contexts;
@@ -62,12 +61,7 @@ public final class SentryClient implements ISentryClient {
 
     final RequestDetailsResolver requestDetailsResolver = new RequestDetailsResolver(options);
     transport = transportFactory.create(options, requestDetailsResolver.resolve());
-    if (options.getLogs().isEnabled()) {
-      loggerBatchProcessor =
-          options.getLogs().getLoggerBatchProcessorFactory().create(options, this);
-    } else {
-      loggerBatchProcessor = NoOpLoggerBatchProcessor.getInstance();
-    }
+    loggerBatchProcessor = options.getLogs().getLoggerBatchProcessorFactory().create(options, this);
     if (options.getMetrics().isEnabled()) {
       metricsBatchProcessor =
           options.getMetrics().getMetricsBatchProcessorFactory().create(options, this);

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3733,10 +3733,6 @@ public class SentryOptions {
       }
     }
 
-    if (options.isEnableLogs() != null) {
-      getLogs().setEnabled(options.isEnableLogs());
-    }
-
     if (options.isEnableMetrics() != null) {
       getMetrics().setEnabled(options.isEnableMetrics());
     }
@@ -3954,9 +3950,6 @@ public class SentryOptions {
 
   public static final class Logs {
 
-    /** Whether Sentry Logs feature is enabled and Sentry.logger() usages are sent to Sentry. */
-    private boolean enable = false;
-
     /**
      * This function is called with an SDK specific log event object and can return a modified event
      * object or nothing to skip reporting the log item
@@ -3965,24 +3958,6 @@ public class SentryOptions {
 
     private @NotNull ILoggerBatchProcessorFactory loggerBatchProcessorFactory =
         new DefaultLoggerBatchProcessorFactory();
-
-    /**
-     * Whether Sentry Logs feature is enabled and Sentry.logger() usages are sent to Sentry.
-     *
-     * @return true if Sentry Logs should be enabled
-     */
-    public boolean isEnabled() {
-      return enable;
-    }
-
-    /**
-     * Whether Sentry Logs feature is enabled and Sentry.logger() usages are sent to Sentry.
-     *
-     * @param enableLogs true if Sentry Logs should be enabled
-     */
-    public void setEnabled(boolean enableLogs) {
-      this.enable = enableLogs;
-    }
 
     /**
      * Returns the BeforeSendLog callback

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -104,13 +104,6 @@ public final class LoggerApi implements ILoggerApi {
         return;
       }
 
-      if (!options.getLogs().isEnabled()) {
-        options
-            .getLogger()
-            .log(SentryLevel.WARNING, "Sentry Log is disabled and this 'logger' call is a no-op.");
-        return;
-      }
-
       if (message == null) {
         return;
       }

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -2517,7 +2517,7 @@ class ScopesTest {
 
   @Test
   fun `when captureLog is called on disabled client, do nothing`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
     sut.close()
 
     sut.logger().warn("test message")
@@ -2525,16 +2525,8 @@ class ScopesTest {
   }
 
   @Test
-  fun `when logging is not enabled, do nothing`() {
-    val (sut, mockClient) = getEnabledScopes()
-
-    sut.logger().warn("test message")
-    verify(mockClient, never()).captureLog(any(), anyOrNull())
-  }
-
-  @Test
   fun `capturing null log does nothing`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().warn(null)
     verify(mockClient, never()).captureLog(any(), anyOrNull())
@@ -2542,7 +2534,7 @@ class ScopesTest {
 
   @Test
   fun `creating trace log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().trace("trace log message")
 
@@ -2559,7 +2551,7 @@ class ScopesTest {
 
   @Test
   fun `creating debug log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().debug("debug log message")
 
@@ -2576,7 +2568,7 @@ class ScopesTest {
 
   @Test
   fun `creating a info log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().info("info log message")
 
@@ -2593,7 +2585,7 @@ class ScopesTest {
 
   @Test
   fun `creating warn log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().warn("warn log message")
 
@@ -2610,7 +2602,7 @@ class ScopesTest {
 
   @Test
   fun `creating error log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().error("error log message")
 
@@ -2627,7 +2619,7 @@ class ScopesTest {
 
   @Test
   fun `creating fatal log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().fatal("fatal log message")
 
@@ -2644,7 +2636,7 @@ class ScopesTest {
 
   @Test
   fun `creating log works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().log(SentryLogLevel.WARN, "log message")
 
@@ -2661,7 +2653,7 @@ class ScopesTest {
 
   @Test
   fun `log with manual origin does not have origin attribute`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().log(SentryLogLevel.WARN, "log message")
 
@@ -2677,7 +2669,7 @@ class ScopesTest {
 
   @Test
   fun `log with non manual origin does have origin attribute`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut
       .logger()
@@ -2700,7 +2692,6 @@ class ScopesTest {
   fun `creating log with format string works`() {
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.environment = "testenv"
         it.release = "1.0"
         it.serverName = "srv1"
@@ -2741,7 +2732,7 @@ class ScopesTest {
 
   @Test
   fun `creating log with timestamp works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().log(SentryLogLevel.WARN, SentryLongDate(123), "log message")
 
@@ -2759,7 +2750,7 @@ class ScopesTest {
 
   @Test
   fun `creating log with attributes from map works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut
       .logger()
@@ -2786,7 +2777,7 @@ class ScopesTest {
 
   @Test
   fun `creating log with attributes works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut
       .logger()
@@ -2862,7 +2853,7 @@ class ScopesTest {
 
   @Test
   fun `creating log with attributes and timestamp works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut
       .logger()
@@ -2893,7 +2884,7 @@ class ScopesTest {
 
   @Test
   fun `creating log with attributes and timestamp and format string works`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut
       .logger()
@@ -2948,7 +2939,7 @@ class ScopesTest {
 
   @Test
   fun `creating log with without args does not add template attribute`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().log(SentryLogLevel.WARN, "log %s")
 
@@ -2971,7 +2962,7 @@ class ScopesTest {
 
   @Test
   fun `captures format string on format error`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().log(SentryLogLevel.WARN, "log %d", "arg1")
 
@@ -2998,7 +2989,6 @@ class ScopesTest {
   fun `adds user fields to log attributes if sendDefaultPii is true`() {
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.distinctId = "distinctId"
         it.isSendDefaultPii = true
       }
@@ -3038,7 +3028,6 @@ class ScopesTest {
   fun `adds user fields to log attributes even if sendDefaultPii is false`() {
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.distinctId = "distinctId"
       }
 
@@ -3077,7 +3066,6 @@ class ScopesTest {
   fun `unset user does provide distinct-id as user-id`() {
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.distinctId = "distinctId"
       }
 
@@ -3100,7 +3088,6 @@ class ScopesTest {
   fun `unset user does provide null user-id when distinct-id is missing`() {
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.distinctId = null
       }
 
@@ -3122,7 +3109,6 @@ class ScopesTest {
   fun `missing user fields do not break attributes`() {
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.isSendDefaultPii = true
         it.distinctId = "distinctId"
       }
@@ -3145,7 +3131,7 @@ class ScopesTest {
 
   @Test
   fun `adds session replay id to log attributes`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
     val replayId = SentryId()
     sut.scope.replayId = replayId
     sut.logger().log(SentryLogLevel.WARN, "log message")
@@ -3163,7 +3149,7 @@ class ScopesTest {
 
   @Test
   fun `missing session replay id do not break attributes`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
     sut.logger().log(SentryLogLevel.WARN, "log message")
 
     verify(mockClient)
@@ -3179,7 +3165,7 @@ class ScopesTest {
 
   @Test
   fun `does not add session replay buffering to log attributes if no replay id in scope and in controller`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut.logger().log(SentryLogLevel.WARN, "log message")
     assertEquals(SentryId.EMPTY_ID, sut.options.replayController.replayId)
@@ -3199,7 +3185,7 @@ class ScopesTest {
 
   @Test
   fun `does not add session replay buffering to log attributes if replay id in scope`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
     val replayId = SentryId()
     sut.scope.replayId = replayId
 
@@ -3223,7 +3209,6 @@ class ScopesTest {
     val mockReplayController = mock<ReplayController>()
     val (sut, mockClient) =
       getEnabledScopes {
-        it.logs.isEnabled = true
         it.setReplayController(mockReplayController)
       }
     val replayId = SentryId()
@@ -3247,7 +3232,7 @@ class ScopesTest {
 
   @Test
   fun `log event has spanId from active span`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     val transaction =
       sut.startTransaction(
@@ -3273,7 +3258,7 @@ class ScopesTest {
 
   @Test
   fun `log event has spanId from propagation context when no active span`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     var propagationContext: PropagationContext? = null
     sut.configureScope { propagationContext = it.propagationContext }
@@ -3385,7 +3370,7 @@ class ScopesTest {
 
   @Test
   fun `metric with non manual origin does have origin attribute`() {
-    val (sut, mockClient) = getEnabledScopes { it.logs.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     sut
       .metrics()

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -181,7 +181,7 @@ class SentryClientTest {
 
   @Test
   fun `when client is closed with isRestarting false, transport waits`() {
-    val sut = fixture.getSut { options -> options.logs.isEnabled = true }
+    val sut = fixture.getSut()
     assertTrue(sut.isEnabled)
     sut.close(false)
     assertNotEquals(0, fixture.sentryOptions.shutdownTimeoutMillis)
@@ -195,7 +195,7 @@ class SentryClientTest {
 
   @Test
   fun `when client is closed with isRestarting true, transport does not wait`() {
-    val sut = fixture.getSut { options -> options.logs.isEnabled = true }
+    val sut = fixture.getSut()
     assertTrue(sut.isEnabled)
     sut.close(true)
     verify(fixture.transport).flush(eq(0))
@@ -307,7 +307,6 @@ class SentryClientTest {
   @Test
   fun `when beforeSend captures a log, the nested log is dropped`() {
     val scope = createScope()
-    fixture.sentryOptions.logs.isEnabled = true
     lateinit var sut: SentryClient
     fixture.sentryOptions.setBeforeSend { e, _ ->
       sut.captureLog(
@@ -328,7 +327,6 @@ class SentryClientTest {
   @Test
   fun `when beforeSendLog logs again, the nested log is dropped and does not recurse`() {
     val scope = createScope()
-    fixture.sentryOptions.logs.isEnabled = true
     var invocations = 0
     lateinit var sut: SentryClient
     fixture.sentryOptions.logs.setBeforeSend { l ->

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -479,7 +479,6 @@ class SentryOptionsTest {
     assertTrue(options.isEnableSpotlight)
     assertEquals("http://local.sentry.io:1234", options.spotlightConnectionUrl)
     assertTrue(options.isGlobalHubMode!!)
-    assertTrue(options.logs.isEnabled!!)
     assertFalse(options.metrics.isEnabled)
     assertEquals(0.8, options.profileSessionSampleRate)
     assertEquals("/profiling-traces${File.separator}${hash}", options.profilingTracesDirPath)


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Removes `SentryOptions.Logs.isEnabled` and `setEnabled` and the aggregate Logs gate from `LoggerApi`. Manual `Sentry.logger()` calls now capture Logs whenever the SDK is enabled.

`SentryClient` now always creates the configured logger batch processor. Logback, Log4j2, JUL, Timber, and Logcat continue to require their integration-local opt-ins introduced earlier in this stack.

Stops applying the legacy external and Android manifest values while retaining their parsing/accessors and metadata key for migration warnings in the following PRs. Removes active legacy Logs configuration from samples and test fixtures.

## :bulb: Motivation and Context

The aggregate Logs flag duplicates integration-local controls and makes manual structured logging require an unnecessary global opt-in. Removing it gives `Sentry.logger()` the same direct capture semantics as other SDK APIs while local integration flags prevent unexpected automatic log forwarding.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:test :sentry-android-core:testReleaseUnitTest`
- `./gradlew :sentry-logback:test :sentry-log4j2:test :sentry-jul:test :sentry-android-timber:testReleaseUnitTest`
- `./gradlew :sentry-spring-boot:test :sentry-spring-boot-jakarta:test :sentry-spring-boot-4:test`
- Updated core and integration tests to verify capture without the aggregate option and continued local gating

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add targeted warnings for legacy Android manifest, external, and Spring Boot Logs configuration.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


