### PR TITLE
perf(android): Use build-time manifest metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Use Android manifest metadata resolved by the Sentry Android Gradle plugin at build time, avoiding `PackageManager` and `Bundle` parsing and reducing median SDK initialization time by 6.5% in a cold-start benchmark ([#5963](https://github.com/getsentry/sentry-java/pull/5963))
+
 ## 8.53.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -18,12 +18,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Class responsible for reading values from manifest and setting them to the options */
 final class ManifestMetadataReader {
+
+  // Populated by the Sentry Android Gradle plugin with manifest metadata resolved at build time.
+  // When set, it is authoritative: the manifest is not read at runtime.
+  static @Nullable Map<String, Object> buildTimeMetadata;
 
   static final String DSN = "io.sentry.dsn";
   static final String DEBUG = "io.sentry.debug";
@@ -217,7 +222,7 @@ final class ManifestMetadataReader {
     Objects.requireNonNull(options, "The options object is required.");
 
     try {
-      final Bundle metadata = getMetadata(context, options.getLogger(), buildInfoProvider);
+      final Object metadata = getMetadata(context, options.getLogger(), buildInfoProvider);
       final ILogger logger = options.getLogger();
 
       if (metadata != null) {
@@ -491,7 +496,7 @@ final class ManifestMetadataReader {
         List<String> tracePropagationTargets =
             readList(metadata, logger, TRACE_PROPAGATION_TARGETS);
 
-        if (metadata.containsKey(TRACE_PROPAGATION_TARGETS) && tracePropagationTargets == null) {
+        if (containsKey(metadata, TRACE_PROPAGATION_TARGETS) && tracePropagationTargets == null) {
           options.setTracePropagationTargets(Collections.emptyList());
         } else if (tracePropagationTargets != null) {
           options.setTracePropagationTargets(tracePropagationTargets);
@@ -779,11 +784,17 @@ final class ManifestMetadataReader {
   }
 
   private static boolean readBool(
-      final @NotNull Bundle metadata,
+      final @NotNull Object metadata,
       final @NotNull ILogger logger,
       final @NotNull String key,
       final boolean defaultValue) {
-    final boolean value = metadata.getBoolean(key, defaultValue);
+    final boolean value;
+    if (metadata instanceof Bundle) {
+      value = ((Bundle) metadata).getBoolean(key, defaultValue);
+    } else {
+      final Object raw = ((Map<?, ?>) metadata).get(key);
+      value = raw instanceof Boolean ? (Boolean) raw : defaultValue;
+    }
     if (logger.isEnabled(SentryLevel.DEBUG)) {
       logger.log(SentryLevel.DEBUG, key + " read: " + value);
     }
@@ -791,11 +802,17 @@ final class ManifestMetadataReader {
   }
 
   private static @Nullable String readString(
-      final @NotNull Bundle metadata,
+      final @NotNull Object metadata,
       final @NotNull ILogger logger,
       final @NotNull String key,
       final @Nullable String defaultValue) {
-    final String value = metadata.getString(key, defaultValue);
+    final String value;
+    if (metadata instanceof Bundle) {
+      value = ((Bundle) metadata).getString(key, defaultValue);
+    } else {
+      final Object raw = ((Map<?, ?>) metadata).get(key);
+      value = raw instanceof String ? (String) raw : defaultValue;
+    }
     if (logger.isEnabled(SentryLevel.DEBUG)) {
       logger.log(SentryLevel.DEBUG, key + " read: " + value);
     }
@@ -803,11 +820,17 @@ final class ManifestMetadataReader {
   }
 
   private static @NotNull String readStringNotNull(
-      final @NotNull Bundle metadata,
+      final @NotNull Object metadata,
       final @NotNull ILogger logger,
       final @NotNull String key,
       final @NotNull String defaultValue) {
-    final String value = metadata.getString(key, defaultValue);
+    final String value;
+    if (metadata instanceof Bundle) {
+      value = ((Bundle) metadata).getString(key, defaultValue);
+    } else {
+      final Object raw = ((Map<?, ?>) metadata).get(key);
+      value = raw instanceof String ? (String) raw : defaultValue;
+    }
     if (logger.isEnabled(SentryLevel.DEBUG)) {
       logger.log(SentryLevel.DEBUG, key + " read: " + value);
     }
@@ -815,8 +838,14 @@ final class ManifestMetadataReader {
   }
 
   private static @Nullable List<String> readList(
-      final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
-    final String value = metadata.getString(key);
+      final @NotNull Object metadata, final @NotNull ILogger logger, final @NotNull String key) {
+    final String value;
+    if (metadata instanceof Bundle) {
+      value = ((Bundle) metadata).getString(key);
+    } else {
+      final Object raw = ((Map<?, ?>) metadata).get(key);
+      value = raw instanceof String ? (String) raw : null;
+    }
     if (logger.isEnabled(SentryLevel.DEBUG)) {
       logger.log(SentryLevel.DEBUG, key + " read: " + value);
     }
@@ -828,11 +857,21 @@ final class ManifestMetadataReader {
   }
 
   private static double readDouble(
-      final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
-    // manifest meta-data only reads float
-    double value = ((Float) metadata.getFloat(key, -1)).doubleValue();
-    if (value == -1) {
-      value = ((Integer) metadata.getInt(key, -1)).doubleValue();
+      final @NotNull Object metadata, final @NotNull ILogger logger, final @NotNull String key) {
+    final double value;
+    if (metadata instanceof Bundle) {
+      // manifest meta-data only reads float
+      double bundleValue = ((Float) ((Bundle) metadata).getFloat(key, -1)).doubleValue();
+      if (bundleValue == -1) {
+        bundleValue = ((Integer) ((Bundle) metadata).getInt(key, -1)).doubleValue();
+      }
+      value = bundleValue;
+    } else {
+      final Object raw = ((Map<?, ?>) metadata).get(key);
+      value =
+          raw instanceof Float
+              ? ((Float) raw).doubleValue()
+              : raw instanceof Integer ? ((Integer) raw).doubleValue() : -1;
     }
     if (logger.isEnabled(SentryLevel.DEBUG)) {
       logger.log(SentryLevel.DEBUG, key + " read: " + value);
@@ -841,12 +880,18 @@ final class ManifestMetadataReader {
   }
 
   private static long readLong(
-      final @NotNull Bundle metadata,
+      final @NotNull Object metadata,
       final @NotNull ILogger logger,
       final @NotNull String key,
       final long defaultValue) {
-    // manifest meta-data only reads int if the value is not big enough
-    final long value = metadata.getInt(key, (int) defaultValue);
+    final long value;
+    if (metadata instanceof Bundle) {
+      // manifest meta-data only reads int if the value is not big enough
+      value = ((Bundle) metadata).getInt(key, (int) defaultValue);
+    } else {
+      final Object raw = ((Map<?, ?>) metadata).get(key);
+      value = raw instanceof Integer ? (Integer) raw : defaultValue;
+    }
     if (logger.isEnabled(SentryLevel.DEBUG)) {
       logger.log(SentryLevel.DEBUG, key + " read: " + value);
     }
@@ -865,7 +910,7 @@ final class ManifestMetadataReader {
 
     boolean autoInit = true;
     try {
-      final Bundle metadata = getMetadata(context, logger, null);
+      final Object metadata = getMetadata(context, logger, null);
       if (metadata != null) {
         autoInit = readBool(metadata, logger, AUTO_INIT, true);
       }
@@ -876,18 +921,28 @@ final class ManifestMetadataReader {
   }
 
   /**
-   * Returns the Bundle attached from the given Context
+   * Returns build-time metadata when available, otherwise metadata attached to the given Context.
    *
    * @param context the application context
-   * @return the Bundle attached to the PackageManager
+   * @return metadata as a Map or PackageManager Bundle
    */
-  private static @Nullable Bundle getMetadata(
+  private static @Nullable Object getMetadata(
       final @NotNull Context context,
       final @NotNull ILogger logger,
       final @Nullable BuildInfoProvider buildInfoProvider) {
+    final @Nullable Map<String, Object> injected = buildTimeMetadata;
+    if (injected != null) {
+      return injected;
+    }
     final ApplicationInfo app =
         ContextUtils.getApplicationInfo(
             context, buildInfoProvider != null ? buildInfoProvider : new BuildInfoProvider(logger));
     return app != null ? app.metaData : null;
+  }
+
+  private static boolean containsKey(final @NotNull Object metadata, final @NotNull String key) {
+    return metadata instanceof Bundle
+        ? ((Bundle) metadata).containsKey(key)
+        : ((Map<?, ?>) metadata).containsKey(key);
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.FilterString
 import io.sentry.ILogger
 import io.sentry.ProfileLifecycle
 import io.sentry.SentryLevel
 import io.sentry.SentryReplayOptions
 import io.sentry.TransactionOptions
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,6 +25,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 
 @RunWith(AndroidJUnit4::class)
 class ManifestMetadataReaderTest {
@@ -40,6 +43,52 @@ class ManifestMetadataReaderTest {
   @BeforeTest
   fun `set up`() {
     ContextUtils.resetInstance()
+  }
+
+  @AfterTest
+  fun `tear down`() {
+    ManifestMetadataReader.buildTimeMetadata = null
+  }
+
+  @Test
+  fun `applyMetadata reads typed build-time metadata without querying context`() {
+    val context = mock<Context>()
+    ManifestMetadataReader.buildTimeMetadata =
+      mapOf(
+        ManifestMetadataReader.DEBUG to true,
+        ManifestMetadataReader.DIST to "dist",
+        ManifestMetadataReader.SAMPLE_RATE to 0.5f,
+        ManifestMetadataReader.MAX_BREADCRUMBS to 42,
+      )
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    assertThat(fixture.options.isDebug).isTrue()
+    assertThat(fixture.options.dist).isEqualTo("dist")
+    assertThat(fixture.options.sampleRate).isEqualTo(0.5)
+    assertThat(fixture.options.maxBreadcrumbs).isEqualTo(42)
+    verifyNoInteractions(context)
+  }
+
+  @Test
+  fun `build-time metadata is authoritative when a key is absent`() {
+    val context = mock<Context>()
+    fixture.options.dist = "configured"
+    ManifestMetadataReader.buildTimeMetadata = emptyMap()
+
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    assertThat(fixture.options.dist).isEqualTo("configured")
+    verifyNoInteractions(context)
+  }
+
+  @Test
+  fun `isAutoInit reads build-time metadata without querying context`() {
+    val context = mock<Context>()
+    ManifestMetadataReader.buildTimeMetadata = mapOf(ManifestMetadataReader.AUTO_INIT to false)
+
+    assertThat(ManifestMetadataReader.isAutoInit(context, fixture.logger)).isFalse()
+    verifyNoInteractions(context)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

Allow the Sentry Android Gradle plugin to inject resolved manifest metadata into
`ManifestMetadataReader`. The injected map is authoritative and read directly;
older plugin versions and unresolved manifests keep using the existing
`PackageManager`/`Bundle` path.

## :bulb: Motivation and Context

Android SDK initialization currently calls `getApplicationInfo(GET_META_DATA)` and
lazily unparcels its metadata bundle on the startup path. Moving resolvable
`io.sentry.*` values to build time avoids both operations without changing manifest
option behavior.

Refs JAVA-531

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump :sentry-android-core:testReleaseUnitTest --tests '*ManifestMetadataReaderTest*'`
- Validated all 98 supported manifest keys in a real app in injected and fallback modes
- Confirmed in Perfetto that both startup `getApplicationInfo` calls disappear when injected
- Compared 24 cold starts per mode; direct-map init median improved from 32.987 ms to 30.835 ms

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

The companion Sentry Android Gradle plugin PR injects the map for compatible SDK versions:
https://github.com/getsentry/sentry-android-gradle-plugin/pull/1401
