### PR TITLE
feat(core): [Logs and Metrics Enable Flags 9] Warn for legacy Logs configuration

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3733,6 +3733,21 @@ public class SentryOptions {
       }
     }
 
+    if (options.isEnableLogs() != null) {
+      if (options.isEnableLogs()) {
+        logger.log(
+            SentryLevel.WARNING,
+            "The 'logs.enabled' option is no longer supported. Manual Sentry.logger() calls no "
+                + "longer require it, and automatic logging integrations now require their own "
+                + "opt-ins.");
+      } else {
+        logger.log(
+            SentryLevel.WARNING,
+            "The 'logs.enabled' option no longer disables manual Sentry.logger() calls. Automatic "
+                + "logging integrations remain disabled unless enabled through their own opt-ins.");
+      }
+    }
+
     if (options.isEnableMetrics() != null) {
       getMetrics().setEnabled(options.isEnableMetrics());
     }

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -438,6 +438,18 @@ class ExternalOptionsTest {
   }
 
   @Test
+  fun `creates options with enableLogs set to false`() {
+    withPropertiesFile("logs.enabled=false") { options ->
+      assertTrue(options.isEnableLogs == false)
+    }
+  }
+
+  @Test
+  fun `creates options with enableLogs set to null when not set`() {
+    withPropertiesFile { assertNull(it.isEnableLogs) }
+  }
+
+  @Test
   fun `creates options with enableMetrics set to true`() {
     withPropertiesFile("metrics.enabled=true") { options ->
       assertTrue(options.isEnableMetrics == true)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -2,6 +2,9 @@ package io.sentry
 
 import io.sentry.SentryOptions.RequestSize
 import io.sentry.logger.ILoggerBatchProcessorFactory
+import io.sentry.logger.LoggerApi
+import io.sentry.test.createSentryClientMock
+import io.sentry.test.createTestScopes
 import io.sentry.util.StringUtils
 import java.io.File
 import java.net.Proxy
@@ -15,8 +18,11 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class SentryOptionsTest {
@@ -499,6 +505,72 @@ class SentryOptionsTest {
     val options = SentryOptions()
     options.merge(externalOptions)
     assertTrue(options.metrics.isEnabled)
+  }
+
+  @Test
+  fun `merging options does not warn when legacy logs configuration is absent`() {
+    val logger = mock<ILogger>()
+    val options =
+      SentryOptions().also {
+        it.isDebug = true
+        it.setLogger(logger)
+      }
+
+    options.merge(ExternalOptions())
+
+    verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+  }
+
+  @Test
+  fun `merging options warns when legacy logs configuration is true`() {
+    val logger = mock<ILogger>()
+    val options =
+      SentryOptions().also {
+        it.isDebug = true
+        it.setLogger(logger)
+      }
+
+    options.merge(ExternalOptions().apply { isEnableLogs = true })
+
+    verify(logger)
+      .log(
+        SentryLevel.WARNING,
+        "The 'logs.enabled' option is no longer supported. Manual Sentry.logger() calls no " +
+          "longer require it, and automatic logging integrations now require their own opt-ins.",
+        *emptyArray(),
+      )
+    assertLegacyLogsConfigurationDoesNotDisableCapture(options)
+  }
+
+  @Test
+  fun `merging options warns when legacy logs configuration is false`() {
+    val logger = mock<ILogger>()
+    val options =
+      SentryOptions().also {
+        it.isDebug = true
+        it.setLogger(logger)
+      }
+
+    options.merge(ExternalOptions().apply { isEnableLogs = false })
+
+    verify(logger)
+      .log(
+        SentryLevel.WARNING,
+        "The 'logs.enabled' option no longer disables manual Sentry.logger() calls. Automatic " +
+          "logging integrations remain disabled unless enabled through their own opt-ins.",
+        *emptyArray(),
+      )
+    assertLegacyLogsConfigurationDoesNotDisableCapture(options)
+  }
+
+  private fun assertLegacyLogsConfigurationDoesNotDisableCapture(options: SentryOptions) {
+    options.dsn = "https://key@sentry.io/proj"
+    val client = createSentryClientMock()
+    val scopes = createTestScopes(options).apply { bindClient(client) }
+
+    LoggerApi(scopes).info("test log")
+
+    verify(client).captureLog(any(), anyOrNull())
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Keeps parsing the nullable legacy `logs.enabled` external option and emits a tailored migration warning from `SentryOptions.merge` for explicit `true` and `false` values.

The legacy value no longer changes SDK behavior. Manual `Sentry.logger()` capture remains active for either value, while absent configuration emits no warning.

## :bulb: Motivation and Context

The aggregate Logs enable flag was removed earlier in this stack. Existing `sentry.properties`, environment-variable, and system-property configurations need a clear migration diagnostic rather than being silently ignored.

## :green_heart: How did you test it?

- `./gradlew :sentry:test`
- `./gradlew spotlessApply apiDump`
- Added external parsing tests for absent, `true`, and `false` values
- Added merge tests for tailored warnings and unchanged manual Logs capture

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add the equivalent migration warning for legacy Spring Boot Logs configuration.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


