### PR TITLE
feat(android): [Logs and Metrics Enable Flags 13] Warn for legacy Metrics metadata

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -723,6 +723,21 @@ final class ManifestMetadataReader {
           }
         }
 
+        if (metadata.containsKey(ENABLE_METRICS)) {
+          final boolean enableMetrics = readBool(metadata, logger, ENABLE_METRICS, false);
+          if (enableMetrics) {
+            logger.log(
+                SentryLevel.WARNING,
+                "The Android manifest option 'io.sentry.metrics.enabled' is no longer supported. "
+                    + "Manual Sentry.metrics() calls no longer require it.");
+          } else {
+            logger.log(
+                SentryLevel.WARNING,
+                "The Android manifest option 'io.sentry.metrics.enabled' no longer disables "
+                    + "manual Sentry.metrics() calls.");
+          }
+        }
+
         options.setEnableTimberLogs(
             readBool(metadata, logger, ENABLE_TIMBER_LOGS, options.isEnableTimberLogs()));
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -2054,8 +2054,22 @@ class ManifestMetadataReaderTest {
   }
 
   @Test
-  fun `legacy metrics metadata does not disable capture`() {
-    val bundle = bundleOf(ManifestMetadataReader.ENABLE_METRICS to false)
+  fun `applyMetadata does not warn when legacy metrics enabled metadata is absent`() {
+    fixture.options.isDebug = true
+    val context = fixture.getContext()
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    verify(fixture.logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+  }
+
+  @Test
+  fun `applyMetadata warns when legacy metrics enabled metadata is true`() {
+    val bundle =
+      bundleOf(
+        ManifestMetadataReader.DEBUG to true,
+        ManifestMetadataReader.ENABLE_METRICS to true,
+      )
     val context = fixture.getContext(metaData = bundle)
     val client = createSentryClientMock()
 
@@ -2064,6 +2078,38 @@ class ManifestMetadataReaderTest {
     val scopes = createTestScopes(fixture.options).also { it.bindClient(client) }
     scopes.metrics().count("metric name")
 
+    verify(fixture.logger)
+      .log(
+        SentryLevel.WARNING,
+        "The Android manifest option 'io.sentry.metrics.enabled' is no longer supported. " +
+          "Manual Sentry.metrics() calls no longer require it.",
+        *emptyArray(),
+      )
+    verify(client).captureMetric(any(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun `applyMetadata warns when legacy metrics enabled metadata is false`() {
+    val bundle =
+      bundleOf(
+        ManifestMetadataReader.DEBUG to true,
+        ManifestMetadataReader.ENABLE_METRICS to false,
+      )
+    val context = fixture.getContext(metaData = bundle)
+    val client = createSentryClientMock()
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+    fixture.options.dsn = "https://key@sentry.io/proj"
+    val scopes = createTestScopes(fixture.options).also { it.bindClient(client) }
+    scopes.metrics().count("metric name")
+
+    verify(fixture.logger)
+      .log(
+        SentryLevel.WARNING,
+        "The Android manifest option 'io.sentry.metrics.enabled' no longer disables manual " +
+          "Sentry.metrics() calls.",
+        *emptyArray(),
+      )
     verify(client).captureMetric(any(), anyOrNull(), anyOrNull())
   }
 


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Detects explicit legacy `io.sentry.metrics.enabled` Android manifest metadata and emits tailored migration warnings for both `true` and `false` values.

The obsolete metadata value is not applied. Manual `Sentry.metrics()` capture remains active regardless of the configured value, and absent metadata emits no warning.

## :bulb: Motivation and Context

The aggregate Metrics enable option was removed in the previous PR. Existing Android applications may still configure its manifest key, so a focused warning helps users remove stale configuration without restoring the old behavior.

## :green_heart: How did you test it?

- `./gradlew :sentry-android-core:testReleaseUnitTest`
- `./gradlew spotlessApply apiDump`
- Added tests for absent, explicit `true`, and explicit `false` metadata
- Verified both explicit values leave manual Metrics capture active

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add a migration warning for legacy external `metrics.enabled` configuration.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


