### PR TITLE
fix(core): Snapshot feature flags before merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Prevent crashes when feature flags are merged during concurrent scope updates ([#5994](https://github.com/getsentry/sentry-java/pull/5994))
 - Prevent duplicated breadcrumbs on tombstone-merged native crash events ([#5888](https://github.com/getsentry/sentry-java/pull/5888))
 - Prevent a class of Session Replay deadlocks by confining lifecycle state changes to Android's main thread ([#5965](https://github.com/getsentry/sentry-java/pull/5965))
 

--- a/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
@@ -135,7 +135,9 @@ public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
       final @Nullable FeatureFlagBuffer isolationBuffer,
       final @Nullable FeatureFlagBuffer currentBuffer) {
 
-    // Capture snapshots to avoid inconsistencies from concurrent modifications
+    // Capture structurally stable snapshots before indexed traversal. Passing a
+    // CopyOnWriteArrayList directly allows its collection constructor to reuse the immutable
+    // backing array instead of copying the elements on runtimes that support this optimization.
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> globalFlags =
         globalBuffer == null ? null : new CopyOnWriteArrayList<>(globalBuffer.flags);
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> isolationFlags =

--- a/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
@@ -44,7 +44,14 @@ public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
 
   private FeatureFlagBuffer(@NotNull FeatureFlagBuffer other) {
     this.maxSize = other.maxSize;
-    this.flags = new CopyOnWriteArrayList<>(other.flags);
+    this.flags = other.snapshot();
+  }
+
+  @ApiStatus.Internal
+  private @NotNull CopyOnWriteArrayList<FeatureFlagEntry> snapshot() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      return new CopyOnWriteArrayList<>(flags);
+    }
   }
 
   @Override
@@ -139,11 +146,11 @@ public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
     // CopyOnWriteArrayList directly allows its collection constructor to reuse the immutable
     // backing array instead of copying the elements on runtimes that support this optimization.
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> globalFlags =
-        globalBuffer == null ? null : new CopyOnWriteArrayList<>(globalBuffer.flags);
+        globalBuffer == null ? null : globalBuffer.snapshot();
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> isolationFlags =
-        isolationBuffer == null ? null : new CopyOnWriteArrayList<>(isolationBuffer.flags);
+        isolationBuffer == null ? null : isolationBuffer.snapshot();
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> currentFlags =
-        currentBuffer == null ? null : new CopyOnWriteArrayList<>(currentBuffer.flags);
+        currentBuffer == null ? null : currentBuffer.snapshot();
 
     final int globalSize = globalFlags == null ? 0 : globalFlags.size();
     final int isolationSize = isolationFlags == null ? 0 : isolationFlags.size();

--- a/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
@@ -8,6 +8,7 @@ import io.sentry.protocol.FeatureFlags;
 import io.sentry.util.AutoClosableReentrantLock;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.jetbrains.annotations.ApiStatus;
@@ -85,9 +86,16 @@ public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
 
   @Override
   public @Nullable FeatureFlags getFeatureFlags() {
-    List<FeatureFlag> featureFlags = new ArrayList<>();
-    for (FeatureFlagEntry entry : flags) {
-      featureFlags.add(entry.toFeatureFlag());
+    final int size;
+    final @NotNull Iterator<FeatureFlagEntry> snapshot;
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      size = flags.size();
+      snapshot = flags.iterator();
+    }
+
+    final @NotNull List<FeatureFlag> featureFlags = new ArrayList<>(size);
+    while (snapshot.hasNext()) {
+      featureFlags.add(snapshot.next().toFeatureFlag());
     }
     return new FeatureFlags(featureFlags);
   }

--- a/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
@@ -135,13 +135,13 @@ public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
       final @Nullable FeatureFlagBuffer isolationBuffer,
       final @Nullable FeatureFlagBuffer currentBuffer) {
 
-    // Capture references to avoid inconsistencies from concurrent modifications
+    // Capture snapshots to avoid inconsistencies from concurrent modifications
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> globalFlags =
-        globalBuffer == null ? null : globalBuffer.flags;
+        globalBuffer == null ? null : new CopyOnWriteArrayList<>(globalBuffer.flags);
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> isolationFlags =
-        isolationBuffer == null ? null : isolationBuffer.flags;
+        isolationBuffer == null ? null : new CopyOnWriteArrayList<>(isolationBuffer.flags);
     final @Nullable CopyOnWriteArrayList<FeatureFlagEntry> currentFlags =
-        currentBuffer == null ? null : currentBuffer.flags;
+        currentBuffer == null ? null : new CopyOnWriteArrayList<>(currentBuffer.flags);
 
     final int globalSize = globalFlags == null ? 0 : globalFlags.size();
     final int isolationSize = isolationFlags == null ? 0 : isolationFlags.size();

--- a/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
 
-  private volatile @NotNull CopyOnWriteArrayList<FeatureFlagEntry> flags;
+  private final @NotNull CopyOnWriteArrayList<FeatureFlagEntry> flags;
   private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
   private int maxSize;
 

--- a/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
+++ b/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
@@ -397,4 +397,47 @@ class FeatureFlagBufferTest {
 
     assertThat(writerFailure.get()).isNull()
   }
+
+  @Test
+  fun `merging does not observe a partially updated buffer`() {
+    val options = SentryOptions().also { it.maxFeatureFlags = 100 }
+    val globalBuffer = FeatureFlagBuffer.create(options)
+    val isolationBuffer = FeatureFlagBuffer.create(options)
+    val currentBuffer = FeatureFlagBuffer.create(options)
+    val expectedFlags = (0 until options.maxFeatureFlags).map { "flag$it" }
+
+    expectedFlags.forEach { globalBuffer.add(it, true) }
+
+    val stop = AtomicBoolean(false)
+    val writerFailure = AtomicReference<Throwable?>(null)
+    val writerStarted = CountDownLatch(1)
+    val writer = Thread {
+      try {
+        var i = 0
+        while (!stop.get()) {
+          globalBuffer.add(expectedFlags[i++ % expectedFlags.size], true)
+          writerStarted.countDown()
+        }
+      } catch (e: Exception) {
+        writerFailure.set(e)
+      }
+    }
+
+    writer.start()
+    try {
+      assertThat(writerStarted.await(5, TimeUnit.SECONDS)).isTrue()
+
+      repeat(1_000) {
+        val featureFlags =
+          FeatureFlagBuffer.merged(options, globalBuffer, isolationBuffer, currentBuffer)
+            .featureFlags
+        assertThat(featureFlags?.values?.map { it?.flag }).containsExactlyElementsIn(expectedFlags)
+      }
+    } finally {
+      stop.set(true)
+      writer.join()
+    }
+
+    assertThat(writerFailure.get()).isNull()
+  }
 }

--- a/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
+++ b/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
@@ -399,6 +399,50 @@ class FeatureFlagBufferTest {
   }
 
   @Test
+  fun `getting feature flags does not observe a partially updated buffer`() {
+    val options = SentryOptions().also { it.maxFeatureFlags = 100 }
+    val buffer = FeatureFlagBuffer.create(options)
+    val expectedFlags = (0 until options.maxFeatureFlags).map { "flag$it" }
+
+    expectedFlags.forEach { buffer.add(it, true) }
+
+    val stop = AtomicBoolean(false)
+    val writerFailure = AtomicReference<Throwable?>(null)
+    val writerOperations = AtomicInteger()
+    val writerStarted = CountDownLatch(1)
+    val writer = Thread {
+      try {
+        var i = 0
+        while (!stop.get()) {
+          buffer.add(expectedFlags[i++ % expectedFlags.size], true)
+          writerOperations.incrementAndGet()
+          writerStarted.countDown()
+        }
+      } catch (e: Exception) {
+        writerFailure.set(e)
+      }
+    }
+
+    writer.start()
+    try {
+      assertThat(writerStarted.await(5, TimeUnit.SECONDS)).isTrue()
+      val writerOperationsBeforeReading = writerOperations.get()
+
+      repeat(1_000) {
+        assertThat(buffer.featureFlags?.values?.map { it?.flag })
+          .containsExactlyElementsIn(expectedFlags)
+      }
+
+      assertThat(writerOperations.get()).isGreaterThan(writerOperationsBeforeReading)
+    } finally {
+      stop.set(true)
+      writer.join()
+    }
+
+    assertThat(writerFailure.get()).isNull()
+  }
+
+  @Test
   fun `merging does not observe a partially updated buffer`() {
     val options = SentryOptions().also { it.maxFeatureFlags = 100 }
     val globalBuffer = FeatureFlagBuffer.create(options)
@@ -410,12 +454,14 @@ class FeatureFlagBufferTest {
 
     val stop = AtomicBoolean(false)
     val writerFailure = AtomicReference<Throwable?>(null)
+    val writerOperations = AtomicInteger()
     val writerStarted = CountDownLatch(1)
     val writer = Thread {
       try {
         var i = 0
         while (!stop.get()) {
           globalBuffer.add(expectedFlags[i++ % expectedFlags.size], true)
+          writerOperations.incrementAndGet()
           writerStarted.countDown()
         }
       } catch (e: Exception) {
@@ -426,6 +472,7 @@ class FeatureFlagBufferTest {
     writer.start()
     try {
       assertThat(writerStarted.await(5, TimeUnit.SECONDS)).isTrue()
+      val writerOperationsBeforeMerging = writerOperations.get()
 
       repeat(1_000) {
         val featureFlags =
@@ -433,6 +480,8 @@ class FeatureFlagBufferTest {
             .featureFlags
         assertThat(featureFlags?.values?.map { it?.flag }).containsExactlyElementsIn(expectedFlags)
       }
+
+      assertThat(writerOperations.get()).isGreaterThan(writerOperationsBeforeMerging)
     } finally {
       stop.set(true)
       writer.join()

--- a/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
+++ b/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
@@ -1,6 +1,12 @@
 package io.sentry.featureflags
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.SentryOptions
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -346,5 +352,49 @@ class FeatureFlagBufferTest {
 
     val featureFlags = buffer.featureFlags
     assertNotNull(featureFlags)
+  }
+
+  @Test
+  fun `merging is safe while another thread adds flags`() {
+    val options = SentryOptions().also { it.maxFeatureFlags = 100 }
+    val globalBuffer = FeatureFlagBuffer.create(options)
+    val isolationBuffer = FeatureFlagBuffer.create(options)
+    val currentBuffer = FeatureFlagBuffer.create(options)
+
+    repeat(options.maxFeatureFlags) { globalBuffer.add("initial$it", true) }
+
+    val stop = AtomicBoolean(false)
+    val writerFailure = AtomicReference<Throwable?>(null)
+    val writerOperations = AtomicInteger()
+    val writerStarted = CountDownLatch(1)
+    val writer = Thread {
+      try {
+        var i = 0
+        while (!stop.get()) {
+          globalBuffer.add("flag${i++ % 150}", true)
+          writerOperations.incrementAndGet()
+          writerStarted.countDown()
+        }
+      } catch (e: Exception) {
+        writerFailure.set(e)
+      }
+    }
+
+    writer.start()
+    try {
+      assertThat(writerStarted.await(5, TimeUnit.SECONDS)).isTrue()
+      val writerOperationsBeforeMerging = writerOperations.get()
+
+      repeat(10_000) {
+        FeatureFlagBuffer.merged(options, globalBuffer, isolationBuffer, currentBuffer).featureFlags
+      }
+
+      assertThat(writerOperations.get()).isGreaterThan(writerOperationsBeforeMerging)
+    } finally {
+      stop.set(true)
+      writer.join()
+    }
+
+    assertThat(writerFailure.get()).isNull()
   }
 }

--- a/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
+++ b/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
@@ -385,7 +385,7 @@ class FeatureFlagBufferTest {
       assertThat(writerStarted.await(5, TimeUnit.SECONDS)).isTrue()
       val writerOperationsBeforeMerging = writerOperations.get()
 
-      repeat(10_000) {
+      repeat(1_000) {
         FeatureFlagBuffer.merged(options, globalBuffer, isolationBuffer, currentBuffer).featureFlags
       }
 


### PR DESCRIPTION
## :scroll: Description

Snapshot each scope's `FeatureFlagBuffer` before merging feature flags into an event. This keeps the existing mutable `CopyOnWriteArrayList` write path while ensuring that the merge traverses structurally stable lists.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-java/issues/5988

`FeatureFlagBuffer` keeps a mutable `CopyOnWriteArrayList` wrapper. Writers update that wrapper through separate remove, add, and eviction operations, while `merged()` previously captured only the wrapper reference and then used separate `size()` and indexed `get()` calls.

A `CopyOnWriteArrayList` makes each individual operation thread-safe, but retaining its wrapper does not retain one backing-array snapshot. A concurrent writer can therefore produce this interleaving:

1. A writer adds a flag and the list reaches 101 entries.
2. The merging thread reads a size of 101.
3. The writer evicts the oldest flag and the list returns to 100 entries.
4. The merging thread calls `get(100)` and throws `ArrayIndexOutOfBoundsException` during event capture.

The same structural race is possible when another thread clears a buffer. Constructing an independent COW wrapper for each input buffer gives the merge a stable size and stable indexed reads without acquiring the global, isolation, and current buffer locks together. This avoids lock-ordering risk and preserves the benchmark-favored write path.

Each per-buffer snapshot is taken under that buffer's writer lock, so it represents a completed add or clear operation. Global, isolation, and current snapshots are captured sequentially rather than as one atomic cross-buffer transaction, preserving best-effort cross-scope semantics.

Refs JAVA-704

## :green_heart: How did you test it?

- Added concurrent regression tests that pre-fill the buffer, verify writer progress during add/evict churn, and confirm merges and direct reads never observe partial updates.
- Confirmed the regression test fails on `main` with `ArrayIndexOutOfBoundsException` and passes with this change.
- Ran `./gradlew ':sentry:test' --tests='*FeatureFlagBufferTest*' --info` (26 tests, 0 failures).
- Ran `./gradlew spotlessApply apiDump` successfully.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.

