### PR TITLE
feat(spring): [Logs and Metrics Enable Flags 15] Warn for legacy Metrics property

### DIFF
--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
@@ -187,6 +187,7 @@ public class SentryAutoConfiguration {
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
       warnForLegacyLogsConfiguration(environment, options);
+      warnForLegacyMetricsConfiguration(environment, options);
       Sentry.init(options);
       return ScopesAdapter.getInstance();
     }
@@ -212,6 +213,29 @@ public class SentryAutoConfiguration {
                   "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
                       + "calls. Automatic logging integrations remain disabled unless enabled "
                       + "through their own opt-ins.");
+        }
+      }
+    }
+
+    private void warnForLegacyMetricsConfiguration(
+        final @NotNull Environment environment, final @NotNull SentryOptions options) {
+      if (environment.containsProperty("sentry.metrics.enabled")) {
+        final boolean enableMetrics =
+            Boolean.TRUE.equals(environment.getProperty("sentry.metrics.enabled", Boolean.class));
+        if (enableMetrics) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.metrics.enabled' property is no longer supported. Manual "
+                      + "Sentry.metrics() calls no longer require it.");
+        } else {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.metrics.enabled' property no longer disables manual "
+                      + "Sentry.metrics() calls.");
         }
       }
     }

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -248,6 +248,52 @@ class SentryAutoConfigurationTest {
   }
 
   @Test
+  fun `legacy metrics property emits no warning when absent`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
+  }
+
+  @Test
+  fun `legacy metrics property true emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.metrics.enabled' property is no longer supported. Manual " +
+              "Sentry.metrics() calls no longer require it.",
+            *emptyArray(),
+          )
+      }
+  }
+
+  @Test
+  fun `legacy metrics property false emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=false")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.metrics.enabled' property no longer disables manual " +
+              "Sentry.metrics() calls.",
+            *emptyArray(),
+          )
+      }
+  }
+
+  @Test
   fun `properties are applied to SentryOptions`() {
     contextRunner
       .withPropertyValues(

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -189,6 +189,7 @@ public class SentryAutoConfiguration {
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
       warnForLegacyLogsConfiguration(environment, options);
+      warnForLegacyMetricsConfiguration(environment, options);
       Sentry.init(options);
       return ScopesAdapter.getInstance();
     }
@@ -214,6 +215,29 @@ public class SentryAutoConfiguration {
                   "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
                       + "calls. Automatic logging integrations remain disabled unless enabled "
                       + "through their own opt-ins.");
+        }
+      }
+    }
+
+    private void warnForLegacyMetricsConfiguration(
+        final @NotNull Environment environment, final @NotNull SentryOptions options) {
+      if (environment.containsProperty("sentry.metrics.enabled")) {
+        final boolean enableMetrics =
+            Boolean.TRUE.equals(environment.getProperty("sentry.metrics.enabled", Boolean.class));
+        if (enableMetrics) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.metrics.enabled' property is no longer supported. Manual "
+                      + "Sentry.metrics() calls no longer require it.");
+        } else {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.metrics.enabled' property no longer disables manual "
+                      + "Sentry.metrics() calls.");
         }
       }
     }

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -251,6 +251,52 @@ class SentryAutoConfigurationTest {
   }
 
   @Test
+  fun `legacy metrics property emits no warning when absent`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
+  }
+
+  @Test
+  fun `legacy metrics property true emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.metrics.enabled' property is no longer supported. Manual " +
+              "Sentry.metrics() calls no longer require it.",
+            *emptyArray(),
+          )
+      }
+  }
+
+  @Test
+  fun `legacy metrics property false emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=false")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.metrics.enabled' property no longer disables manual " +
+              "Sentry.metrics() calls.",
+            *emptyArray(),
+          )
+      }
+  }
+
+  @Test
   fun `properties are applied to SentryOptions`() {
     contextRunner
       .withPropertyValues(

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -184,6 +184,7 @@ public class SentryAutoConfiguration {
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
       warnForLegacyLogsConfiguration(environment, options);
+      warnForLegacyMetricsConfiguration(environment, options);
       Sentry.init(options);
       return ScopesAdapter.getInstance();
     }
@@ -209,6 +210,29 @@ public class SentryAutoConfiguration {
                   "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
                       + "calls. Automatic logging integrations remain disabled unless enabled "
                       + "through their own opt-ins.");
+        }
+      }
+    }
+
+    private void warnForLegacyMetricsConfiguration(
+        final @NotNull Environment environment, final @NotNull SentryOptions options) {
+      if (environment.containsProperty("sentry.metrics.enabled")) {
+        final boolean enableMetrics =
+            Boolean.TRUE.equals(environment.getProperty("sentry.metrics.enabled", Boolean.class));
+        if (enableMetrics) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.metrics.enabled' property is no longer supported. Manual "
+                      + "Sentry.metrics() calls no longer require it.");
+        } else {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.WARNING,
+                  "The 'sentry.metrics.enabled' property no longer disables manual "
+                      + "Sentry.metrics() calls.");
         }
       }
     }

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -249,6 +249,52 @@ class SentryAutoConfigurationTest {
   }
 
   @Test
+  fun `legacy metrics property emits no warning when absent`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
+  }
+
+  @Test
+  fun `legacy metrics property true emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=true")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.metrics.enabled' property is no longer supported. Manual " +
+              "Sentry.metrics() calls no longer require it.",
+            *emptyArray(),
+          )
+      }
+  }
+
+  @Test
+  fun `legacy metrics property false emits migration warning`() {
+    val logger = mock<ILogger>()
+    dsnEnabledRunner
+      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=false")
+      .withBean(ILogger::class.java, { logger })
+      .withUserConfiguration(LoggerConfiguration::class.java)
+      .run {
+        verify(logger)
+          .log(
+            SentryLevel.WARNING,
+            "The 'sentry.metrics.enabled' property no longer disables manual " +
+              "Sentry.metrics() calls.",
+            *emptyArray(),
+          )
+      }
+  }
+
+  @Test
   fun `properties are applied to SentryOptions`() {
     contextRunner
       .withPropertyValues(


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Detects explicit `sentry.metrics.enabled` configuration through Spring's `Environment` in all three Spring Boot variants. Migration warnings are emitted after `Sentry.init`, when the diagnostic logger has been initialized.

Both `true` and `false` values emit tailored migration warnings. The obsolete property is not added back to `SentryProperties` and does not affect manual Metrics capture. Absent configuration emits no warning.

## :bulb: Motivation and Context

After removal of the aggregate Metrics option, Spring's relaxed binder ignores the old property. Inspecting the complete Spring `Environment` preserves a useful migration diagnostic across property files, YAML, environment variables, command-line values, and other property sources.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-boot:test :sentry-spring-boot-jakarta:test :sentry-spring-boot-4:test`
- `./gradlew spotlessApply apiDump`
- Added absent, explicit `true`, and explicit `false` tests to all three Spring Boot variants

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Avoid starting the Metrics batch worker thread until the first accepted Metrics item.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


