### PR TITLE
perf(core): [Logs and Metrics Enable Flags 16] Avoid unused Metrics worker thread

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMetricsBatchProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMetricsBatchProcessorTest.kt
@@ -1,11 +1,14 @@
 package io.sentry.android.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.ISentryClient
 import io.sentry.SentryMetricsEvent
 import io.sentry.SentryOptions
 import io.sentry.protocol.SentryId
 import io.sentry.test.ImmediateExecutorService
+import io.sentry.test.getProperty
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -14,6 +17,7 @@ import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -52,6 +56,16 @@ class AndroidMetricsBatchProcessorTest {
   fun `constructor registers as AppState listener`() {
     fixture.getSut()
     assertNotNull(AppState.getInstance().lifecycleObserver)
+  }
+
+  @Test
+  fun `onBackground does not flush before first accepted item`() {
+    val sut = fixture.getSut(useImmediateExecutor = true)
+
+    sut.onBackground()
+
+    assertThat(sut.getProperty<AtomicBoolean>("hasScheduled").get()).isFalse()
+    verify(fixture.client, never()).captureBatchedMetricsEvents(any())
   }
 
   @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5490,7 +5490,6 @@ public class io/sentry/metrics/MetricsBatchProcessor : io/sentry/metrics/IMetric
 	public static final field MAX_QUEUE_SIZE I
 	protected final field options Lio/sentry/SentryOptions;
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;)V
-	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;Lio/sentry/ISentryExecutorService;)V
 	public fun add (Lio/sentry/SentryMetricsEvent;)V
 	public fun close (Z)V
 	public fun flush (J)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5490,6 +5490,7 @@ public class io/sentry/metrics/MetricsBatchProcessor : io/sentry/metrics/IMetric
 	public static final field MAX_QUEUE_SIZE I
 	protected final field options Lio/sentry/SentryOptions;
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;)V
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;Lio/sentry/ISentryExecutorService;)V
 	public fun add (Lio/sentry/SentryMetricsEvent;)V
 	public fun close (Z)V
 	public fun flush (J)V

--- a/sentry/src/main/java/io/sentry/metrics/MetricsBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsBatchProcessor.java
@@ -19,8 +19,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 @Open
 public class MetricsBatchProcessor implements IMetricsBatchProcessor {
@@ -34,16 +36,26 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
   private final @NotNull Queue<SentryMetricsEvent> queue;
   private final @NotNull ISentryExecutorService executorService;
   private final @NotNull AtomicBoolean hasScheduled = new AtomicBoolean(false);
+  private volatile boolean hasAcceptedItem = false;
   private volatile boolean isShuttingDown = false;
 
   private final @NotNull ReusableCountLatch pendingCount = new ReusableCountLatch();
 
   public MetricsBatchProcessor(
       final @NotNull SentryOptions options, final @NotNull ISentryClient client) {
+    this(options, client, new SentryExecutorService(options));
+  }
+
+  @ApiStatus.Internal
+  @TestOnly
+  public MetricsBatchProcessor(
+      final @NotNull SentryOptions options,
+      final @NotNull ISentryClient client,
+      final @NotNull ISentryExecutorService executorService) {
     this.options = options;
     this.client = client;
     this.queue = new ConcurrentLinkedQueue<>();
-    this.executorService = new SentryExecutorService(options);
+    this.executorService = executorService;
   }
 
   @Override
@@ -65,6 +77,7 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
     }
     pendingCount.increment();
     queue.offer(metricsEvent);
+    hasAcceptedItem = true;
     maybeSchedule(false);
   }
 
@@ -72,14 +85,14 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
   @Override
   public void close(final boolean isRestarting) {
     isShuttingDown = true;
-    if (isRestarting) {
+    if (isRestarting && hasAcceptedItem) {
       maybeSchedule(true);
       executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
-    } else {
-      executorService.close(options.getShutdownTimeoutMillis());
-      while (!queue.isEmpty()) {
-        flushBatch();
-      }
+      return;
+    }
+    executorService.close(options.getShutdownTimeoutMillis());
+    while (!queue.isEmpty()) {
+      flushBatch();
     }
   }
 
@@ -106,6 +119,9 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
 
   @Override
   public void flush(long timeoutMillis) {
+    if (!hasAcceptedItem) {
+      return;
+    }
     maybeSchedule(true);
     try {
       pendingCount.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/sentry/src/main/java/io/sentry/metrics/MetricsBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsBatchProcessor.java
@@ -19,10 +19,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
 
 @Open
 public class MetricsBatchProcessor implements IMetricsBatchProcessor {
@@ -46,9 +44,7 @@ public class MetricsBatchProcessor implements IMetricsBatchProcessor {
     this(options, client, new SentryExecutorService(options));
   }
 
-  @ApiStatus.Internal
-  @TestOnly
-  public MetricsBatchProcessor(
+  MetricsBatchProcessor(
       final @NotNull SentryOptions options,
       final @NotNull ISentryClient client,
       final @NotNull ISentryExecutorService executorService) {

--- a/sentry/src/test/java/io/sentry/metrics/MetricsBatchProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/MetricsBatchProcessorTest.kt
@@ -3,6 +3,7 @@ package io.sentry.metrics
 import com.google.common.truth.Truth.assertThat
 import io.sentry.DataCategory
 import io.sentry.ISentryClient
+import io.sentry.ISentryExecutorService
 import io.sentry.SentryMetricsEvent
 import io.sentry.SentryMetricsEvents
 import io.sentry.SentryNanotimeDate
@@ -12,19 +13,106 @@ import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.DiscardedEvent
 import io.sentry.protocol.SentryId
 import io.sentry.test.DeferredExecutorService
+import io.sentry.test.getProperty
 import io.sentry.test.injectForField
+import io.sentry.transport.ReusableCountLatch
 import io.sentry.util.JsonSerializationUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 
 class MetricsBatchProcessorTest {
+  @Test
+  fun `constructor does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+
+    MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    verifyNoInteractions(mockExecutor)
+  }
+
+  @Test
+  fun `empty flush does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    processor.flush(0)
+
+    verifyNoInteractions(mockExecutor)
+  }
+
+  @Test
+  fun `close before first accepted item does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    processor.close(false)
+
+    verify(mockExecutor).close(any())
+    verify(mockExecutor, never()).schedule(any(), any())
+    verify(mockExecutor, never()).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `restart close before first accepted item does not submit processor work`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+
+    processor.close(true)
+
+    verify(mockExecutor).close(any())
+    verify(mockExecutor, never()).schedule(any(), any())
+    verify(mockExecutor, never()).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `item rejected during shutdown does not mark processor as used`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+    processor.close(false)
+
+    processor.add(metricsEvent("rejected"))
+    processor.flush(0)
+
+    verify(mockExecutor, never()).schedule(any(), any())
+    verify(mockExecutor, never()).submit(any<Runnable>())
+  }
+
+  @Test
+  fun `item rejected due to queue capacity does not mark processor as used`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+    val pendingCount = processor.getProperty<ReusableCountLatch>("pendingCount")
+    repeat(MetricsBatchProcessor.MAX_QUEUE_SIZE) { pendingCount.increment() }
+
+    processor.add(metricsEvent("rejected"))
+    processor.flush(0)
+
+    verifyNoInteractions(mockExecutor)
+  }
+
+  @Test
+  fun `flush and restart close submit processor work after first accepted item`() {
+    val mockExecutor = mock<ISentryExecutorService>()
+    val processor = MetricsBatchProcessor(SentryOptions(), mock(), mockExecutor)
+    processor.add(metricsEvent("accepted"))
+
+    processor.flush(0)
+    processor.close(true)
+
+    verify(mockExecutor, times(3)).schedule(any(), any())
+    verify(mockExecutor).submit(any<Runnable>())
+  }
+
   @Test
   fun `schedules another flush after previous flush has run`() {
     val mockClient = mock<ISentryClient>()
@@ -45,6 +133,9 @@ class MetricsBatchProcessorTest {
       .containsExactly("first", "second")
       .inOrder()
   }
+
+  private fun metricsEvent(name: String) =
+    SentryMetricsEvent(SentryId(), SentryNanotimeDate(), name, "gauge", 1.0)
 
   @Test
   fun `drops metrics events after reaching MAX_QUEUE_SIZE limit`() {


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Defers Metrics batch processor work until the processor accepts its first Metrics item.

Before first use, empty flushes and normal or restart closes do not schedule processor work. Rejected items do not mark the processor as used. After the first accepted item, batching, flush, restart-close, and Android background behavior remain unchanged.

## :bulb: Motivation and Context

The Metrics enable flag is gone, so every initialized SDK now creates a real Metrics batch processor. Avoid starting its executor thread for applications that never capture Metrics.

## :green_heart: How did you test it?

- `./gradlew :sentry:test :sentry-android-core:testReleaseUnitTest`
- `./gradlew spotlessApply apiDump`
- Added lifecycle tests for construction, empty flush, close, restart close, rejected items, and first accepted use
- Added Android coverage for background callbacks before and after first use

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

