### PR TITLE
fix(android): mark tombstone and ANR exits as reported when the event is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prevent duplicated breadcrumbs on tombstone-merged native crash events ([#5888](https://github.com/getsentry/sentry-java/pull/5888))
 - Prevent a class of Session Replay deadlocks by confining lifecycle state changes to Android's main thread ([#5965](https://github.com/getsentry/sentry-java/pull/5965))
 - Symbolicate tombstone native frames for libraries loaded directly from APKs ([#5992](https://github.com/getsentry/sentry-java/pull/5992))
+- Keep tombstone and ANR events discarded from `beforeSend` discarded, instead of reporting them again at every app start ([#6002](https://github.com/getsentry/sentry-java/pull/6002))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Keep tombstone and ANR events discarded from `beforeSend` discarded, instead of reporting them again at every app start ([#6002](https://github.com/getsentry/sentry-java/pull/6002))
+- Keep dropped tombstone and ANR events dropped, instead of reporting the same app exit again at every app start ([#6002](https://github.com/getsentry/sentry-java/pull/6002))
 
 ## 8.54.0
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -638,6 +638,7 @@ public class io/sentry/android/core/TombstoneIntegration$TombstonePolicy : io/se
 	public fun getLabel ()Ljava/lang/String;
 	public fun getLastReportedTimestamp ()Ljava/lang/Long;
 	public fun getTargetReason ()I
+	public fun markReported (J)V
 	public fun shouldReportHistorical ()Z
 }
 
@@ -749,6 +750,8 @@ public final class io/sentry/android/core/cache/AndroidEnvelopeCache : io/sentry
 	public static fun hasStartupCrashMarker (Lio/sentry/SentryOptions;)Z
 	public static fun lastReportedAnr (Lio/sentry/SentryOptions;)Ljava/lang/Long;
 	public static fun lastReportedTombstone (Lio/sentry/SentryOptions;)Ljava/lang/Long;
+	public static fun markAnrReported (Lio/sentry/SentryOptions;J)V
+	public static fun markTombstoneReported (Lio/sentry/SentryOptions;J)V
 	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 	public fun storeEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Z
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -133,6 +133,11 @@ public class AnrV2Integration implements Integration, Closeable {
     }
 
     @Override
+    public void markReported(final long timestamp) {
+      AndroidEnvelopeCache.markAnrReported(options, timestamp);
+    }
+
+    @Override
     public @Nullable ApplicationExitInfoHistoryDispatcher.Report buildReport(
         final @NotNull ApplicationExitInfo exitInfo, final boolean shouldEnrich) {
       final long anrTimestamp = exitInfo.getTimestamp();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
@@ -12,7 +12,6 @@ import io.sentry.SentryLevel;
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.cache.IEnvelopeCache;
 import io.sentry.hints.BlockingFlushHint;
-import io.sentry.hints.EventDropReason;
 import io.sentry.protocol.SentryId;
 import io.sentry.transport.ICurrentDateProvider;
 import io.sentry.util.HintUtils;
@@ -192,18 +191,22 @@ final class ApplicationExitInfoHistoryDispatcher implements Runnable {
     if (isEventDropped) {
       // A dropped event never reaches the envelope disk cache, which is where the last reported
       // marker is normally written. Without writing it here, the very same exit would be turned
-      // into an event again on the next app start, ignoring the user's decision to drop it.
-      // An empty id alone is not enough: capturing also returns one when building or handing over
-      // the envelope failed, and such an exit has to stay eligible for the next app start.
-      final @Nullable EventDropReason dropReason = HintUtils.getEventDropReason(report.getHint());
-      if (dropReason != null) {
+      // into an event again on the next app start, no matter why it was dropped. Only a technical
+      // failure to hand the event over keeps the exit eligible for another attempt.
+      if (HintUtils.isCaptureFailed(report.getHint())) {
         options
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
-                "%s event was dropped (%s), marking the exit as reported.",
-                policy.getLabel(),
-                dropReason);
+                "Capturing the %s event failed, leaving the exit for the next app start.",
+                policy.getLabel());
+      } else {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "%s event was dropped, marking the exit as reported.",
+                policy.getLabel());
         policy.markReported(exitInfo.getTimestamp());
       }
     } else {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
@@ -177,6 +177,7 @@ final class ApplicationExitInfoHistoryDispatcher implements Runnable {
     }
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.R)
   private void report(final @NotNull ApplicationExitInfo exitInfo, final boolean enrich) {
     final @Nullable Report report = policy.buildReport(exitInfo, enrich);
 
@@ -186,7 +187,12 @@ final class ApplicationExitInfoHistoryDispatcher implements Runnable {
 
     final @NotNull SentryId sentryId = scopes.captureEvent(report.getEvent(), report.getHint());
     final boolean isEventDropped = sentryId.equals(SentryId.EMPTY_ID);
-    if (!isEventDropped) {
+    if (isEventDropped) {
+      // A dropped event never reaches the envelope disk cache, which is where the last reported
+      // marker is normally written. Without writing it here, the very same exit would be turned
+      // into an event again on the next app start, ignoring the user's decision to drop it.
+      policy.markReported(exitInfo.getTimestamp());
+    } else {
       final @Nullable BlockingFlushHint flushHint = report.getFlushHint();
       if (flushHint != null && !flushHint.waitFlush()) {
         options
@@ -210,6 +216,9 @@ final class ApplicationExitInfoHistoryDispatcher implements Runnable {
 
     @Nullable
     Long getLastReportedTimestamp();
+
+    /** Records {@code timestamp} as the last reported exit, so it is not reported again. */
+    void markReported(long timestamp);
 
     @Nullable
     Report buildReport(@NotNull ApplicationExitInfo exitInfo, boolean enrich);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
@@ -12,8 +12,10 @@ import io.sentry.SentryLevel;
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.cache.IEnvelopeCache;
 import io.sentry.hints.BlockingFlushHint;
+import io.sentry.hints.EventDropReason;
 import io.sentry.protocol.SentryId;
 import io.sentry.transport.ICurrentDateProvider;
+import io.sentry.util.HintUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -191,7 +193,19 @@ final class ApplicationExitInfoHistoryDispatcher implements Runnable {
       // A dropped event never reaches the envelope disk cache, which is where the last reported
       // marker is normally written. Without writing it here, the very same exit would be turned
       // into an event again on the next app start, ignoring the user's decision to drop it.
-      policy.markReported(exitInfo.getTimestamp());
+      // An empty id alone is not enough: capturing also returns one when building or handing over
+      // the envelope failed, and such an exit has to stay eligible for the next app start.
+      final @Nullable EventDropReason dropReason = HintUtils.getEventDropReason(report.getHint());
+      if (dropReason != null) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "%s event was dropped (%s), marking the exit as reported.",
+                policy.getLabel(),
+                dropReason);
+        policy.markReported(exitInfo.getTimestamp());
+      }
     } else {
       final @Nullable BlockingFlushHint flushHint = report.getFlushHint();
       if (flushHint != null && !flushHint.waitFlush()) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -147,6 +147,11 @@ public class TombstoneIntegration implements Integration, Closeable {
       return AndroidEnvelopeCache.lastReportedTombstone(options);
     }
 
+    @Override
+    public void markReported(final long timestamp) {
+      AndroidEnvelopeCache.markTombstoneReported(options, timestamp);
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.R)
     @Override
     public @Nullable ApplicationExitInfoHistoryDispatcher.Report buildReport(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -85,7 +85,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
     }
 
     for (TimestampMarkerHandler<?> handler : TIMESTAMP_MARKER_HANDLERS) {
-      handler.handle(this, hint, options);
+      handler.handle(hint, options);
     }
 
     return didStore;
@@ -182,7 +182,8 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
     return null;
   }
 
-  private void writeLastReportedMarker(
+  private static void writeLastReportedMarker(
+      final @NotNull SentryOptions options,
       final @Nullable Long timestamp,
       @NotNull String reportFilename,
       @NotNull String markerCategory) {
@@ -215,6 +216,15 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
     return lastReportedMarker(options, LAST_TOMBSTONE_REPORT, LAST_TOMBSTONE_MARKER_LABEL);
   }
 
+  public static void markAnrReported(final @NotNull SentryOptions options, final long timestamp) {
+    writeLastReportedMarker(options, timestamp, LAST_ANR_REPORT, LAST_ANR_MARKER_LABEL);
+  }
+
+  public static void markTombstoneReported(
+      final @NotNull SentryOptions options, final long timestamp) {
+    writeLastReportedMarker(options, timestamp, LAST_TOMBSTONE_REPORT, LAST_TOMBSTONE_MARKER_LABEL);
+  }
+
   private static final class TimestampMarkerHandler<T> {
     interface TimestampExtractor<T> {
       @NotNull
@@ -237,10 +247,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
       this.timestampProvider = timestampProvider;
     }
 
-    void handle(
-        final @NotNull AndroidEnvelopeCache cache,
-        final @NotNull Hint hint,
-        final @NotNull SentryAndroidOptions options) {
+    void handle(final @NotNull Hint hint, final @NotNull SentryAndroidOptions options) {
       HintUtils.runIfHasType(
           hint,
           type,
@@ -253,7 +260,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
                     "Writing last reported %s marker with timestamp %d",
                     label,
                     timestamp);
-            cache.writeLastReportedMarker(timestamp, reportFilename, label);
+            writeLastReportedMarker(options, timestamp, reportFilename, label);
           });
     }
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitIntegrationTestBase.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitIntegrationTestBase.kt
@@ -188,6 +188,17 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
   }
 
   @Test
+  fun `when latest event was dropped, marks the exit as reported`() {
+    val integration =
+      fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp, lastEventId = SentryId.EMPTY_ID)
+    fixture.addAppExitInfo(timestamp = newTimestamp)
+
+    integration.register(fixture.scopes, fixture.options)
+
+    assertEquals(newTimestamp.toString(), fixture.lastReportedFile.readText())
+  }
+
+  @Test
   fun `historical exits are reported non-enriched`() {
     val integration = fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp)
     fixture.addAppExitInfo(timestamp = newTimestamp - 2 * 60 * 1000)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitIntegrationTestBase.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitIntegrationTestBase.kt
@@ -12,7 +12,6 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.cache.EnvelopeCache
 import io.sentry.hints.DiskFlushNotification
-import io.sentry.hints.EventDropReason
 import io.sentry.hints.SessionStartHint
 import io.sentry.protocol.SentryId
 import io.sentry.test.ImmediateExecutorService
@@ -189,14 +188,9 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
   }
 
   @Test
-  fun `when latest event was dropped by beforeSend, marks the exit as reported`() {
+  fun `when latest event was dropped, marks the exit as reported`() {
     val integration =
-      fixture.getSut(
-        tmpDir,
-        lastReportedTimestamp = oldTimestamp,
-        lastEventId = SentryId.EMPTY_ID,
-        eventDropReason = EventDropReason.BEFORE_SEND,
-      )
+      fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp, lastEventId = SentryId.EMPTY_ID)
     fixture.addAppExitInfo(timestamp = newTimestamp)
 
     integration.register(fixture.scopes, fixture.options)
@@ -207,7 +201,12 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
   @Test
   fun `when capturing the latest event failed, does not mark the exit as reported`() {
     val integration =
-      fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp, lastEventId = SentryId.EMPTY_ID)
+      fixture.getSut(
+        tmpDir,
+        lastReportedTimestamp = oldTimestamp,
+        lastEventId = SentryId.EMPTY_ID,
+        captureFailed = true,
+      )
     fixture.addAppExitInfo(timestamp = newTimestamp)
 
     integration.register(fixture.scopes, fixture.options)
@@ -431,7 +430,7 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
       sessionFlushTimeoutMillis: Long = 0L,
       lastReportedTimestamp: Long? = null,
       lastEventId: SentryId = SentryId(),
-      eventDropReason: EventDropReason? = null,
+      captureFailed: Boolean = false,
       sessionTrackingEnabled: Boolean = true,
       reportHistorical: Boolean = true,
       extraOptions: (SentryAndroidOptions) -> Unit = {},
@@ -456,7 +455,9 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
         lastReportedFile.writeText(lastReportedTimestamp.toString())
       }
       whenever(scopes.captureEvent(any(), anyOrNull<Hint>())).thenAnswer { invocation ->
-        eventDropReason?.let { HintUtils.setEventDropReason(invocation.getArgument(1), it) }
+        if (captureFailed) {
+          HintUtils.setCaptureFailed(invocation.getArgument(1))
+        }
         lastEventId
       }
       return config.createIntegration(context)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitIntegrationTestBase.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ApplicationExitIntegrationTestBase.kt
@@ -12,6 +12,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.cache.EnvelopeCache
 import io.sentry.hints.DiskFlushNotification
+import io.sentry.hints.EventDropReason
 import io.sentry.hints.SessionStartHint
 import io.sentry.protocol.SentryId
 import io.sentry.test.ImmediateExecutorService
@@ -188,14 +189,30 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
   }
 
   @Test
-  fun `when latest event was dropped, marks the exit as reported`() {
+  fun `when latest event was dropped by beforeSend, marks the exit as reported`() {
+    val integration =
+      fixture.getSut(
+        tmpDir,
+        lastReportedTimestamp = oldTimestamp,
+        lastEventId = SentryId.EMPTY_ID,
+        eventDropReason = EventDropReason.BEFORE_SEND,
+      )
+    fixture.addAppExitInfo(timestamp = newTimestamp)
+
+    integration.register(fixture.scopes, fixture.options)
+
+    assertEquals(newTimestamp.toString(), fixture.lastReportedFile.readText())
+  }
+
+  @Test
+  fun `when capturing the latest event failed, does not mark the exit as reported`() {
     val integration =
       fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp, lastEventId = SentryId.EMPTY_ID)
     fixture.addAppExitInfo(timestamp = newTimestamp)
 
     integration.register(fixture.scopes, fixture.options)
 
-    assertEquals(newTimestamp.toString(), fixture.lastReportedFile.readText())
+    assertEquals(oldTimestamp.toString(), fixture.lastReportedFile.readText())
   }
 
   @Test
@@ -414,6 +431,7 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
       sessionFlushTimeoutMillis: Long = 0L,
       lastReportedTimestamp: Long? = null,
       lastEventId: SentryId = SentryId(),
+      eventDropReason: EventDropReason? = null,
       sessionTrackingEnabled: Boolean = true,
       reportHistorical: Boolean = true,
       extraOptions: (SentryAndroidOptions) -> Unit = {},
@@ -437,7 +455,10 @@ abstract class ApplicationExitIntegrationTestBase<THint : Any> {
         lastReportedFile = File(cacheDir, config.lastReportedFileName)
         lastReportedFile.writeText(lastReportedTimestamp.toString())
       }
-      whenever(scopes.captureEvent(any(), anyOrNull<Hint>())).thenReturn(lastEventId)
+      whenever(scopes.captureEvent(any(), anyOrNull<Hint>())).thenAnswer { invocation ->
+        eventDropReason?.let { HintUtils.setEventDropReason(invocation.getArgument(1), it) }
+        lastEventId
+      }
       return config.createIntegration(context)
     }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4737,6 +4737,7 @@ public final class io/sentry/TypeCheckHint {
 	public static final field OPEN_FEIGN_REQUEST Ljava/lang/String;
 	public static final field OPEN_FEIGN_RESPONSE Ljava/lang/String;
 	public static final field REPLAY_FRAME_BITMAP Ljava/lang/String;
+	public static final field SENTRY_CAPTURE_FAILED Ljava/lang/String;
 	public static final field SENTRY_DART_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_DOTNET_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_EVENT_DROP_REASON Ljava/lang/String;
@@ -5207,10 +5208,7 @@ public abstract interface class io/sentry/hints/Enqueable {
 }
 
 public final class io/sentry/hints/EventDropReason : java/lang/Enum {
-	public static final field BEFORE_SEND Lio/sentry/hints/EventDropReason;
-	public static final field IGNORED Lio/sentry/hints/EventDropReason;
 	public static final field MULTITHREADED_DEDUPLICATION Lio/sentry/hints/EventDropReason;
-	public static final field SAMPLE_RATE Lio/sentry/hints/EventDropReason;
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/hints/EventDropReason;
 	public static fun values ()[Lio/sentry/hints/EventDropReason;
 }
@@ -7765,11 +7763,13 @@ public final class io/sentry/util/HintUtils {
 	public static fun getEventDropReason (Lio/sentry/Hint;)Lio/sentry/hints/EventDropReason;
 	public static fun getSentrySdkHint (Lio/sentry/Hint;)Ljava/lang/Object;
 	public static fun hasType (Lio/sentry/Hint;Ljava/lang/Class;)Z
+	public static fun isCaptureFailed (Lio/sentry/Hint;)Z
 	public static fun isFromHybridSdk (Lio/sentry/Hint;)Z
 	public static fun runIfDoesNotHaveType (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryNullableConsumer;)V
 	public static fun runIfHasType (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryConsumer;)V
 	public static fun runIfHasType (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryConsumer;Lio/sentry/util/HintUtils$SentryHintFallback;)V
 	public static fun runIfHasTypeLogIfNot (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/ILogger;Lio/sentry/util/HintUtils$SentryConsumer;)V
+	public static fun setCaptureFailed (Lio/sentry/Hint;)V
 	public static fun setEventDropReason (Lio/sentry/Hint;Lio/sentry/hints/EventDropReason;)V
 	public static fun setIsFromHybridSdk (Lio/sentry/Hint;Ljava/lang/String;)V
 	public static fun setTypeCheckHint (Lio/sentry/Hint;Ljava/lang/Object;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5197,7 +5197,10 @@ public abstract interface class io/sentry/hints/Enqueable {
 }
 
 public final class io/sentry/hints/EventDropReason : java/lang/Enum {
+	public static final field BEFORE_SEND Lio/sentry/hints/EventDropReason;
+	public static final field IGNORED Lio/sentry/hints/EventDropReason;
 	public static final field MULTITHREADED_DEDUPLICATION Lio/sentry/hints/EventDropReason;
+	public static final field SAMPLE_RATE Lio/sentry/hints/EventDropReason;
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/hints/EventDropReason;
 	public static fun values ()[Lio/sentry/hints/EventDropReason;
 }

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -152,8 +152,10 @@ public final class Scopes implements IScopes {
           .getLogger()
           .log(
               SentryLevel.WARNING, "Instance is disabled and this 'captureEvent' call is a no-op.");
+      HintUtils.setCaptureFailed(hint);
     } else if (event == null) {
       getOptions().getLogger().log(SentryLevel.WARNING, "captureEvent called with null parameter.");
+      HintUtils.setCaptureFailed(hint);
     } else {
       try {
         assignTraceContext(event);
@@ -166,6 +168,7 @@ public final class Scopes implements IScopes {
             .getLogger()
             .log(
                 SentryLevel.ERROR, "Error while capturing event with id: " + event.getEventId(), e);
+        HintUtils.setCaptureFailed(hint);
       }
     }
     return sentryId;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -7,6 +7,7 @@ import io.sentry.hints.ApplyScopeData;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.Cached;
 import io.sentry.hints.DiskFlushNotification;
+import io.sentry.hints.EventDropReason;
 import io.sentry.hints.TransactionEnd;
 import io.sentry.logger.ILoggerBatchProcessor;
 import io.sentry.logger.NoOpLoggerBatchProcessor;
@@ -137,6 +138,7 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
+        HintUtils.setEventDropReason(hint, EventDropReason.IGNORED);
         return SentryId.EMPTY_ID;
       }
 
@@ -150,6 +152,7 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
+        HintUtils.setEventDropReason(hint, EventDropReason.IGNORED);
         return SentryId.EMPTY_ID;
       }
     }
@@ -176,6 +179,7 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Error);
+        HintUtils.setEventDropReason(hint, EventDropReason.BEFORE_SEND);
       }
     }
 
@@ -208,6 +212,7 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.SAMPLE_RATE, DataCategory.Error);
+        HintUtils.setEventDropReason(hint, EventDropReason.SAMPLE_RATE);
         // setting event as null to not be sent as its been discarded by sample rate
         event = null;
       }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -7,7 +7,6 @@ import io.sentry.hints.ApplyScopeData;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.Cached;
 import io.sentry.hints.DiskFlushNotification;
-import io.sentry.hints.EventDropReason;
 import io.sentry.hints.TransactionEnd;
 import io.sentry.logger.ILoggerBatchProcessor;
 import io.sentry.logger.NoOpLoggerBatchProcessor;
@@ -138,7 +137,6 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
-        HintUtils.setEventDropReason(hint, EventDropReason.IGNORED);
         return SentryId.EMPTY_ID;
       }
 
@@ -152,7 +150,6 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
-        HintUtils.setEventDropReason(hint, EventDropReason.IGNORED);
         return SentryId.EMPTY_ID;
       }
     }
@@ -179,7 +176,6 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Error);
-        HintUtils.setEventDropReason(hint, EventDropReason.BEFORE_SEND);
       }
     }
 
@@ -212,7 +208,6 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.SAMPLE_RATE, DataCategory.Error);
-        HintUtils.setEventDropReason(hint, EventDropReason.SAMPLE_RATE);
         // setting event as null to not be sent as its been discarded by sample rate
         event = null;
       }
@@ -292,6 +287,7 @@ public final class SentryClient implements ISentryClient {
       options.getLogger().log(SentryLevel.WARNING, e, "Capturing event %s failed.", sentryId);
 
       // if there was an error capturing the event, we return an emptyId
+      HintUtils.setCaptureFailed(hint);
       sentryId = SentryId.EMPTY_ID;
     }
 

--- a/sentry/src/main/java/io/sentry/TypeCheckHint.java
+++ b/sentry/src/main/java/io/sentry/TypeCheckHint.java
@@ -13,6 +13,8 @@ public final class TypeCheckHint {
   @ApiStatus.Internal
   public static final String SENTRY_EVENT_DROP_REASON = "sentry:eventDropReason";
 
+  @ApiStatus.Internal public static final String SENTRY_CAPTURE_FAILED = "sentry:captureFailed";
+
   @ApiStatus.Internal
   public static final String SENTRY_REPLAY_NETWORK_DETAILS = "sentry:replayNetworkDetails";
 

--- a/sentry/src/main/java/io/sentry/hints/EventDropReason.java
+++ b/sentry/src/main/java/io/sentry/hints/EventDropReason.java
@@ -5,11 +5,5 @@ import org.jetbrains.annotations.ApiStatus;
 /** A reason for which an event was dropped, used for (not to confuse with ClientReports) */
 @ApiStatus.Internal
 public enum EventDropReason {
-  MULTITHREADED_DEDUPLICATION,
-  /** The event matched {@code ignoredExceptionsForType} or {@code ignoredErrors}. */
-  IGNORED,
-  /** The {@code beforeSend} callback returned {@code null} or threw. */
-  BEFORE_SEND,
-  /** The event lost the {@code sampleRate} draw. */
-  SAMPLE_RATE
+  MULTITHREADED_DEDUPLICATION
 }

--- a/sentry/src/main/java/io/sentry/hints/EventDropReason.java
+++ b/sentry/src/main/java/io/sentry/hints/EventDropReason.java
@@ -5,5 +5,11 @@ import org.jetbrains.annotations.ApiStatus;
 /** A reason for which an event was dropped, used for (not to confuse with ClientReports) */
 @ApiStatus.Internal
 public enum EventDropReason {
-  MULTITHREADED_DEDUPLICATION
+  MULTITHREADED_DEDUPLICATION,
+  /** The event matched {@code ignoredExceptionsForType} or {@code ignoredErrors}. */
+  IGNORED,
+  /** The {@code beforeSend} callback returned {@code null}. */
+  BEFORE_SEND,
+  /** The event lost the {@code sampleRate} draw. */
+  SAMPLE_RATE
 }

--- a/sentry/src/main/java/io/sentry/hints/EventDropReason.java
+++ b/sentry/src/main/java/io/sentry/hints/EventDropReason.java
@@ -8,7 +8,7 @@ public enum EventDropReason {
   MULTITHREADED_DEDUPLICATION,
   /** The event matched {@code ignoredExceptionsForType} or {@code ignoredErrors}. */
   IGNORED,
-  /** The {@code beforeSend} callback returned {@code null}. */
+  /** The {@code beforeSend} callback returned {@code null} or threw. */
   BEFORE_SEND,
   /** The event lost the {@code sampleRate} draw. */
   SAMPLE_RATE

--- a/sentry/src/main/java/io/sentry/util/HintUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HintUtils.java
@@ -1,5 +1,6 @@
 package io.sentry.util;
 
+import static io.sentry.TypeCheckHint.SENTRY_CAPTURE_FAILED;
 import static io.sentry.TypeCheckHint.SENTRY_DART_SDK_NAME;
 import static io.sentry.TypeCheckHint.SENTRY_DOTNET_SDK_NAME;
 import static io.sentry.TypeCheckHint.SENTRY_EVENT_DROP_REASON;
@@ -43,6 +44,21 @@ public final class HintUtils {
   @Nullable
   public static EventDropReason getEventDropReason(final @NotNull Hint hint) {
     return hint.getAs(SENTRY_EVENT_DROP_REASON, EventDropReason.class);
+  }
+
+  /**
+   * Marks the event as not captured because of a technical failure, as opposed to being dropped on
+   * purpose. Callers that keep an event around for a later attempt use this to tell the two apart:
+   * an empty event id alone does not, because almost every drop also returns one.
+   */
+  public static void setCaptureFailed(final @Nullable Hint hint) {
+    if (hint != null) {
+      hint.set(SENTRY_CAPTURE_FAILED, true);
+    }
+  }
+
+  public static boolean isCaptureFailed(final @NotNull Hint hint) {
+    return Boolean.TRUE.equals(hint.getAs(SENTRY_CAPTURE_FAILED, Boolean.class));
   }
 
   public static Hint createWithTypeCheckHint(Object typeCheckHint) {

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -345,6 +345,17 @@ class ScopesTest {
   }
 
   @Test
+  fun `when captureEvent is called on disabled client, the hint is marked as capture failed`() {
+    val (sut, _) = getEnabledScopes()
+    sut.close()
+
+    val hint = Hint()
+    sut.captureEvent(SentryEvent(), hint)
+
+    assertTrue(HintUtils.isCaptureFailed(hint))
+  }
+
+  @Test
   fun `when captureEvent is called with a valid argument, captureEvent on the client should be called`() {
     val (sut, mockClient) = getEnabledScopes()
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -1636,6 +1636,28 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when capturing the event throws, the hint is marked as capture failed`() {
+    whenever(fixture.transport.send(any(), anyOrNull())).thenThrow(IOException())
+
+    val hint = Hint()
+    val sentryId = fixture.getSut().captureEvent(SentryEvent(), hint)
+
+    assertEquals(SentryId.EMPTY_ID, sentryId)
+    assertTrue(HintUtils.isCaptureFailed(hint))
+  }
+
+  @Test
+  fun `when the event is dropped, the hint is not marked as capture failed`() {
+    fixture.sentryOptions.setBeforeSend { _, _ -> null }
+
+    val hint = Hint()
+    val sentryId = fixture.getSut().captureEvent(SentryEvent(), hint)
+
+    assertEquals(SentryId.EMPTY_ID, sentryId)
+    assertFalse(HintUtils.isCaptureFailed(hint))
+  }
+
+  @Test
   fun `when captureEnvelope and thres an exception, returns empty sentryId`() {
     whenever(fixture.transport.send(any(), anyOrNull())).thenThrow(IOException())
 


### PR DESCRIPTION
## :scroll: Description

The last reported marker (`last_tombstone_report` / `last_anr_report`) was only written as a side
effect of caching the envelope on disk. An event dropped by `beforeSend` never gets there, so the
same `ApplicationExitInfo` was turned into an event again at every app start.

`ApplicationExitInfoHistoryDispatcher` now writes the marker as well when `captureEvent` returns
`SentryId.EMPTY_ID`, through a new `ApplicationExitInfoPolicy.markReported(long)`. The successful
path is unchanged.

## :bulb: Motivation and Context

A discarded crash must stay discarded. This is how signal handler events already behave, because
`OutboxSender` deletes the outbox file independent of the result of `beforeSend`.

* resolves: #5973
* resolves: JAVA-697

## :green_heart: How did you test it?

New test in `ApplicationExitIntegrationTestBase`, so it runs for both `TombstoneIntegrationTest`
and `AnrV2IntegrationTest`. It failed before the change and passes now. Full
`:sentry-android-core:testReleaseUnitTest` is green.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

`TombstonePolicy` deletes the matching native outbox file before the capture, so native data cannot
come back if the merged event is lost. That is a separate defect.
