### PR TITLE
feat(android): [Unhandled Sessions 4] Add session update API for unsampled hybrid errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Internal
 
 - Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
+- Add `InternalSentrySdk.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can still update the session when an error is dropped by sampling or rate limiting
 
 ## 8.54.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Internal
 
 - Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
-- Add `InternalSentrySdk.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can still update the session when an error is dropped by sampling or rate limiting
+- Add `InternalSentrySdk.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can still update the session when an error is dropped by sampling or rate limiting ([#5990](https://github.com/getsentry/sentry-java/pull/5990))
 
 ## 8.54.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Internal
 
 - Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed` ([#5921](https://github.com/getsentry/sentry-java/pull/5921))
-- Add `InternalSentrySdk.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can still update the session when an error is dropped by sampling or rate limiting ([#5990](https://github.com/getsentry/sentry-java/pull/5990))
+- Add `InternalSentrySdk.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can still update the session when an error is dropped by sampling ([#5990](https://github.com/getsentry/sentry-java/pull/5990))
 
 ## 8.54.0
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -323,6 +323,7 @@ public final class io/sentry/android/core/InternalSentrySdk {
 	public static fun getCurrentScope ()Lio/sentry/IScope;
 	public static fun serializeScope (Landroid/content/Context;Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/IScope;)Ljava/util/Map;
 	public static fun setTrace (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;)V
+	public static fun updateSessionForDroppedEventNonTerminating (Z)V
 }
 
 public final class io/sentry/android/core/LoadClass : io/sentry/util/LoadClass {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -266,7 +266,7 @@ public final class InternalSentrySdk {
 
   /**
    * Session side effects of {@link #captureEnvelopeNonTerminating(byte[])} without sending the
-   * event. Hybrid SDKs should call this when an error is dropped by sample rate or rate limiting.
+   * event. Hybrid SDKs should call this when an error is dropped by sampling.
    *
    * <p>Do not call this for events dropped by {@code beforeSend} or ignored exception types.
    *

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -270,6 +270,10 @@ public final class InternalSentrySdk {
    *
    * <p>Do not call this for events dropped by {@code beforeSend} or ignored exception types.
    *
+   * <p>Persisting the session is a blocking disk write on the calling thread, so call this off the
+   * main thread as the hybrid SDKs do. It is synchronous on purpose: a deferred write would not be
+   * on disk yet if the process dies right after this returns.
+   *
    * @param crashed {@code true} if the dropped error was unhandled ({@code
    *     mechanism.handled=false})
    */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -265,6 +265,19 @@ public final class InternalSentrySdk {
   }
 
   /**
+   * Session side effects of {@link #captureEnvelopeNonTerminating(byte[])} without sending the
+   * event. Hybrid SDKs should call this when an error is dropped by sample rate or rate limiting.
+   *
+   * <p>Do not call this for events dropped by {@code beforeSend} or ignored exception types.
+   *
+   * @param crashed {@code true} if the dropped error was unhandled ({@code
+   *     mechanism.handled=false})
+   */
+  public static void updateSessionForDroppedEventNonTerminating(final boolean crashed) {
+    updateSessionNonTerminating(crashed);
+  }
+
+  /**
    * Flags the current session for a non-terminating hybrid error and persists it before returning,
    * so the marker survives an immediate process death.
    *

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -613,6 +613,86 @@ class InternalSentrySdkTest {
   }
 
   @Test
+  fun `updateSessionForDroppedEventNonTerminating flags an unhandled error without sending an envelope`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    val originalSid = AtomicReference<String>()
+    Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }
+    fixture.capturedEnvelopes.clear()
+
+    InternalSentrySdk.updateSessionForDroppedEventNonTerminating(true)
+
+    assertThat(fixture.capturedEnvelopes).isEmpty()
+
+    val scopeSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> scopeSession.set(scope.session) }
+    assertThat(scopeSession.get().status).isEqualTo(Session.State.Ok)
+    assertThat(scopeSession.get().hasNonTerminatingUnhandledError()).isTrue()
+    assertThat(scopeSession.get().errorCount()).isEqualTo(1)
+    assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
+
+    val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val persistedSession =
+      fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
+    assertThat(persistedSession.status).isEqualTo(Session.State.Ok)
+    assertThat(persistedSession.hasNonTerminatingUnhandledError()).isTrue()
+    assertThat(persistedSession.errorCount()).isEqualTo(1)
+    assertThat(persistedSession.sessionId).isEqualTo(originalSid.get())
+  }
+
+  @Test
+  fun `updateSessionForDroppedEventNonTerminating increments errors for a handled error without sending an envelope`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    val originalSid = AtomicReference<String>()
+    Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }
+    fixture.capturedEnvelopes.clear()
+
+    InternalSentrySdk.updateSessionForDroppedEventNonTerminating(false)
+
+    assertThat(fixture.capturedEnvelopes).isEmpty()
+
+    val scopeSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> scopeSession.set(scope.session) }
+    assertThat(scopeSession.get().status).isEqualTo(Session.State.Ok)
+    assertThat(scopeSession.get().hasNonTerminatingUnhandledError()).isFalse()
+    assertThat(scopeSession.get().errorCount()).isEqualTo(1)
+    assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
+
+    val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val persistedSession =
+      fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
+    assertThat(persistedSession.status).isEqualTo(Session.State.Ok)
+    assertThat(persistedSession.hasNonTerminatingUnhandledError()).isFalse()
+    assertThat(persistedSession.errorCount()).isEqualTo(1)
+  }
+
+  @Test
+  fun `updateSessionForDroppedEventNonTerminating then endSession finalizes the session as unhandled`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    InternalSentrySdk.updateSessionForDroppedEventNonTerminating(true)
+    fixture.capturedEnvelopes.clear()
+
+    Sentry.endSession()
+
+    val sessionItems =
+      fixture.capturedEnvelopes
+        .flatMap { it.items.toList() }
+        .filter { it.header.type == SentryItemType.Session }
+    assertThat(sessionItems).hasSize(1)
+    val endedSession =
+      fixture.options.serializer.deserialize(
+        InputStreamReader(ByteArrayInputStream(sessionItems[0].data)),
+        Session::class.java,
+      )!!
+    assertThat(endedSession.status).isEqualTo(Session.State.Unhandled)
+  }
+
+  @Test
   fun `getAppStartMeasurement returns correct serialized data from the app start instance`() {
     Fixture().mockFinishedAppStart()
 


### PR DESCRIPTION
## PR Stack (Unhandled Sessions)

- #5919
- #5920
- #5921
- #5990

---

## :scroll: Description

Adds `InternalSentrySdk.updateSessionForDroppedEventNonTerminating(boolean crashed)` so hybrid SDKs can apply the same session side effects as `captureEnvelopeNonTerminating` when an error is dropped by sampling.

It delegates to the private `updateSessionNonTerminating` helper extracted in #5921.

- `crashed=true` records a non-terminating unhandled error (same session id, stay `Ok`, persist)
- `crashed=false` increments the error count without the unhandled flag
- no envelope is sent
- `endSession` still finalizes as `unhandled`

## :bulb: Motivation and Context

Hybrid SDKs sample in Dart/JS before calling into Java. Unsampled errors never reach `captureEnvelopeNonTerminating`, so the session is not updated. Native `SentryClient` updates the session before sampling; this API closes that gap for the non-terminating hybrid path.

Hybrid's should not call this for events dropped by `beforeSend` or ignored exception types.

## :green_heart: How did you test it?

New `InternalSentrySdkTest` coverage: an unhandled dropped error flags and persists the session without sending an envelope; a handled dropped error increments `errors` only; `endSession` afterwards finalizes as `unhandled`.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Update the Flutter Android bridge to call this when an error is dropped by sampling, instead of skipping the native session update.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
