### PR TITLE
feat(core): [Logs and Metrics Enable Flags 12] Remove Metrics enable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Remove the aggregate Sentry Metrics enable flag; `Sentry.metrics()` calls now capture Metrics by default ([#5953](https://github.com/getsentry/sentry-java/pull/5953))
 - Remove the aggregate Sentry Logs enable flag; manual `Sentry.logger()` calls now capture Logs by default ([#5947](https://github.com/getsentry/sentry-java/pull/5947))
 - Add an explicit Logs opt-in to Spring Boot logging auto-configuration ([#5946](https://github.com/getsentry/sentry-java/pull/5946))
 - Add an explicit Logs opt-in to the Android Logcat integration ([#5945](https://github.com/getsentry/sentry-java/pull/5945))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -729,11 +729,6 @@ final class ManifestMetadataReader {
         options.setEnableLogcatLogs(
             readBool(metadata, logger, ENABLE_LOGCAT_LOGS, options.isEnableLogcatLogs()));
 
-        options
-            .getMetrics()
-            .setEnabled(
-                readBool(metadata, logger, ENABLE_METRICS, options.getMetrics().isEnabled()));
-
         final @NotNull SentryFeedbackOptions feedbackOptions = options.getFeedbackOptions();
         feedbackOptions.setNameRequired(
             readBool(metadata, logger, FEEDBACK_NAME_REQUIRED, feedbackOptions.isNameRequired()));

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -11,6 +11,8 @@ import io.sentry.ProfileLifecycle
 import io.sentry.SentryLevel
 import io.sentry.SentryReplayOptions
 import io.sentry.TransactionOptions
+import io.sentry.test.createSentryClientMock
+import io.sentry.test.createTestScopes
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,6 +22,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -2051,41 +2054,17 @@ class ManifestMetadataReaderTest {
   }
 
   @Test
-  fun `applyMetadata reads metrics enabled and keep default value if not found`() {
-    // Arrange
-    val context = fixture.getContext()
-
-    // Act
-    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
-
-    // Assert
-    assertTrue(fixture.options.metrics.isEnabled)
-  }
-
-  @Test
-  fun `applyMetadata reads metrics enabled to options`() {
-    // Arrange
+  fun `legacy metrics metadata does not disable capture`() {
     val bundle = bundleOf(ManifestMetadataReader.ENABLE_METRICS to false)
     val context = fixture.getContext(metaData = bundle)
+    val client = createSentryClientMock()
 
-    // Act
     ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+    fixture.options.dsn = "https://key@sentry.io/proj"
+    val scopes = createTestScopes(fixture.options).also { it.bindClient(client) }
+    scopes.metrics().count("metric name")
 
-    // Assert
-    assertFalse(fixture.options.metrics.isEnabled)
-  }
-
-  @Test
-  fun `applyMetadata reads metrics enabled to options when set to true`() {
-    // Arrange
-    val bundle = bundleOf(ManifestMetadataReader.ENABLE_METRICS to true)
-    val context = fixture.getContext(metaData = bundle)
-
-    // Act
-    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
-
-    // Assert
-    assertTrue(fixture.options.metrics.isEnabled)
+    verify(client).captureMetric(any(), anyOrNull(), anyOrNull())
   }
 
   @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3976,9 +3976,7 @@ public final class io/sentry/SentryOptions$Metrics {
 	public fun <init> ()V
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$Metrics$BeforeSendMetricCallback;
 	public fun getMetricsBatchProcessorFactory ()Lio/sentry/metrics/IMetricsBatchProcessorFactory;
-	public fun isEnabled ()Z
 	public fun setBeforeSend (Lio/sentry/SentryOptions$Metrics$BeforeSendMetricCallback;)V
-	public fun setEnabled (Z)V
 	public fun setMetricsBatchProcessorFactory (Lio/sentry/metrics/IMetricsBatchProcessorFactory;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -10,7 +10,6 @@ import io.sentry.hints.DiskFlushNotification;
 import io.sentry.hints.TransactionEnd;
 import io.sentry.logger.ILoggerBatchProcessor;
 import io.sentry.metrics.IMetricsBatchProcessor;
-import io.sentry.metrics.NoOpMetricsBatchProcessor;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.DebugMeta;
 import io.sentry.protocol.FeatureFlags;
@@ -62,12 +61,8 @@ public final class SentryClient implements ISentryClient {
     final RequestDetailsResolver requestDetailsResolver = new RequestDetailsResolver(options);
     transport = transportFactory.create(options, requestDetailsResolver.resolve());
     loggerBatchProcessor = options.getLogs().getLoggerBatchProcessorFactory().create(options, this);
-    if (options.getMetrics().isEnabled()) {
-      metricsBatchProcessor =
-          options.getMetrics().getMetricsBatchProcessorFactory().create(options, this);
-    } else {
-      metricsBatchProcessor = NoOpMetricsBatchProcessor.getInstance();
-    }
+    metricsBatchProcessor =
+        options.getMetrics().getMetricsBatchProcessorFactory().create(options, this);
   }
 
   private boolean shouldApplyScopeData(

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3748,10 +3748,6 @@ public class SentryOptions {
       }
     }
 
-    if (options.isEnableMetrics() != null) {
-      getMetrics().setEnabled(options.isEnableMetrics());
-    }
-
     if (options.getProfileSessionSampleRate() != null) {
       setProfileSessionSampleRate(options.getProfileSessionSampleRate());
     }
@@ -4023,9 +4019,6 @@ public class SentryOptions {
 
   public static final class Metrics {
 
-    /** Whether Sentry Metrics feature is enabled and metrics are sent to Sentry. */
-    private boolean enable = true;
-
     /**
      * This function is called with a metric key and tags and can return false to skip sending the
      * metric
@@ -4034,24 +4027,6 @@ public class SentryOptions {
 
     private @NotNull IMetricsBatchProcessorFactory metricsBatchProcessorFactory =
         new DefaultMetricsBatchProcessorFactory();
-
-    /**
-     * Whether Sentry Metrics feature is enabled and metrics are sent to Sentry.
-     *
-     * @return true if Sentry Metrics should be enabled
-     */
-    public boolean isEnabled() {
-      return enable;
-    }
-
-    /**
-     * Whether Sentry Metrics feature is enabled and metrics are sent to Sentry.
-     *
-     * @param enableMetrics true if Sentry Metrics should be enabled
-     */
-    public void setEnabled(final boolean enableMetrics) {
-      this.enable = enableMetrics;
-    }
 
     /**
      * Returns the BeforeSendMetric callback

--- a/sentry/src/main/java/io/sentry/metrics/MetricsApi.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsApi.java
@@ -118,15 +118,6 @@ public final class MetricsApi implements IMetricsApi {
         return;
       }
 
-      if (!options.getMetrics().isEnabled()) {
-        options
-            .getLogger()
-            .log(
-                SentryLevel.WARNING,
-                "Sentry Metrics is disabled and this 'metrics' call is a no-op.");
-        return;
-      }
-
       if (name == null) {
         return;
       }

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -3290,11 +3290,15 @@ class ScopesTest {
   }
 
   @Test
-  fun `when metrics is not enabled, do nothing`() {
-    val (sut, mockClient) = getEnabledScopes { it.metrics.isEnabled = false }
+  fun `legacy external metrics configuration does not disable capture`() {
+    val (sut, mockClient) =
+      getEnabledScopes { options ->
+        options.merge(ExternalOptions().also { it.isEnableMetrics = false })
+      }
 
     sut.metrics().count("metric name")
-    verify(mockClient, never()).captureMetric(any(), anyOrNull(), anyOrNull())
+
+    verify(mockClient).captureMetric(any(), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -4226,7 +4230,7 @@ class ScopesTest {
 
   @Test
   fun `metric event has spanId from active span`() {
-    val (sut, mockClient) = getEnabledScopes { it.metrics.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     val transaction =
       sut.startTransaction(
@@ -4253,7 +4257,7 @@ class ScopesTest {
 
   @Test
   fun `metric event has spanId from propagation context when no active span`() {
-    val (sut, mockClient) = getEnabledScopes { it.metrics.isEnabled = true }
+    val (sut, mockClient) = getEnabledScopes()
 
     var propagationContext: PropagationContext? = null
     sut.configureScope { propagationContext = it.propagationContext }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -154,6 +154,13 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when client is created, metrics batch processor is created`() {
+    val sut = fixture.getSut()
+
+    verify(fixture.metricsBatchProcessorFactory).create(fixture.sentryOptions, sut)
+  }
+
+  @Test
   fun `when dsn is an invalid string, client throws`() {
     fixture.sentryOptions.dsn = "invalid-dsn"
     assertFailsWith<IllegalArgumentException> { fixture.getSut() }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -485,7 +485,6 @@ class SentryOptionsTest {
     assertTrue(options.isEnableSpotlight)
     assertEquals("http://local.sentry.io:1234", options.spotlightConnectionUrl)
     assertTrue(options.isGlobalHubMode!!)
-    assertFalse(options.metrics.isEnabled)
     assertEquals(0.8, options.profileSessionSampleRate)
     assertEquals("/profiling-traces${File.separator}${hash}", options.profilingTracesDirPath)
     assertEquals(ProfileLifecycle.TRACE, options.profileLifecycle)
@@ -497,14 +496,6 @@ class SentryOptionsTest {
     val options = SentryOptions()
     options.merge(externalOptions)
     assertTrue(options.isEnableUncaughtExceptionHandler)
-  }
-
-  @Test
-  fun `merging options when enableMetrics is not set preserves the default value`() {
-    val externalOptions = ExternalOptions()
-    val options = SentryOptions()
-    options.merge(externalOptions)
-    assertTrue(options.metrics.isEnabled)
   }
 
   @Test
@@ -802,11 +793,6 @@ class SentryOptionsTest {
   @Test
   fun `when options are initialized, enableQueueTracing is set to false by default`() {
     assertFalse(SentryOptions().isEnableQueueTracing)
-  }
-
-  @Test
-  fun `when options are initialized, metrics is enabled by default`() {
-    assertTrue(SentryOptions().metrics.isEnabled)
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Removes the aggregate Metrics enable option from `SentryOptions.Metrics`. Manual `Sentry.metrics()` calls now capture without an enable flag, and `SentryClient` always creates the configured Metrics batch processor.

Legacy `metrics.enabled` external configuration and `io.sentry.metrics.enabled` Android metadata remain detectable for follow-up migration warnings, but their values are no longer applied. `NoOpMetricsBatchProcessor` remains available as a separate public API.

## :bulb: Motivation and Context

Metrics are a manual namespaced API and no production integration currently generates them automatically. Requiring an aggregate enable option adds configuration without protecting users from automatic instrumentation.

## :green_heart: How did you test it?

- `./gradlew :sentry:test :sentry-android-core:testReleaseUnitTest`
- `./gradlew spotlessApply apiDump`
- Verified explicit legacy external and Android `false` values do not disable capture
- Verified the configured Metrics batch processor is always created
- Verified the removed methods disappear from the core API dump

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add an Android migration warning for explicit legacy `io.sentry.metrics.enabled` metadata.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


