### PR TITLE
fix(core): [Logs and Metrics Enable Flags 20] Make migration warnings visible

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -709,32 +709,40 @@ final class ManifestMetadataReader {
         if (metadata.containsKey(ENABLE_LOGS)) {
           final boolean enableLogs = readBool(metadata, logger, ENABLE_LOGS, false);
           if (enableLogs) {
-            logger.log(
-                SentryLevel.WARNING,
-                "The Android manifest option 'io.sentry.logs.enabled' is no longer supported. "
-                    + "Manual Sentry.logger() calls no longer require it, and automatic logging "
-                    + "integrations now require their own opt-ins.");
+            options
+                .getFatalLogger()
+                .log(
+                    SentryLevel.WARNING,
+                    "The Android manifest option 'io.sentry.logs.enabled' is no longer supported. "
+                        + "Manual Sentry.logger() calls no longer require it, and automatic logging "
+                        + "integrations now require their own opt-ins.");
           } else {
-            logger.log(
-                SentryLevel.WARNING,
-                "The Android manifest option 'io.sentry.logs.enabled' no longer disables manual "
-                    + "Sentry.logger() calls. Automatic logging integrations remain disabled "
-                    + "unless enabled through their own opt-ins.");
+            options
+                .getFatalLogger()
+                .log(
+                    SentryLevel.WARNING,
+                    "The Android manifest option 'io.sentry.logs.enabled' no longer disables manual "
+                        + "Sentry.logger() calls. Automatic logging integrations remain disabled "
+                        + "unless enabled through their own opt-ins.");
           }
         }
 
         if (metadata.containsKey(ENABLE_METRICS)) {
           final boolean enableMetrics = readBool(metadata, logger, ENABLE_METRICS, false);
           if (enableMetrics) {
-            logger.log(
-                SentryLevel.WARNING,
-                "The Android manifest option 'io.sentry.metrics.enabled' is no longer supported. "
-                    + "Manual Sentry.metrics() calls no longer require it.");
+            options
+                .getFatalLogger()
+                .log(
+                    SentryLevel.WARNING,
+                    "The Android manifest option 'io.sentry.metrics.enabled' is no longer supported. "
+                        + "Manual Sentry.metrics() calls no longer require it.");
           } else {
-            logger.log(
-                SentryLevel.WARNING,
-                "The Android manifest option 'io.sentry.metrics.enabled' no longer disables "
-                    + "manual Sentry.metrics() calls.");
+            options
+                .getFatalLogger()
+                .log(
+                    SentryLevel.WARNING,
+                    "The Android manifest option 'io.sentry.metrics.enabled' no longer disables "
+                        + "manual Sentry.metrics() calls.");
           }
         }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.CompositePerformanceCollector
@@ -58,6 +59,7 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
 
 @RunWith(AndroidJUnit4::class)
 class AndroidOptionsInitializerTest {
@@ -201,6 +203,26 @@ class AndroidOptionsInitializerTest {
     val innerLogger = loggerField.javaClass.declaredFields.first { it.name == "logger" }
     innerLogger.isAccessible = true
     assertTrue(innerLogger.get(loggerField) is AndroidLogger)
+  }
+
+  @Test
+  fun `legacy manifest warning is visible when debug is disabled`() {
+    ShadowLog.clear()
+
+    fixture.initSut(
+      metadata =
+        Bundle().apply {
+          putString(ManifestMetadataReader.DSN, "https://key@sentry.io/123")
+          putBoolean(ManifestMetadataReader.ENABLE_LOGS, true)
+        },
+      hasAppContext = false,
+    )
+
+    assertTrue(
+      ShadowLog.getLogsForTag("Sentry").any {
+        it.type == Log.ASSERT && it.msg.contains("'io.sentry.logs.enabled' is no longer supported")
+      }
+    )
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -32,7 +32,12 @@ import org.mockito.kotlin.verify
 class ManifestMetadataReaderTest {
   private class Fixture {
     val logger = mock<ILogger>()
-    val options = SentryAndroidOptions().apply { setLogger(this@Fixture.logger) }
+    val fatalLogger = mock<ILogger>()
+    val options =
+      SentryAndroidOptions().apply {
+        setLogger(this@Fixture.logger)
+        setFatalLogger(this@Fixture.fatalLogger)
+      }
     val buildInfoProvider = mock<BuildInfoProvider>()
 
     fun getContext(metaData: Bundle = Bundle()): Context =
@@ -1948,26 +1953,21 @@ class ManifestMetadataReaderTest {
 
   @Test
   fun `applyMetadata does not warn when legacy logs enabled metadata is absent`() {
-    fixture.options.isDebug = true
     val context = fixture.getContext()
 
     ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
-    verify(fixture.logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+    verify(fixture.fatalLogger, never()).log(eq(SentryLevel.WARNING), any<String>())
   }
 
   @Test
   fun `applyMetadata warns when legacy logs enabled metadata is true`() {
-    val bundle =
-      bundleOf(
-        ManifestMetadataReader.DEBUG to true,
-        ManifestMetadataReader.ENABLE_LOGS to true,
-      )
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_LOGS to true)
     val context = fixture.getContext(metaData = bundle)
 
     ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
-    verify(fixture.logger)
+    verify(fixture.fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The Android manifest option 'io.sentry.logs.enabled' is no longer supported. " +
@@ -1983,16 +1983,12 @@ class ManifestMetadataReaderTest {
   fun `applyMetadata warns when legacy logs enabled metadata is false`() {
     fixture.options.isEnableTimberLogs = true
     fixture.options.isEnableLogcatLogs = true
-    val bundle =
-      bundleOf(
-        ManifestMetadataReader.DEBUG to true,
-        ManifestMetadataReader.ENABLE_LOGS to false,
-      )
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_LOGS to false)
     val context = fixture.getContext(metaData = bundle)
 
     ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
-    verify(fixture.logger)
+    verify(fixture.fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The Android manifest option 'io.sentry.logs.enabled' no longer disables manual " +
@@ -2055,21 +2051,16 @@ class ManifestMetadataReaderTest {
 
   @Test
   fun `applyMetadata does not warn when legacy metrics enabled metadata is absent`() {
-    fixture.options.isDebug = true
     val context = fixture.getContext()
 
     ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
-    verify(fixture.logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+    verify(fixture.fatalLogger, never()).log(eq(SentryLevel.WARNING), any<String>())
   }
 
   @Test
   fun `applyMetadata warns when legacy metrics enabled metadata is true`() {
-    val bundle =
-      bundleOf(
-        ManifestMetadataReader.DEBUG to true,
-        ManifestMetadataReader.ENABLE_METRICS to true,
-      )
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_METRICS to true)
     val context = fixture.getContext(metaData = bundle)
     val client = createSentryClientMock()
 
@@ -2078,7 +2069,7 @@ class ManifestMetadataReaderTest {
     val scopes = createTestScopes(fixture.options).also { it.bindClient(client) }
     scopes.metrics().count("metric name")
 
-    verify(fixture.logger)
+    verify(fixture.fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The Android manifest option 'io.sentry.metrics.enabled' is no longer supported. " +
@@ -2090,11 +2081,7 @@ class ManifestMetadataReaderTest {
 
   @Test
   fun `applyMetadata warns when legacy metrics enabled metadata is false`() {
-    val bundle =
-      bundleOf(
-        ManifestMetadataReader.DEBUG to true,
-        ManifestMetadataReader.ENABLE_METRICS to false,
-      )
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_METRICS to false)
     val context = fixture.getContext(metaData = bundle)
     val client = createSentryClientMock()
 
@@ -2103,7 +2090,7 @@ class ManifestMetadataReaderTest {
     val scopes = createTestScopes(fixture.options).also { it.bindClient(client) }
     scopes.metrics().count("metric name")
 
-    verify(fixture.logger)
+    verify(fixture.fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The Android manifest option 'io.sentry.metrics.enabled' no longer disables manual " +

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
@@ -199,7 +199,7 @@ public class SentryAutoConfiguration {
             Boolean.TRUE.equals(environment.getProperty("sentry.logs.enabled", Boolean.class));
         if (enableLogs) {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.logs.enabled' property is no longer supported. Manual "
@@ -207,7 +207,7 @@ public class SentryAutoConfiguration {
                       + "integrations now require their own opt-ins.");
         } else {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
@@ -224,14 +224,14 @@ public class SentryAutoConfiguration {
             Boolean.TRUE.equals(environment.getProperty("sentry.metrics.enabled", Boolean.class));
         if (enableMetrics) {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.metrics.enabled' property is no longer supported. Manual "
                       + "Sentry.metrics() calls no longer require it.");
         } else {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.metrics.enabled' property no longer disables manual "

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -201,9 +201,8 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property emits no warning when absent`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
   }
 
@@ -211,9 +210,9 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property true emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=true")
+      .withPropertyValues("sentry.logs.enabled=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -231,9 +230,9 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property false emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=false")
+      .withPropertyValues("sentry.logs.enabled=false")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -251,9 +250,8 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property emits no warning when absent`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
   }
 
@@ -261,9 +259,9 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property true emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=true")
+      .withPropertyValues("sentry.metrics.enabled=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -279,9 +277,9 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property false emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=false")
+      .withPropertyValues("sentry.metrics.enabled=false")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -1384,10 +1382,10 @@ class SentryAutoConfigurationTest {
   }
 
   @Configuration(proxyBeanMethods = false)
-  open class LoggerConfiguration {
+  open class FatalLoggerConfiguration {
     @Bean
-    open fun loggerConfiguration(logger: ILogger) =
-      Sentry.OptionsConfiguration<SentryOptions> { it.setLogger(logger) }
+    open fun fatalLoggerConfiguration(logger: ILogger) =
+      Sentry.OptionsConfiguration<SentryOptions> { it.setFatalLogger(logger) }
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -201,7 +201,7 @@ public class SentryAutoConfiguration {
             Boolean.TRUE.equals(environment.getProperty("sentry.logs.enabled", Boolean.class));
         if (enableLogs) {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.logs.enabled' property is no longer supported. Manual "
@@ -209,7 +209,7 @@ public class SentryAutoConfiguration {
                       + "integrations now require their own opt-ins.");
         } else {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
@@ -226,14 +226,14 @@ public class SentryAutoConfiguration {
             Boolean.TRUE.equals(environment.getProperty("sentry.metrics.enabled", Boolean.class));
         if (enableMetrics) {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.metrics.enabled' property is no longer supported. Manual "
                       + "Sentry.metrics() calls no longer require it.");
         } else {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.metrics.enabled' property no longer disables manual "

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -204,9 +204,8 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property emits no warning when absent`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
   }
 
@@ -214,9 +213,9 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property true emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=true")
+      .withPropertyValues("sentry.logs.enabled=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -234,9 +233,9 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property false emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=false")
+      .withPropertyValues("sentry.logs.enabled=false")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -254,9 +253,8 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property emits no warning when absent`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
   }
 
@@ -264,9 +262,9 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property true emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=true")
+      .withPropertyValues("sentry.metrics.enabled=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -282,9 +280,9 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property false emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=false")
+      .withPropertyValues("sentry.metrics.enabled=false")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -1376,10 +1374,10 @@ class SentryAutoConfigurationTest {
   }
 
   @Configuration(proxyBeanMethods = false)
-  open class LoggerConfiguration {
+  open class FatalLoggerConfiguration {
     @Bean
-    open fun loggerConfiguration(logger: ILogger) =
-      Sentry.OptionsConfiguration<SentryOptions> { it.setLogger(logger) }
+    open fun fatalLoggerConfiguration(logger: ILogger) =
+      Sentry.OptionsConfiguration<SentryOptions> { it.setFatalLogger(logger) }
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -196,7 +196,7 @@ public class SentryAutoConfiguration {
             Boolean.TRUE.equals(environment.getProperty("sentry.logs.enabled", Boolean.class));
         if (enableLogs) {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.logs.enabled' property is no longer supported. Manual "
@@ -204,7 +204,7 @@ public class SentryAutoConfiguration {
                       + "integrations now require their own opt-ins.");
         } else {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.logs.enabled' property no longer disables manual Sentry.logger() "
@@ -221,14 +221,14 @@ public class SentryAutoConfiguration {
             Boolean.TRUE.equals(environment.getProperty("sentry.metrics.enabled", Boolean.class));
         if (enableMetrics) {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.metrics.enabled' property is no longer supported. Manual "
                       + "Sentry.metrics() calls no longer require it.");
         } else {
           options
-              .getLogger()
+              .getFatalLogger()
               .log(
                   SentryLevel.WARNING,
                   "The 'sentry.metrics.enabled' property no longer disables manual "

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -202,9 +202,8 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property emits no warning when absent`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
   }
 
@@ -212,9 +211,9 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property true emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=true")
+      .withPropertyValues("sentry.logs.enabled=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -232,9 +231,9 @@ class SentryAutoConfigurationTest {
   fun `legacy logs property false emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.logs.enabled=false")
+      .withPropertyValues("sentry.logs.enabled=false")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -252,9 +251,8 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property emits no warning when absent`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run { verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>()) }
   }
 
@@ -262,9 +260,9 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property true emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=true")
+      .withPropertyValues("sentry.metrics.enabled=true")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -280,9 +278,9 @@ class SentryAutoConfigurationTest {
   fun `legacy metrics property false emits migration warning`() {
     val logger = mock<ILogger>()
     dsnEnabledRunner
-      .withPropertyValues("sentry.debug=true", "sentry.metrics.enabled=false")
+      .withPropertyValues("sentry.metrics.enabled=false")
       .withBean(ILogger::class.java, { logger })
-      .withUserConfiguration(LoggerConfiguration::class.java)
+      .withUserConfiguration(FatalLoggerConfiguration::class.java)
       .run {
         verify(logger)
           .log(
@@ -1309,10 +1307,10 @@ class SentryAutoConfigurationTest {
   }
 
   @Configuration(proxyBeanMethods = false)
-  open class LoggerConfiguration {
+  open class FatalLoggerConfiguration {
     @Bean
-    open fun loggerConfiguration(logger: ILogger) =
-      Sentry.OptionsConfiguration<SentryOptions> { it.setLogger(logger) }
+    open fun fatalLoggerConfiguration(logger: ILogger) =
+      Sentry.OptionsConfiguration<SentryOptions> { it.setFatalLogger(logger) }
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -306,6 +306,7 @@ public final class Sentry {
                 + options.getClass().getName());
       }
 
+      initFatalLogger(options);
       if (!preInitConfigurations(options)) {
         return;
       }
@@ -317,7 +318,6 @@ public final class Sentry {
           .getLogger()
           .log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubModeToUse));
       Sentry.globalHubMode = globalHubModeToUse;
-      initFatalLogger(options);
       final boolean shouldInit =
           InitUtil.shouldInit(globalScope.getOptions(), options, isEnabled());
       if (shouldInit) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3735,13 +3735,13 @@ public class SentryOptions {
 
     if (options.isEnableLogs() != null) {
       if (options.isEnableLogs()) {
-        logger.log(
+        fatalLogger.log(
             SentryLevel.WARNING,
             "The 'logs.enabled' option is no longer supported. Manual Sentry.logger() calls no "
                 + "longer require it, and automatic logging integrations now require their own "
                 + "opt-ins.");
       } else {
-        logger.log(
+        fatalLogger.log(
             SentryLevel.WARNING,
             "The 'logs.enabled' option no longer disables manual Sentry.logger() calls. Automatic "
                 + "logging integrations remain disabled unless enabled through their own opt-ins.");
@@ -3750,12 +3750,12 @@ public class SentryOptions {
 
     if (options.isEnableMetrics() != null) {
       if (options.isEnableMetrics()) {
-        logger.log(
+        fatalLogger.log(
             SentryLevel.WARNING,
             "The 'metrics.enabled' option is no longer supported. Manual Sentry.metrics() calls no "
                 + "longer require it.");
       } else {
-        logger.log(
+        fatalLogger.log(
             SentryLevel.WARNING,
             "The 'metrics.enabled' option no longer disables manual Sentry.metrics() calls.");
       }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -501,30 +501,22 @@ class SentryOptionsTest {
 
   @Test
   fun `merging options does not warn when legacy logs configuration is absent`() {
-    val logger = mock<ILogger>()
-    val options =
-      SentryOptions().also {
-        it.isDebug = true
-        it.setLogger(logger)
-      }
+    val fatalLogger = mock<ILogger>()
+    val options = SentryOptions().also { it.setFatalLogger(fatalLogger) }
 
     options.merge(ExternalOptions())
 
-    verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+    verify(fatalLogger, never()).log(eq(SentryLevel.WARNING), any<String>())
   }
 
   @Test
-  fun `merging options warns when legacy logs configuration is true`() {
-    val logger = mock<ILogger>()
-    val options =
-      SentryOptions().also {
-        it.isDebug = true
-        it.setLogger(logger)
-      }
+  fun `merging options warns through fatal logger when legacy logs configuration is true`() {
+    val fatalLogger = mock<ILogger>()
+    val options = SentryOptions().also { it.setFatalLogger(fatalLogger) }
 
     options.merge(ExternalOptions().apply { isEnableLogs = true })
 
-    verify(logger)
+    verify(fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The 'logs.enabled' option is no longer supported. Manual Sentry.logger() calls no " +
@@ -535,17 +527,13 @@ class SentryOptionsTest {
   }
 
   @Test
-  fun `merging options warns when legacy logs configuration is false`() {
-    val logger = mock<ILogger>()
-    val options =
-      SentryOptions().also {
-        it.isDebug = true
-        it.setLogger(logger)
-      }
+  fun `merging options warns through fatal logger when legacy logs configuration is false`() {
+    val fatalLogger = mock<ILogger>()
+    val options = SentryOptions().also { it.setFatalLogger(fatalLogger) }
 
     options.merge(ExternalOptions().apply { isEnableLogs = false })
 
-    verify(logger)
+    verify(fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The 'logs.enabled' option no longer disables manual Sentry.logger() calls. Automatic " +
@@ -567,30 +555,22 @@ class SentryOptionsTest {
 
   @Test
   fun `merging options does not warn when legacy metrics configuration is absent`() {
-    val logger = mock<ILogger>()
-    val options =
-      SentryOptions().also {
-        it.isDebug = true
-        it.setLogger(logger)
-      }
+    val fatalLogger = mock<ILogger>()
+    val options = SentryOptions().also { it.setFatalLogger(fatalLogger) }
 
     options.merge(ExternalOptions())
 
-    verify(logger, never()).log(eq(SentryLevel.WARNING), any<String>())
+    verify(fatalLogger, never()).log(eq(SentryLevel.WARNING), any<String>())
   }
 
   @Test
-  fun `merging options warns when legacy metrics configuration is true`() {
-    val logger = mock<ILogger>()
-    val options =
-      SentryOptions().also {
-        it.isDebug = true
-        it.setLogger(logger)
-      }
+  fun `merging options warns through fatal logger when legacy metrics configuration is true`() {
+    val fatalLogger = mock<ILogger>()
+    val options = SentryOptions().also { it.setFatalLogger(fatalLogger) }
 
     options.merge(ExternalOptions().apply { isEnableMetrics = true })
 
-    verify(logger)
+    verify(fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The 'metrics.enabled' option is no longer supported. Manual Sentry.metrics() calls no " +
@@ -601,17 +581,13 @@ class SentryOptionsTest {
   }
 
   @Test
-  fun `merging options warns when legacy metrics configuration is false`() {
-    val logger = mock<ILogger>()
-    val options =
-      SentryOptions().also {
-        it.isDebug = true
-        it.setLogger(logger)
-      }
+  fun `merging options warns through fatal logger when legacy metrics configuration is false`() {
+    val fatalLogger = mock<ILogger>()
+    val options = SentryOptions().also { it.setFatalLogger(fatalLogger) }
 
     options.merge(ExternalOptions().apply { isEnableMetrics = false })
 
-    verify(logger)
+    verify(fatalLogger)
       .log(
         SentryLevel.WARNING,
         "The 'metrics.enabled' option no longer disables manual Sentry.metrics() calls.",

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -24,9 +24,11 @@ import io.sentry.test.injectForField
 import io.sentry.util.PlatformTestManipulator
 import io.sentry.util.thread.IThreadChecker
 import io.sentry.util.thread.ThreadChecker
+import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.File
 import java.io.FileReader
+import java.io.PrintStream
 import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent.CompletableFuture
@@ -299,8 +301,36 @@ class SentryTest {
       initForTest { it.isEnableExternalConfiguration = true }
       assertTrue(ScopesAdapter.getInstance().isEnabled)
     } finally {
+      System.clearProperty("sentry.properties.file")
       temporaryFolder.delete()
     }
+  }
+
+  @Test
+  fun `external legacy configuration warning is visible when debug is disabled`() {
+    val file = tmpDir.newFile("sentry.properties")
+    file.writeText("dsn=$dsn\nlogs.enabled=true")
+    System.setProperty("sentry.properties.file", file.absolutePath)
+    val originalOut = System.out
+    val output = ByteArrayOutputStream()
+    System.setOut(PrintStream(output))
+
+    try {
+      initForTest { it.isEnableExternalConfiguration = true }
+    } finally {
+      System.setOut(originalOut)
+      System.clearProperty("sentry.properties.file")
+    }
+
+    assertTrue(
+      output
+        .toString()
+        .contains(
+          "WARNING: The 'logs.enabled' option is no longer supported. Manual Sentry.logger() " +
+            "calls no longer require it, and automatic logging integrations now require their " +
+            "own opt-ins."
+        )
+    )
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Logs and Metrics Enable Flags)

- #5939
- #5940
- #5941
- #5942
- #5943
- #5945
- #5946
- #5947
- #5949
- #5950
- #5951
- #5952
- #5953
- #5954
- #5955
- #5956
- #5957
- #5960
- #5961
- #5964
- #5966
- #5970

---

## :scroll: Description

Routes obsolete Logs and Metrics enable-flag migration warnings through the always-visible fatal logger across core external configuration, Android manifest metadata, and all three Spring Boot variants.

Core now initializes its fatal logger before external configuration is merged. Android continues using `AndroidFatalLogger`, whose output is emitted at `Log.ASSERT`. Spring emits its warnings after `Sentry.init`, when the fatal logger is initialized.

## :bulb: Motivation and Context

The migration warnings previously used the diagnostic logger. During external configuration merge that logger was still a no-op, and in Android or Spring normal startup it remained hidden unless SDK debug logging or a custom diagnostic logger was enabled.

These warnings are the migration path for removed aggregate options, so explicit obsolete configuration should be visible without asking users to enable debug logging.

## :green_heart: How did you test it?

- `./gradlew :sentry:test :sentry-android-core:testReleaseUnitTest :sentry-spring-boot:test :sentry-spring-boot-jakarta:test :sentry-spring-boot-4:test`
- `./gradlew spotlessApply apiDump`
- Verified JVM external configuration writes through `SystemOutLogger` with debug disabled
- Verified Android manifest warnings appear at `Log.ASSERT` with debug disabled
- Verified Spring warnings use a configured fatal logger without enabling debug logging

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

