### PR TITLE
fix(android): [Logs and Metrics Enable Flags 19] Read Timber option lazily

### DIFF
--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
   testImplementation(projects.sentrySpotlight)
   testImplementation(projects.sentryAndroidFragment)
   testImplementation(projects.sentryAndroidTimber)
+  testImplementation(libs.timber)
   testImplementation(projects.sentryAndroidReplay)
   testImplementation(projects.sentryCompose)
   testImplementation(projects.sentryAndroidNdk)
@@ -132,5 +133,4 @@ dependencies {
   testImplementation(libs.androidx.compose.foundation.layout)
   testImplementation(libs.androidx.compose.material3)
   testRuntimeOnly(libs.androidx.fragment.ktx)
-  testRuntimeOnly(libs.timber)
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -473,7 +473,7 @@ final class AndroidOptionsInitializer {
     }
 
     if (isTimberAvailable) {
-      options.addIntegration(new SentryTimberIntegration(options.isEnableTimberLogs()));
+      options.addIntegration(new SentryTimberIntegration(options::isEnableTimberLogs));
     }
     options.addIntegration(new AppComponentsBreadcrumbsIntegration(context));
     options.addIntegration(new SystemEventsBreadcrumbsIntegration(context));

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -23,6 +23,7 @@ import io.sentry.SentryEnvelope
 import io.sentry.SentryLevel
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.FATAL
+import io.sentry.SentryLogEvent
 import io.sentry.SentryOptions
 import io.sentry.SentryOptions.BeforeSendCallback
 import io.sentry.Session
@@ -84,6 +85,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadow.api.Shadow
 import org.robolectric.shadows.ShadowActivityManager
 import org.robolectric.shadows.ShadowActivityManager.ApplicationExitInfoBuilder
+import timber.log.Timber
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.N], shadows = [SentryShadowProcess::class])
@@ -236,6 +238,46 @@ class SentryAndroidTest {
     }
 
     assertNotEquals(0, AppStartMetrics.getInstance().appStartTimeSpan.durationMs)
+  }
+
+  @Test
+  fun `auto-installed Timber integration uses Logs option set in configuration callback`() {
+    val logs = mutableListOf<SentryLogEvent>()
+    fixture.initSut { options ->
+      options.isEnableTimberLogs = true
+      options.logs.beforeSend =
+        SentryOptions.Logs.BeforeSendLogCallback { log ->
+          logs.add(log)
+          log
+        }
+    }
+
+    Timber.i("message")
+
+    assertEquals(1, logs.size)
+  }
+
+  @Test
+  fun `auto-installed Timber integration uses configuration callback override of manifest option`() {
+    val metadata =
+      Bundle().apply {
+        putString(ManifestMetadataReader.DSN, "https://key@sentry.io/123")
+        putBoolean(ManifestMetadataReader.ENABLE_TIMBER_LOGS, true)
+      }
+    val mockContext = ContextUtilsTestHelper.mockMetaData(metaData = metadata)
+    val logs = mutableListOf<SentryLogEvent>()
+
+    initForTest(mockContext) { options ->
+      options.isEnableTimberLogs = false
+      options.logs.beforeSend =
+        SentryOptions.Logs.BeforeSendLogCallback { log ->
+          logs.add(log)
+          log
+        }
+    }
+    Timber.i("message")
+
+    assertTrue(logs.isEmpty())
   }
 
   @Test

--- a/sentry-android-timber/api/sentry-android-timber.api
+++ b/sentry-android-timber/api/sentry-android-timber.api
@@ -12,6 +12,7 @@ public final class io/sentry/android/timber/SentryTimberIntegration : io/sentry/
 	public fun <init> (Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;Lio/sentry/SentryLogLevel;)V
 	public synthetic fun <init> (Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;Lio/sentry/SentryLogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;Lio/sentry/SentryLogLevel;Z)V
+	public fun <init> (Lio/sentry/util/LazyEvaluator$Evaluator;)V
 	public fun <init> (Z)V
 	public fun close ()V
 	public final fun getEnableLogs ()Z

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
@@ -9,6 +9,7 @@ import io.sentry.SentryLogLevel
 import io.sentry.SentryOptions
 import io.sentry.android.timber.BuildConfig.VERSION_NAME
 import io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion
+import io.sentry.util.LazyEvaluator.Evaluator
 import java.io.Closeable
 import timber.log.Timber
 
@@ -18,11 +19,13 @@ public class SentryTimberIntegration(
   public val minBreadcrumbLevel: SentryLevel = SentryLevel.INFO,
   public val minLogsLevel: SentryLogLevel = SentryLogLevel.INFO,
 ) : Integration, Closeable {
-  public var enableLogs: Boolean = false
-    private set
+  public val enableLogs: Boolean
+    get() = enableLogsProvider.evaluate()
+
+  private var enableLogsProvider: Evaluator<Boolean> = Evaluator { false }
 
   public constructor(enableLogs: Boolean) : this() {
-    this.enableLogs = enableLogs
+    enableLogsProvider = Evaluator { enableLogs }
   }
 
   public constructor(
@@ -31,7 +34,11 @@ public class SentryTimberIntegration(
     minLogsLevel: SentryLogLevel,
     enableLogs: Boolean,
   ) : this(minEventLevel, minBreadcrumbLevel, minLogsLevel) {
-    this.enableLogs = enableLogs
+    enableLogsProvider = Evaluator { enableLogs }
+  }
+
+  public constructor(enableLogsProvider: Evaluator<Boolean>) : this() {
+    this.enableLogsProvider = enableLogsProvider
   }
 
   private lateinit var tree: SentryTimberTree
@@ -47,7 +54,14 @@ public class SentryTimberIntegration(
   override fun register(scopes: IScopes, options: SentryOptions) {
     logger = options.logger
 
-    tree = SentryTimberTree(scopes, minEventLevel, minBreadcrumbLevel, minLogsLevel, enableLogs)
+    tree =
+      SentryTimberTree(
+        scopes,
+        minEventLevel,
+        minBreadcrumbLevel,
+        minLogsLevel,
+        enableLogsProvider.evaluate(),
+      )
     Timber.plant(tree)
 
     logger.log(SentryLevel.DEBUG, "SentryTimberIntegration installed.")

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
@@ -12,6 +12,7 @@ import io.sentry.logger.ILoggerApi
 import io.sentry.logger.SentryLogParameters
 import io.sentry.protocol.SdkVersion
 import io.sentry.transport.ITransport
+import io.sentry.util.LazyEvaluator.Evaluator
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -103,6 +104,18 @@ class SentryTimberIntegrationTest {
     sut.register(fixture.scopes, fixture.options)
 
     assertTrue(sut.enableLogs)
+    Timber.i("message")
+
+    verify(fixture.logs).log(any(), any<SentryLogParameters>(), any<String>())
+  }
+
+  @Test
+  fun `Integration evaluates Logs provider when registered`() {
+    var enableLogs = false
+    val sut = SentryTimberIntegration(Evaluator { enableLogs })
+    enableLogs = true
+
+    sut.register(fixture.scopes, fixture.options)
     Timber.i("message")
 
     verify(fixture.logs).log(any(), any<SentryLogParameters>(), any<String>())


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Makes the auto-installed Timber integration resolve `timberLogsEnabled` lazily when the integration registers rather than snapshotting it while Android default integrations are constructed.

This honors the final option value after the Android configuration callback, including both programmatic opt-in and programmatic override of manifest configuration. Existing boolean constructors continue to behave as fixed values for manually installed integrations.

## :bulb: Motivation and Context

Android installs default integrations before invoking the user's options callback so users can remove or replace them. Passing the current boolean value into Timber at that earlier point caused later programmatic configuration to be ignored.

## :green_heart: How did you test it?

- `./gradlew :sentry-android-timber:testReleaseUnitTest :sentry-android-core:testReleaseUnitTest`
- `./gradlew spotlessApply apiDump`
- Added full Android initialization tests for callback `false -> true` and manifest `true -> callback false`
- Added an integration-level test proving the supplier is evaluated at registration

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

