### PR TITLE
fix(jul): [Logs and Metrics Enable Flags 17] Preserve null-message records

### DIFF
--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -150,10 +150,15 @@ public class SentryHandler extends Handler {
     final @Nullable Object[] arguments = loggingEvent.getParameters();
     final @NotNull SentryAttributes attributes = SentryAttributes.of();
 
-    @NotNull String message = loggingEvent.getMessage();
+    final @Nullable String messageTemplate = loggingEvent.getMessage();
+    if (messageTemplate == null) {
+      return;
+    }
+
+    @NotNull String message = messageTemplate;
     if (loggingEvent.getResourceBundle() != null
-        && loggingEvent.getResourceBundle().containsKey(loggingEvent.getMessage())) {
-      message = loggingEvent.getResourceBundle().getString(loggingEvent.getMessage());
+        && loggingEvent.getResourceBundle().containsKey(messageTemplate)) {
+      message = loggingEvent.getResourceBundle().getString(messageTemplate);
     }
 
     final @NotNull String formattedMessage = maybeFormatted(arguments, message);

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -486,6 +486,31 @@ class SentryHandlerTest {
   }
 
   @Test
+  fun `captures null message as event and breadcrumb when logs are enabled`() {
+    fixture =
+      Fixture(
+        minimumBreadcrumbLevel = Level.INFO,
+        minimumEventLevel = Level.SEVERE,
+        enableLogs = true,
+      )
+
+    fixture.logger.info(null as String?)
+    fixture.logger.severe(null as String?)
+    Sentry.flush(10)
+
+    verify(fixture.transport)
+      .send(
+        checkEvent { event ->
+          assertNull(event.message?.message)
+          assertEquals(1, event.breadcrumbs?.size)
+          assertNull(event.breadcrumbs?.single()?.message)
+        },
+        anyOrNull(),
+      )
+    verify(fixture.transport, never()).send(checkLogs {})
+  }
+
+  @Test
   fun `converts finest log level to Sentry log level`() {
     fixture = Fixture(minimumLevel = Level.FINEST)
     fixture.logger.finest("testing trace level")


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Skips Sentry Logs conversion when a valid JUL `LogRecord` has a null message. Event and breadcrumb processing continues normally, while no invalid Sentry Log item is created.

## :bulb: Motivation and Context

JUL permits null messages. When Sentry Logs forwarding was enabled, `captureLog` dereferenced the null formatted message before the established event and breadcrumb branches ran. The enclosing error handler then aborted processing, dropping an otherwise valid event or breadcrumb.

The issue is specific to JUL's nullable `LogRecord` path. Logcat and Timber already handle nullable bodies explicitly, Logback does not dereference its nullable formatted message in this path, and standard Log4j2 message implementations provide a formatted string.

## :green_heart: How did you test it?

- `./gradlew :sentry-jul:test`
- `./gradlew spotlessApply apiDump`
- Added a regression test proving null-message JUL records still produce an event and breadcrumb with Logs enabled, but no Sentry Log item

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

