### PR TITLE
feat(android): [Logs and Metrics Enable Flags 8] Warn for legacy Logs metadata

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -706,6 +706,23 @@ final class ManifestMetadataReader {
           }
         }
 
+        if (metadata.containsKey(ENABLE_LOGS)) {
+          final boolean enableLogs = readBool(metadata, logger, ENABLE_LOGS, false);
+          if (enableLogs) {
+            logger.log(
+                SentryLevel.WARNING,
+                "The Android manifest option 'io.sentry.logs.enabled' is no longer supported. "
+                    + "Manual Sentry.logger() calls no longer require it, and automatic logging "
+                    + "integrations now require their own opt-ins.");
+          } else {
+            logger.log(
+                SentryLevel.WARNING,
+                "The Android manifest option 'io.sentry.logs.enabled' no longer disables manual "
+                    + "Sentry.logger() calls. Automatic logging integrations remain disabled "
+                    + "unless enabled through their own opt-ins.");
+          }
+        }
+
         options.setEnableTimberLogs(
             readBool(metadata, logger, ENABLE_TIMBER_LOGS, options.isEnableTimberLogs()));
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -29,7 +29,7 @@ import org.mockito.kotlin.verify
 class ManifestMetadataReaderTest {
   private class Fixture {
     val logger = mock<ILogger>()
-    val options = SentryAndroidOptions().apply { setLogger(logger) }
+    val options = SentryAndroidOptions().apply { setLogger(this@Fixture.logger) }
     val buildInfoProvider = mock<BuildInfoProvider>()
 
     fun getContext(metaData: Bundle = Bundle()): Context =
@@ -1941,6 +1941,64 @@ class ManifestMetadataReaderTest {
 
     // Assert
     assertTrue(fixture.options.inAppExcludes.isEmpty())
+  }
+
+  @Test
+  fun `applyMetadata does not warn when legacy logs enabled metadata is absent`() {
+    fixture.options.isDebug = true
+    val context = fixture.getContext()
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    verify(fixture.logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+  }
+
+  @Test
+  fun `applyMetadata warns when legacy logs enabled metadata is true`() {
+    val bundle =
+      bundleOf(
+        ManifestMetadataReader.DEBUG to true,
+        ManifestMetadataReader.ENABLE_LOGS to true,
+      )
+    val context = fixture.getContext(metaData = bundle)
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    verify(fixture.logger)
+      .log(
+        SentryLevel.WARNING,
+        "The Android manifest option 'io.sentry.logs.enabled' is no longer supported. " +
+          "Manual Sentry.logger() calls no longer require it, and automatic logging " +
+          "integrations now require their own opt-ins.",
+        *emptyArray(),
+      )
+    assertThat(fixture.options.isEnableTimberLogs).isFalse()
+    assertThat(fixture.options.isEnableLogcatLogs).isFalse()
+  }
+
+  @Test
+  fun `applyMetadata warns when legacy logs enabled metadata is false`() {
+    fixture.options.isEnableTimberLogs = true
+    fixture.options.isEnableLogcatLogs = true
+    val bundle =
+      bundleOf(
+        ManifestMetadataReader.DEBUG to true,
+        ManifestMetadataReader.ENABLE_LOGS to false,
+      )
+    val context = fixture.getContext(metaData = bundle)
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    verify(fixture.logger)
+      .log(
+        SentryLevel.WARNING,
+        "The Android manifest option 'io.sentry.logs.enabled' no longer disables manual " +
+          "Sentry.logger() calls. Automatic logging integrations remain disabled unless " +
+          "enabled through their own opt-ins.",
+        *emptyArray(),
+      )
+    assertThat(fixture.options.isEnableTimberLogs).isTrue()
+    assertThat(fixture.options.isEnableLogcatLogs).isTrue()
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Detects explicit `io.sentry.logs.enabled` Android manifest metadata and emits a tailored migration warning for both `true` and `false` values.

The legacy value is read only to select the warning. It does not change Timber or Logcat integration-local opt-ins, and absent metadata emits no warning.

## :bulb: Motivation and Context

The aggregate Logs enable flag was removed in the previous PR. Android applications may still carry the old manifest key, so a targeted startup warning explains the new behavior and points users toward integration-local opt-ins without silently applying obsolete configuration.

## :green_heart: How did you test it?

- `./gradlew :sentry-android-core:testReleaseUnitTest`
- `./gradlew spotlessApply apiDump`
- Added tests for absent, explicit `true`, and explicit `false` metadata
- Verified legacy metadata does not mutate Timber or Logcat Logs options

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add equivalent migration warnings for legacy external and Spring Boot Logs configuration.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


