### PR TITLE
feat(core): [Logs and Metrics Enable Flags 14] Warn for legacy Metrics configuration

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3748,6 +3748,19 @@ public class SentryOptions {
       }
     }
 
+    if (options.isEnableMetrics() != null) {
+      if (options.isEnableMetrics()) {
+        logger.log(
+            SentryLevel.WARNING,
+            "The 'metrics.enabled' option is no longer supported. Manual Sentry.metrics() calls no "
+                + "longer require it.");
+      } else {
+        logger.log(
+            SentryLevel.WARNING,
+            "The 'metrics.enabled' option no longer disables manual Sentry.metrics() calls.");
+      }
+    }
+
     if (options.getProfileSessionSampleRate() != null) {
       setProfileSessionSampleRate(options.getProfileSessionSampleRate());
     }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -3,6 +3,7 @@ package io.sentry
 import io.sentry.SentryOptions.RequestSize
 import io.sentry.logger.ILoggerBatchProcessorFactory
 import io.sentry.logger.LoggerApi
+import io.sentry.metrics.MetricsApi
 import io.sentry.test.createSentryClientMock
 import io.sentry.test.createTestScopes
 import io.sentry.util.StringUtils
@@ -562,6 +563,71 @@ class SentryOptionsTest {
     LoggerApi(scopes).info("test log")
 
     verify(client).captureLog(any(), anyOrNull())
+  }
+
+  @Test
+  fun `merging options does not warn when legacy metrics configuration is absent`() {
+    val logger = mock<ILogger>()
+    val options =
+      SentryOptions().also {
+        it.isDebug = true
+        it.setLogger(logger)
+      }
+
+    options.merge(ExternalOptions())
+
+    verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+  }
+
+  @Test
+  fun `merging options warns when legacy metrics configuration is true`() {
+    val logger = mock<ILogger>()
+    val options =
+      SentryOptions().also {
+        it.isDebug = true
+        it.setLogger(logger)
+      }
+
+    options.merge(ExternalOptions().apply { isEnableMetrics = true })
+
+    verify(logger)
+      .log(
+        SentryLevel.WARNING,
+        "The 'metrics.enabled' option is no longer supported. Manual Sentry.metrics() calls no " +
+          "longer require it.",
+        *emptyArray(),
+      )
+    assertLegacyMetricsConfigurationDoesNotDisableCapture(options)
+  }
+
+  @Test
+  fun `merging options warns when legacy metrics configuration is false`() {
+    val logger = mock<ILogger>()
+    val options =
+      SentryOptions().also {
+        it.isDebug = true
+        it.setLogger(logger)
+      }
+
+    options.merge(ExternalOptions().apply { isEnableMetrics = false })
+
+    verify(logger)
+      .log(
+        SentryLevel.WARNING,
+        "The 'metrics.enabled' option no longer disables manual Sentry.metrics() calls.",
+        *emptyArray(),
+      )
+    assertLegacyMetricsConfigurationDoesNotDisableCapture(options)
+  }
+
+  private fun assertLegacyMetricsConfigurationDoesNotDisableCapture(options: SentryOptions) {
+    options.dsn = "https://key@sentry.io/proj"
+    val client = createSentryClientMock()
+    val scopes = createTestScopes(options).apply { bindClient(client) }
+
+    MetricsApi(scopes).count("test metric")
+
+    verify(client).captureMetric(any(), anyOrNull(), anyOrNull())
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Continues parsing nullable `metrics.enabled` external configuration and emits tailored migration warnings during `SentryOptions.merge` for explicit `true` and `false` values.

The obsolete value is not applied. Manual `Sentry.metrics()` capture remains active for either value, while absent configuration emits no warning.

## :bulb: Motivation and Context

The aggregate Metrics enable flag has been removed. Keeping nullable external parsing temporarily lets users of `sentry.properties`, environment variables, and system properties receive a targeted migration warning instead of having obsolete configuration silently ignored.

## :green_heart: How did you test it?

- `./gradlew :sentry:test`
- `./gradlew spotlessApply apiDump`
- Added tests for absent, explicit `true`, and explicit `false` configuration
- Verified both legacy values leave manual Metrics capture active

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add equivalent migration warnings for the legacy Spring Boot Metrics property.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


