### PR TITLE
feat(spring): [Logs and Metrics Enable Flags 10] Warn for legacy Logs property

### DIFF
--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
@@ -186,8 +186,8 @@ public class SentryAutoConfiguration {
       // its technically possible to set non-throwable class to `ignoredExceptionsForType` set
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
-      warnForLegacyLogsConfiguration(environment, options);
       Sentry.init(options);
+      warnForLegacyLogsConfiguration(environment, options);
       return ScopesAdapter.getInstance();
     }
 

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
@@ -11,6 +11,7 @@ import io.sentry.Integration;
 import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.quartz.SentryJobListener;
@@ -163,7 +164,8 @@ public class SentryAutoConfiguration {
         final @NotNull List<Sentry.OptionsConfiguration<SentryOptions>> optionsConfigurations,
         final @NotNull SentryProperties options,
         final @NotNull ObjectProvider<ISpanFactory> spanFactory,
-        final @NotNull ObjectProvider<GitProperties> gitProperties) {
+        final @NotNull ObjectProvider<GitProperties> gitProperties,
+        final @NotNull Environment environment) {
       optionsConfigurations.forEach(
           optionsConfiguration -> optionsConfiguration.configure(options));
       gitProperties.ifAvailable(
@@ -184,8 +186,34 @@ public class SentryAutoConfiguration {
       // its technically possible to set non-throwable class to `ignoredExceptionsForType` set
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
+      warnForLegacyLogsConfiguration(environment, options);
       Sentry.init(options);
       return ScopesAdapter.getInstance();
+    }
+
+    private void warnForLegacyLogsConfiguration(
+        final @NotNull Environment environment, final @NotNull SentryOptions options) {
+      if (environment.containsProperty("sentry.logs.enabled")) {
+        final boolean enableLogs =
+            Boolean.TRUE.equals(environment.getProperty("sentry.logs.enabled", Boolean.class));
+        if (enableLogs) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.logs.enabled' property is no longer supported. Manual "
+                      + "Sentry.logger() calls no longer require it, and automatic logging "
+                      + "integrations now require their own opt-ins.");
+        } else {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
+                      + "calls. Automatic logging integrations remain disabled unless enabled "
+                      + "through their own opt-ins.");
+        }
+      }
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -8,6 +8,7 @@ import io.sentry.EventProcessor
 import io.sentry.FilterString
 import io.sentry.Hint
 import io.sentry.IContinuousProfiler
+import io.sentry.ILogger
 import io.sentry.IProfileConverter
 import io.sentry.IScopes
 import io.sentry.ITransportFactory
@@ -56,7 +57,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.mockito.internal.util.MockUtil.isMock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.quartz.JobExecutionContext
@@ -191,6 +194,56 @@ class SentryAutoConfigurationTest {
             it.getBean(Sentry.OptionsConfiguration::class.java, "customOptionsConfiguration")
           )
           .isNotNull
+      }
+  }
+
+  @Test
+  fun `legacy logs property emits no warning when absent`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
+  }
+
+  @Test
+  fun `legacy logs property true emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.logs.enabled' property is no longer supported. Manual " +
+              "Sentry.logger() calls no longer require it, and automatic logging " +
+              "integrations now require their own opt-ins.",
+            *emptyArray(),
+          )
+        assertThat(it.getBean(SentryProperties::class.java).logging.isEnableLogs).isFalse()
+      }
+  }
+
+  @Test
+  fun `legacy logs property false emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=false")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() " +
+              "calls. Automatic logging integrations remain disabled unless enabled through " +
+              "their own opt-ins.",
+            *emptyArray(),
+          )
+        assertThat(it.getBean(SentryProperties::class.java).logging.isEnableLogs).isFalse()
       }
   }
 
@@ -1282,6 +1335,13 @@ class SentryAutoConfigurationTest {
     }
 
     @Bean open fun sentryTransport() = transport
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  open class LoggerConfiguration {
+    @Bean
+    open fun loggerConfiguration(logger: ILogger) =
+      Sentry.OptionsConfiguration<SentryOptions> { it.setLogger(logger) }
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -11,6 +11,7 @@ import io.sentry.Integration;
 import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.quartz.SentryJobListener;
@@ -165,7 +166,8 @@ public class SentryAutoConfiguration {
         final @NotNull List<Sentry.OptionsConfiguration<SentryOptions>> optionsConfigurations,
         final @NotNull SentryProperties options,
         final @NotNull ObjectProvider<ISpanFactory> spanFactory,
-        final @NotNull ObjectProvider<GitProperties> gitProperties) {
+        final @NotNull ObjectProvider<GitProperties> gitProperties,
+        final @NotNull Environment environment) {
       optionsConfigurations.forEach(
           optionsConfiguration -> optionsConfiguration.configure(options));
       gitProperties.ifAvailable(
@@ -186,8 +188,34 @@ public class SentryAutoConfiguration {
       // its technically possible to set non-throwable class to `ignoredExceptionsForType` set
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
+      warnForLegacyLogsConfiguration(environment, options);
       Sentry.init(options);
       return ScopesAdapter.getInstance();
+    }
+
+    private void warnForLegacyLogsConfiguration(
+        final @NotNull Environment environment, final @NotNull SentryOptions options) {
+      if (environment.containsProperty("sentry.logs.enabled")) {
+        final boolean enableLogs =
+            Boolean.TRUE.equals(environment.getProperty("sentry.logs.enabled", Boolean.class));
+        if (enableLogs) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.logs.enabled' property is no longer supported. Manual "
+                      + "Sentry.logger() calls no longer require it, and automatic logging "
+                      + "integrations now require their own opt-ins.");
+        } else {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
+                      + "calls. Automatic logging integrations remain disabled unless enabled "
+                      + "through their own opt-ins.");
+        }
+      }
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -188,8 +188,8 @@ public class SentryAutoConfiguration {
       // its technically possible to set non-throwable class to `ignoredExceptionsForType` set
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
-      warnForLegacyLogsConfiguration(environment, options);
       Sentry.init(options);
+      warnForLegacyLogsConfiguration(environment, options);
       return ScopesAdapter.getInstance();
     }
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -9,6 +9,7 @@ import io.sentry.EventProcessor
 import io.sentry.FilterString
 import io.sentry.Hint
 import io.sentry.IContinuousProfiler
+import io.sentry.ILogger
 import io.sentry.IProfileConverter
 import io.sentry.IScopes
 import io.sentry.ITransportFactory
@@ -59,7 +60,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.mockito.internal.util.MockUtil.isMock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.quartz.JobExecutionContext
@@ -194,6 +197,56 @@ class SentryAutoConfigurationTest {
             it.getBean(Sentry.OptionsConfiguration::class.java, "customOptionsConfiguration")
           )
           .isNotNull
+      }
+  }
+
+  @Test
+  fun `legacy logs property emits no warning when absent`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
+  }
+
+  @Test
+  fun `legacy logs property true emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.logs.enabled' property is no longer supported. Manual " +
+              "Sentry.logger() calls no longer require it, and automatic logging " +
+              "integrations now require their own opt-ins.",
+            *emptyArray(),
+          )
+        assertThat(it.getBean(SentryProperties::class.java).logging.isEnableLogs).isFalse()
+      }
+  }
+
+  @Test
+  fun `legacy logs property false emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=false")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() " +
+              "calls. Automatic logging integrations remain disabled unless enabled through " +
+              "their own opt-ins.",
+            *emptyArray(),
+          )
+        assertThat(it.getBean(SentryProperties::class.java).logging.isEnableLogs).isFalse()
       }
   }
 
@@ -1274,6 +1327,13 @@ class SentryAutoConfigurationTest {
     }
 
     @Bean open fun sentryTransport() = transport
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  open class LoggerConfiguration {
+    @Bean
+    open fun loggerConfiguration(logger: ILogger) =
+      Sentry.OptionsConfiguration<SentryOptions> { it.setLogger(logger) }
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -10,6 +10,7 @@ import io.sentry.Integration;
 import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.quartz.SentryJobListener;
@@ -160,7 +161,8 @@ public class SentryAutoConfiguration {
         final @NotNull List<Sentry.OptionsConfiguration<SentryOptions>> optionsConfigurations,
         final @NotNull SentryProperties options,
         final @NotNull ObjectProvider<ISpanFactory> spanFactory,
-        final @NotNull ObjectProvider<GitProperties> gitProperties) {
+        final @NotNull ObjectProvider<GitProperties> gitProperties,
+        final @NotNull Environment environment) {
       optionsConfigurations.forEach(
           optionsConfiguration -> optionsConfiguration.configure(options));
       gitProperties.ifAvailable(
@@ -181,8 +183,34 @@ public class SentryAutoConfiguration {
       // its technically possible to set non-throwable class to `ignoredExceptionsForType` set
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
+      warnForLegacyLogsConfiguration(environment, options);
       Sentry.init(options);
       return ScopesAdapter.getInstance();
+    }
+
+    private void warnForLegacyLogsConfiguration(
+        final @NotNull Environment environment, final @NotNull SentryOptions options) {
+      if (environment.containsProperty("sentry.logs.enabled")) {
+        final boolean enableLogs =
+            Boolean.TRUE.equals(environment.getProperty("sentry.logs.enabled", Boolean.class));
+        if (enableLogs) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.logs.enabled' property is no longer supported. Manual "
+                      + "Sentry.logger() calls no longer require it, and automatic logging "
+                      + "integrations now require their own opt-ins.");
+        } else {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
+                      + "calls. Automatic logging integrations remain disabled unless enabled "
+                      + "through their own opt-ins.");
+        }
+      }
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -183,8 +183,8 @@ public class SentryAutoConfiguration {
       // its technically possible to set non-throwable class to `ignoredExceptionsForType` set
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
-      warnForLegacyLogsConfiguration(environment, options);
       Sentry.init(options);
+      warnForLegacyLogsConfiguration(environment, options);
       return ScopesAdapter.getInstance();
     }
 

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -9,6 +9,7 @@ import io.sentry.EventProcessor
 import io.sentry.FilterString
 import io.sentry.Hint
 import io.sentry.IContinuousProfiler
+import io.sentry.ILogger
 import io.sentry.IProfileConverter
 import io.sentry.IScopes
 import io.sentry.ITransportFactory
@@ -59,7 +60,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.mockito.internal.util.MockUtil.isMock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.quartz.JobExecutionContext
@@ -192,6 +195,56 @@ class SentryAutoConfigurationTest {
             it.getBean(Sentry.OptionsConfiguration::class.java, "customOptionsConfiguration")
           )
           .isNotNull
+      }
+  }
+
+  @Test
+  fun `legacy logs property emits no warning when absent`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
+  }
+
+  @Test
+  fun `legacy logs property true emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.logs.enabled' property is no longer supported. Manual " +
+              "Sentry.logger() calls no longer require it, and automatic logging " +
+              "integrations now require their own opt-ins.",
+            *emptyArray(),
+          )
+        assertThat(it.getBean(SentryProperties::class.java).logging.isEnableLogs).isFalse()
+      }
+  }
+
+  @Test
+  fun `legacy logs property false emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=false")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() " +
+              "calls. Automatic logging integrations remain disabled unless enabled through " +
+              "their own opt-ins.",
+            *emptyArray(),
+          )
+        assertThat(it.getBean(SentryProperties::class.java).logging.isEnableLogs).isFalse()
       }
   }
 
@@ -1207,6 +1260,13 @@ class SentryAutoConfigurationTest {
     }
 
     @Bean open fun sentryTransport() = transport
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  open class LoggerConfiguration {
+    @Bean
+    open fun loggerConfiguration(logger: ILogger) =
+      Sentry.OptionsConfiguration<SentryOptions> { it.setLogger(logger) }
   }
 
   @Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Injects the Spring `Environment` into SDK initialization for all three Spring Boot variants and detects explicit `sentry.logs.enabled` configuration. Migration warnings are emitted after `Sentry.init`, when the diagnostic logger has been initialized.

Both `true` and `false` values emit tailored migration warnings. The obsolete property is not restored to `SentryProperties` and does not affect capture or the new `sentry.logging.logs-enabled` integration control. Absent configuration emits no warning.

## :bulb: Motivation and Context

After removal of the aggregate Logs option, Spring's relaxed binder ignores the old property. Inspecting the complete Spring `Environment` preserves a useful migration diagnostic across property files, YAML, environment variables, command-line values, and other property sources.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-boot:test :sentry-spring-boot-jakarta:test :sentry-spring-boot-4:test`
- `./gradlew spotlessApply apiDump`
- Added absent, explicit `true`, and explicit `false` tests to all three Spring Boot variants
- Verified the integration-local Logback Logs opt-in remains disabled

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Avoid starting the Logs batch worker thread until the first accepted Log item.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.



