### PR TITLE
perf(core): [Logs and Metrics Enable Flags 11] Avoid unused Logs worker thread

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidLoggerBatchProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidLoggerBatchProcessorTest.kt
@@ -1,12 +1,15 @@
 package io.sentry.android.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.ISentryClient
 import io.sentry.SentryLogEvent
 import io.sentry.SentryLogLevel
 import io.sentry.SentryOptions
 import io.sentry.protocol.SentryId
 import io.sentry.test.ImmediateExecutorService
+import io.sentry.test.getProperty
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -15,6 +18,7 @@ import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -53,6 +57,16 @@ class AndroidLoggerBatchProcessorTest {
   fun `constructor registers as AppState listener`() {
     fixture.getSut()
     assertNotNull(AppState.getInstance().lifecycleObserver)
+  }
+
+  @Test
+  fun `onBackground does not flush before first accepted item`() {
+    val sut = fixture.getSut(useImmediateExecutor = true)
+
+    sut.onBackground()
+
+    assertThat(sut.getProperty<AtomicBoolean>("hasScheduled").get()).isFalse()
+    verify(fixture.client, never()).captureBatchedLogEvents(any())
   }
 
   @Test

--- a/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
@@ -36,6 +36,7 @@ public class LoggerBatchProcessor implements ILoggerBatchProcessor {
   private final @NotNull Queue<SentryLogEvent> queue;
   private final @NotNull ISentryExecutorService executorService;
   private final @NotNull AtomicBoolean hasScheduled = new AtomicBoolean(false);
+  private volatile boolean hasAcceptedItem = false;
   private volatile boolean isShuttingDown = false;
 
   private final @NotNull ReusableCountLatch pendingCount = new ReusableCountLatch();
@@ -75,6 +76,7 @@ public class LoggerBatchProcessor implements ILoggerBatchProcessor {
     }
     pendingCount.increment();
     queue.offer(logEvent);
+    hasAcceptedItem = true;
     maybeSchedule(false);
   }
 
@@ -82,14 +84,14 @@ public class LoggerBatchProcessor implements ILoggerBatchProcessor {
   @Override
   public void close(final boolean isRestarting) {
     isShuttingDown = true;
-    if (isRestarting) {
+    if (isRestarting && hasAcceptedItem) {
       maybeSchedule(true);
       executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
-    } else {
-      executorService.close(options.getShutdownTimeoutMillis());
-      while (!queue.isEmpty()) {
-        flushBatch();
-      }
+      return;
+    }
+    executorService.close(options.getShutdownTimeoutMillis());
+    while (!queue.isEmpty()) {
+      flushBatch();
     }
   }
 
@@ -114,6 +116,9 @@ public class LoggerBatchProcessor implements ILoggerBatchProcessor {
 
   @Override
   public void flush(long timeoutMillis) {
+    if (!hasAcceptedItem) {
+      return;
+    }
     maybeSchedule(true);
     try {
       pendingCount.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/sentry/src/test/java/io/sentry/logger/LoggerBatchProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/logger/LoggerBatchProcessorTest.kt
@@ -3,6 +3,7 @@ package io.sentry.logger
 import com.google.common.truth.Truth.assertThat
 import io.sentry.DataCategory
 import io.sentry.ISentryClient
+import io.sentry.ISentryExecutorService
 import io.sentry.SentryLogEvent
 import io.sentry.SentryLogEvents
 import io.sentry.SentryLogLevel
@@ -13,19 +14,106 @@ import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.DiscardedEvent
 import io.sentry.protocol.SentryId
 import io.sentry.test.DeferredExecutorService
+import io.sentry.test.getProperty
 import io.sentry.test.injectForField
+import io.sentry.transport.ReusableCountLatch
 import io.sentry.util.JsonSerializationUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 
 class LoggerBatchProcessorTest {
+  @Test
+  fun `constructor does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+
+    LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    verifyNoInteractions(mockExecutor)
+  }
+
+  @Test
+  fun `empty flush does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    processor.flush(0)
+
+    verifyNoInteractions(mockExecutor)
+  }
+
+  @Test
+  fun `close before first accepted item does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    processor.close(false)
+
+    verify(mockExecutor).close(any())
+    verify(mockExecutor, never()).schedule(any(), any())
+    verify(mockExecutor, never()).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `restart close before first accepted item does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    processor.close(true)
+
+    verify(mockExecutor).close(any())
+    verify(mockExecutor, never()).schedule(any(), any())
+    verify(mockExecutor, never()).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `item rejected during shutdown does not mark processor as used`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+    processor.close(false)
+
+    processor.add(logEvent("rejected"))
+    processor.flush(0)
+
+    verify(mockExecutor, never()).schedule(any(), any())
+    verify(mockExecutor, never()).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `item rejected due to queue capacity does not mark processor as used`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+    val pendingCount = processor.getProperty<ReusableCountLatch>("pendingCount")
+    repeat(LoggerBatchProcessor.MAX_QUEUE_SIZE) { pendingCount.increment() }
+
+    processor.add(logEvent("rejected"))
+    processor.flush(0)
+
+    verifyNoInteractions(mockExecutor)
+  }
+
+  @Test
+  fun `flush and restart close submit processor work after first accepted item`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = LoggerBatchProcessor(SentryOptions(), mock(), mockExecutor)
+    processor.add(logEvent("accepted"))
+
+    processor.flush(0)
+    processor.close(true)
+
+    verify(mockExecutor, times(3)).schedule(any(), any())
+    verify(mockExecutor).submit(any<Runnable>())
+  }
+
   @Test
   fun `schedules another flush after previous flush has run`() {
     val mockClient = mock<ISentryClient>()
@@ -45,6 +133,9 @@ class LoggerBatchProcessorTest {
       .containsExactly("first", "second")
       .inOrder()
   }
+
+  private fun logEvent(body: String) =
+    SentryLogEvent(SentryId(), SentryNanotimeDate(), body, SentryLogLevel.INFO)
 
   @Test
   fun `drops log events after reaching MAX_QUEUE_SIZE limit`() {


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Tracks whether `LoggerBatchProcessor` has accepted its first Log item. Before that point, empty flushes and restart closes do not schedule processor work. Normal close still closes the executor directly.

After the first accepted item, batching, flushing, and restart-close behavior remain unchanged. Items rejected because of shutdown or queue capacity do not mark the processor as used.

## :bulb: Motivation and Context

The aggregate Logs enable flag has been removed, so every SDK client now owns a logger batch processor. Without this guard, lifecycle flushes—particularly Android background callbacks—can start a worker thread even when the application never captures a Log.

## :green_heart: How did you test it?

- `./gradlew :sentry:test :sentry-android-core:testReleaseUnitTest`
- `./gradlew spotlessApply apiDump`
- Added core tests for construction, empty flush, close, restart close, rejected items, and behavior after first use
- Added an Android background callback test before first use

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Remove the aggregate Metrics enable flag.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


