### PR TITLE
DO NOT MERGE test(macrobenchmark): Exercise the A/B workflow with a known 20ms init regression

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -99,6 +99,16 @@ public final class SentryAndroid {
     // Started before acquiring the lock so it stays balanced with the endSection() in the finally
     // even if acquire() throws.
     Trace.beginSection("SentryAndroid.init");
+    // ---------------------------------------------------------------------------------------
+    // DO NOT MERGE. Deliberate 20ms regression, inside the traced section, to prove the
+    // macrobenchmark A/B harness detects a known change and attributes it to the right metric.
+    // This branch exists only to exercise that workflow and must never reach main.
+    // ---------------------------------------------------------------------------------------
+    try {
+      Thread.sleep(20);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
     try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
       Sentry.init(
           new SentryAndroidOptionsContainer(),


### PR DESCRIPTION
> ## ⛔ DO NOT MERGE
>
> Throwaway PR. It deliberately makes `SentryAndroid.init` 20 ms slower and exists only to exercise the macrobenchmark A/B workflow from #5991. Close it once the run has been inspected.

## :scroll: Description

Two things this PR is for, neither of which #5991 can do for itself:

**1. Give the workflow a base that can build a baseline.** The baseline APK is built from the PR's base commit, and it needs the `sampleAppIdSuffix` Gradle property to get its own application id. That property lands in #5991, so `main` does not have it yet — a PR against `main` fails the collision guard. This PR is therefore based on **`no/macrobenchmark-compare-to-base`**, which does have it, so the baseline builds correctly and the two APKs install side by side.

**2. Give it a known regression to find.** `Thread.sleep(20)` inside the `SentryAndroid.init` trace section.

Expected result:

| Metric | expectation |
|---|---|
| `SentryAndroid.init` | ≈ **+20 ms**, `p` near zero |
| `timeToInitialDisplay` | moves by roughly the same absolute amount, but with a much weaker `p` — whole-start noise swamps a change this size at 12 iterations per arm |

That contrast is the entire argument for measuring the trace section rather than just cold-start time, so seeing it on real hardware is the point. A synthetic run of the parser reproduced exactly this shape (`p=0.000` vs `p=0.309`); this checks it holds on an actual device.

## :bulb: Motivation and Context

Validates, on real hardware, the parts of #5991 that could only be checked against a schema or a fixture:

- the `pull_request` trigger firing and the workflow resolving its base from the merge ref
- `espresso.otherApps` uploading and installing the second APK
- `appSettings.resigningEnabled: false` being accepted by our Sauce account — if it is not, the run fails here rather than silently biasing every future comparison
- both packages being measurable, and the ABBA alternation producing 12 iterations per arm
- 24 cold starts plus 8 AOT compiles fitting inside the 60m suite timeout
- what the sticky comment actually looks like

* related: JAVA-679

## :green_heart: How did you test it?

That is what this PR is. `spotlessApply` is clean and `:sentry-android-core:compileReleaseJavaWithJavac` passes; everything else is what the workflow run will tell us.

Expect other CI checks to be unhappy — a 20 ms sleep in SDK init is not something the test suite should be relaxed about.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Read the comment this PR posts, then close it without merging.

If the numbers look right, the remaining validation for #5991 is an A/A run — any PR that touches no SDK or sample code, where Δ should come out ≈0. That one also gives the empirical noise floor, which is worth recording in the module README.

#skip-changelog
