### PR TITLE
fix(okhttp): keep the wrapped EventListener per Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prevent duplicated breadcrumbs on tombstone-merged native crash events ([#5888](https://github.com/getsentry/sentry-java/pull/5888))
 - Prevent a class of Session Replay deadlocks by confining lifecycle state changes to Android's main thread ([#5965](https://github.com/getsentry/sentry-java/pull/5965))
 - Symbolicate tombstone native frames for libraries loaded directly from APKs ([#5992](https://github.com/getsentry/sentry-java/pull/5992))
+- Keep the `EventListener` wrapped by `SentryOkHttpEventListener` per `Call` ([#6003](https://github.com/getsentry/sentry-java/pull/6003))
 
 ### Features
 

--- a/sentry-okhttp/build.gradle.kts
+++ b/sentry-okhttp/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   testImplementation(libs.mockito.inline)
   testImplementation(libs.okhttp)
   testImplementation(libs.okhttp.mockwebserver)
+  testImplementation(libs.google.truth)
 }
 
 buildConfig {

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -45,7 +45,7 @@ public open class SentryOkHttpEventListener(
   private val scopes: IScopes = ScopesAdapter.getInstance(),
   private val originalEventListenerCreator: ((call: Call) -> EventListener)? = null,
 ) : EventListener() {
-  private var originalEventListener: EventListener? = null
+  private val originalEventListenerMap: MutableMap<Call, EventListener> = ConcurrentHashMap()
 
   public companion object {
     internal const val PROXY_SELECT_EVENT = "http.client.proxy_select_ms"
@@ -85,18 +85,23 @@ public open class SentryOkHttpEventListener(
   ) : this(scopes, originalEventListenerCreator = { originalEventListenerFactory.create(it) })
 
   override fun callStart(call: Call) {
-    originalEventListener = originalEventListenerCreator?.invoke(call)
+    // The EventListener.Factory contract binds a listener to a single call, so the wrapped
+    // listener is kept per call instead of in a field shared by all concurrent calls
+    val originalEventListener = originalEventListenerCreator?.invoke(call)
+    if (originalEventListener != null) {
+      originalEventListenerMap[call] = originalEventListener
+    }
     originalEventListener?.callStart(call)
     // If the wrapped EventListener is ours, we can just delegate the calls,
     // without creating other events that would create duplicates
-    if (canCreateEventSpan()) {
+    if (canCreateEventSpan(originalEventListener)) {
       eventMap[call] = SentryOkHttpEvent(scopes, call.request())
     }
   }
 
   override fun proxySelectStart(call: Call, url: HttpUrl) {
-    originalEventListener?.proxySelectStart(call, url)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.proxySelectStart(call, url)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -104,8 +109,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun proxySelectEnd(call: Call, url: HttpUrl, proxies: List<Proxy>) {
-    originalEventListener?.proxySelectEnd(call, url, proxies)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.proxySelectEnd(call, url, proxies)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -117,8 +122,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun dnsStart(call: Call, domainName: String) {
-    originalEventListener?.dnsStart(call, domainName)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.dnsStart(call, domainName)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -126,8 +131,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
-    originalEventListener?.dnsEnd(call, domainName, inetAddressList)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.dnsEnd(call, domainName, inetAddressList)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -140,8 +145,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
-    originalEventListener?.connectStart(call, inetSocketAddress, proxy)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.connectStart(call, inetSocketAddress, proxy)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -149,8 +154,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun secureConnectStart(call: Call) {
-    originalEventListener?.secureConnectStart(call)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.secureConnectStart(call)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -158,8 +163,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun secureConnectEnd(call: Call, handshake: Handshake?) {
-    originalEventListener?.secureConnectEnd(call, handshake)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.secureConnectEnd(call, handshake)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -172,8 +177,8 @@ public open class SentryOkHttpEventListener(
     proxy: Proxy,
     protocol: Protocol?,
   ) {
-    originalEventListener?.connectEnd(call, inetSocketAddress, proxy, protocol)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.connectEnd(call, inetSocketAddress, proxy, protocol)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -188,8 +193,8 @@ public open class SentryOkHttpEventListener(
     protocol: Protocol?,
     ioe: IOException,
   ) {
-    originalEventListener?.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -202,8 +207,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun connectionAcquired(call: Call, connection: Connection) {
-    originalEventListener?.connectionAcquired(call, connection)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.connectionAcquired(call, connection)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -211,8 +216,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun connectionReleased(call: Call, connection: Connection) {
-    originalEventListener?.connectionReleased(call, connection)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.connectionReleased(call, connection)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -220,8 +225,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestHeadersStart(call: Call) {
-    originalEventListener?.requestHeadersStart(call)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.requestHeadersStart(call)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -229,8 +234,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestHeadersEnd(call: Call, request: Request) {
-    originalEventListener?.requestHeadersEnd(call, request)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.requestHeadersEnd(call, request)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -238,8 +243,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestBodyStart(call: Call) {
-    originalEventListener?.requestBodyStart(call)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.requestBodyStart(call)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -247,8 +252,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestBodyEnd(call: Call, byteCount: Long) {
-    originalEventListener?.requestBodyEnd(call, byteCount)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.requestBodyEnd(call, byteCount)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -261,8 +266,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestFailed(call: Call, ioe: IOException) {
-    originalEventListener?.requestFailed(call, ioe)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.requestFailed(call, ioe)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -282,8 +287,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseHeadersStart(call: Call) {
-    originalEventListener?.responseHeadersStart(call)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.responseHeadersStart(call)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -291,8 +296,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseHeadersEnd(call: Call, response: Response) {
-    originalEventListener?.responseHeadersEnd(call, response)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.responseHeadersEnd(call, response)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -307,8 +312,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseBodyStart(call: Call) {
-    originalEventListener?.responseBodyStart(call)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.responseBodyStart(call)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -316,8 +321,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseBodyEnd(call: Call, byteCount: Long) {
-    originalEventListener?.responseBodyEnd(call, byteCount)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.responseBodyEnd(call, byteCount)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -330,8 +335,8 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseFailed(call: Call, ioe: IOException) {
-    originalEventListener?.responseFailed(call, ioe)
-    if (!canCreateEventSpan()) {
+    originalEventListenerMap[call]?.responseFailed(call, ioe)
+    if (!canCreateEventSpan(call)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -351,14 +356,15 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun callEnd(call: Call) {
-    originalEventListener?.callEnd(call)
+    originalEventListenerMap.remove(call)?.callEnd(call)
     val okHttpEvent: SentryOkHttpEvent = eventMap.remove(call) ?: return
     okHttpEvent.finish()
   }
 
   override fun callFailed(call: Call, ioe: IOException) {
+    val originalEventListener = originalEventListenerMap.remove(call)
     originalEventListener?.callFailed(call, ioe)
-    if (!canCreateEventSpan()) {
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap.remove(call) ?: return
@@ -370,26 +376,29 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun canceled(call: Call) {
-    originalEventListener?.canceled(call)
+    originalEventListenerMap[call]?.canceled(call)
   }
 
   override fun satisfactionFailure(call: Call, response: Response) {
-    originalEventListener?.satisfactionFailure(call, response)
+    originalEventListenerMap[call]?.satisfactionFailure(call, response)
   }
 
   override fun cacheHit(call: Call, response: Response) {
-    originalEventListener?.cacheHit(call, response)
+    originalEventListenerMap[call]?.cacheHit(call, response)
   }
 
   override fun cacheMiss(call: Call) {
-    originalEventListener?.cacheMiss(call)
+    originalEventListenerMap[call]?.cacheMiss(call)
   }
 
   override fun cacheConditionalHit(call: Call, cachedResponse: Response) {
-    originalEventListener?.cacheConditionalHit(call, cachedResponse)
+    originalEventListenerMap[call]?.cacheConditionalHit(call, cachedResponse)
   }
 
-  private fun canCreateEventSpan(): Boolean {
+  private fun canCreateEventSpan(call: Call): Boolean =
+    canCreateEventSpan(originalEventListenerMap[call])
+
+  private fun canCreateEventSpan(originalEventListener: EventListener?): Boolean {
     // If the wrapped EventListener is ours, we shouldn't create spans, as the originalEventListener
     // already did it
     // In case SentryOkHttpEventListener from sentry-android-okhttp is used, the is check won't work

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -403,16 +403,25 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun canceled(call: Call) {
-    // canceled() is not part of the call window: OkHttp may deliver it before callStart() and
-    // after callEnd()/callFailed(), because it holds the listener for the whole Call lifetime
-    // while we only keep it for the duration of the call.
-    val originalEventListener =
-      originalEventListenerMap[call]
-        ?: fixedOriginalEventListener
-        // The call already reached its terminal event, so its listener is gone. Call.cancel() is
-        // documented as a no-op for a completed request, thus there is nothing to report, and
-        // creating a second listener here would break the Factory contract and leak the entry.
-        ?: if (call.isExecuted()) null else getOrCreateEventListener(call)
+    // canceled() is the only callback that is not part of the call window. OkHttp creates the
+    // listener in the Call constructor and keeps it for the whole lifetime of the Call, so it may
+    // deliver canceled() before callStart() and after callEnd()/callFailed(). We only keep the
+    // listener between callStart() and the terminal event, so out of that window there is nothing
+    // in originalEventListenerMap.
+    //
+    // We deliberately do not create a listener for such a cancel:
+    // - After the terminal event the call is over. Call.cancel() is documented as a no-op for a
+    //   request that is already complete, so there is nothing to report.
+    // - Before callStart() there may never be a call at all. A Call that is canceled and then
+    //   never executed gets no callEnd()/callFailed(), so an entry added here could never be
+    //   removed again and would leak the Call. If the Call is executed after all, OkHttp fails it
+    //   with IOException("Canceled") and the listener still learns about it through callFailed().
+    //
+    // Creating one would also hand the EventListener.Factory contract a second listener for a
+    // single Call. A listener kept in a field instead is shared by all calls by definition, the
+    // same as OkHttp's own EventListener.asFactory(), so it exists outside the window and always
+    // gets the event.
+    val originalEventListener = originalEventListenerMap[call] ?: fixedOriginalEventListener
     originalEventListener?.canceled(call)
   }
 
@@ -432,8 +441,8 @@ public open class SentryOkHttpEventListener(
     originalEventListenerMap[call]?.cacheConditionalHit(call, cachedResponse)
   }
 
-  // computeIfAbsent, so that a cancel racing callStart() cannot make the Factory produce two
-  // listeners for the same Call
+  // computeIfAbsent, so that concurrent callbacks cannot make the Factory produce two listeners
+  // for the same Call
   private fun getOrCreateEventListener(call: Call): EventListener? {
     val creator = originalEventListenerCreator ?: return null
     return originalEventListenerMap.computeIfAbsent(call) { creator.invoke(it) }

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -397,7 +397,13 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun canceled(call: Call) {
-    originalEventListenerMap[call]?.canceled(call)
+    // Unlike the other callbacks, canceled() can occur before callStart() and after
+    // callEnd()/callFailed(), so there is not always a listener bound to the call. Create one on
+    // the fly in that case, but do not put it in the map: nothing would remove it again, because
+    // a call that is canceled before it starts never gets a callEnd() or callFailed().
+    val originalEventListener =
+      originalEventListenerMap[call] ?: originalEventListenerCreator?.invoke(call) ?: return
+    originalEventListener.canceled(call)
   }
 
   override fun satisfactionFailure(call: Call, response: Response) {

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -100,8 +100,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun proxySelectStart(call: Call, url: HttpUrl) {
-    originalEventListenerMap[call]?.proxySelectStart(call, url)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.proxySelectStart(call, url)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -109,8 +110,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun proxySelectEnd(call: Call, url: HttpUrl, proxies: List<Proxy>) {
-    originalEventListenerMap[call]?.proxySelectEnd(call, url, proxies)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.proxySelectEnd(call, url, proxies)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -122,8 +124,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun dnsStart(call: Call, domainName: String) {
-    originalEventListenerMap[call]?.dnsStart(call, domainName)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.dnsStart(call, domainName)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -131,8 +134,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
-    originalEventListenerMap[call]?.dnsEnd(call, domainName, inetAddressList)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.dnsEnd(call, domainName, inetAddressList)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -145,8 +149,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
-    originalEventListenerMap[call]?.connectStart(call, inetSocketAddress, proxy)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.connectStart(call, inetSocketAddress, proxy)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -154,8 +159,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun secureConnectStart(call: Call) {
-    originalEventListenerMap[call]?.secureConnectStart(call)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.secureConnectStart(call)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -163,8 +169,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun secureConnectEnd(call: Call, handshake: Handshake?) {
-    originalEventListenerMap[call]?.secureConnectEnd(call, handshake)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.secureConnectEnd(call, handshake)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -177,8 +184,9 @@ public open class SentryOkHttpEventListener(
     proxy: Proxy,
     protocol: Protocol?,
   ) {
-    originalEventListenerMap[call]?.connectEnd(call, inetSocketAddress, proxy, protocol)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.connectEnd(call, inetSocketAddress, proxy, protocol)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -193,8 +201,9 @@ public open class SentryOkHttpEventListener(
     protocol: Protocol?,
     ioe: IOException,
   ) {
-    originalEventListenerMap[call]?.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -207,8 +216,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun connectionAcquired(call: Call, connection: Connection) {
-    originalEventListenerMap[call]?.connectionAcquired(call, connection)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.connectionAcquired(call, connection)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -216,8 +226,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun connectionReleased(call: Call, connection: Connection) {
-    originalEventListenerMap[call]?.connectionReleased(call, connection)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.connectionReleased(call, connection)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -225,8 +236,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestHeadersStart(call: Call) {
-    originalEventListenerMap[call]?.requestHeadersStart(call)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.requestHeadersStart(call)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -234,8 +246,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestHeadersEnd(call: Call, request: Request) {
-    originalEventListenerMap[call]?.requestHeadersEnd(call, request)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.requestHeadersEnd(call, request)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -243,8 +256,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestBodyStart(call: Call) {
-    originalEventListenerMap[call]?.requestBodyStart(call)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.requestBodyStart(call)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -252,8 +266,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestBodyEnd(call: Call, byteCount: Long) {
-    originalEventListenerMap[call]?.requestBodyEnd(call, byteCount)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.requestBodyEnd(call, byteCount)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -266,8 +281,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun requestFailed(call: Call, ioe: IOException) {
-    originalEventListenerMap[call]?.requestFailed(call, ioe)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.requestFailed(call, ioe)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -287,8 +303,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseHeadersStart(call: Call) {
-    originalEventListenerMap[call]?.responseHeadersStart(call)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.responseHeadersStart(call)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -296,8 +313,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseHeadersEnd(call: Call, response: Response) {
-    originalEventListenerMap[call]?.responseHeadersEnd(call, response)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.responseHeadersEnd(call, response)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -312,8 +330,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseBodyStart(call: Call) {
-    originalEventListenerMap[call]?.responseBodyStart(call)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.responseBodyStart(call)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -321,8 +340,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseBodyEnd(call: Call, byteCount: Long) {
-    originalEventListenerMap[call]?.responseBodyEnd(call, byteCount)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.responseBodyEnd(call, byteCount)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -335,8 +355,9 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun responseFailed(call: Call, ioe: IOException) {
-    originalEventListenerMap[call]?.responseFailed(call, ioe)
-    if (!canCreateEventSpan(call)) {
+    val originalEventListener = originalEventListenerMap[call]
+    originalEventListener?.responseFailed(call, ioe)
+    if (!canCreateEventSpan(originalEventListener)) {
       return
     }
     val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
@@ -394,9 +415,6 @@ public open class SentryOkHttpEventListener(
   override fun cacheConditionalHit(call: Call, cachedResponse: Response) {
     originalEventListenerMap[call]?.cacheConditionalHit(call, cachedResponse)
   }
-
-  private fun canCreateEventSpan(call: Call): Boolean =
-    canCreateEventSpan(originalEventListenerMap[call])
 
   private fun canCreateEventSpan(originalEventListener: EventListener?): Boolean {
     // If the wrapped EventListener is ours, we shouldn't create spans, as the originalEventListener

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -45,7 +45,12 @@ public open class SentryOkHttpEventListener(
   private val scopes: IScopes = ScopesAdapter.getInstance(),
   private val originalEventListenerCreator: ((call: Call) -> EventListener)? = null,
 ) : EventListener() {
-  private val originalEventListenerMap: MutableMap<Call, EventListener> = ConcurrentHashMap()
+  private val originalEventListenerMap: ConcurrentHashMap<Call, EventListener> = ConcurrentHashMap()
+
+  // Set only by the constructors that wrap a single EventListener instance. Such a listener is
+  // shared by every Call anyway, exactly like OkHttp's own EventListener.asFactory(), so it
+  // exists independently of the callStart()..callEnd() window and can always be delegated to.
+  private var fixedOriginalEventListener: EventListener? = null
 
   public companion object {
     internal const val PROXY_SELECT_EVENT = "http.client.proxy_select_ms"
@@ -65,7 +70,9 @@ public open class SentryOkHttpEventListener(
 
   public constructor(
     originalEventListener: EventListener
-  ) : this(ScopesAdapter.getInstance(), originalEventListenerCreator = { originalEventListener })
+  ) : this(ScopesAdapter.getInstance(), originalEventListenerCreator = { originalEventListener }) {
+    fixedOriginalEventListener = originalEventListener
+  }
 
   public constructor(
     originalEventListenerFactory: Factory
@@ -77,7 +84,9 @@ public open class SentryOkHttpEventListener(
   public constructor(
     scopes: IScopes = ScopesAdapter.getInstance(),
     originalEventListener: EventListener,
-  ) : this(scopes, originalEventListenerCreator = { originalEventListener })
+  ) : this(scopes, originalEventListenerCreator = { originalEventListener }) {
+    fixedOriginalEventListener = originalEventListener
+  }
 
   public constructor(
     scopes: IScopes = ScopesAdapter.getInstance(),
@@ -87,10 +96,7 @@ public open class SentryOkHttpEventListener(
   override fun callStart(call: Call) {
     // The EventListener.Factory contract binds a listener to a single call, so the wrapped
     // listener is kept per call instead of in a field shared by all concurrent calls
-    val originalEventListener = originalEventListenerCreator?.invoke(call)
-    if (originalEventListener != null) {
-      originalEventListenerMap[call] = originalEventListener
-    }
+    val originalEventListener = getOrCreateEventListener(call)
     originalEventListener?.callStart(call)
     // If the wrapped EventListener is ours, we can just delegate the calls,
     // without creating other events that would create duplicates
@@ -397,13 +403,17 @@ public open class SentryOkHttpEventListener(
   }
 
   override fun canceled(call: Call) {
-    // Unlike the other callbacks, canceled() can occur before callStart() and after
-    // callEnd()/callFailed(), so there is not always a listener bound to the call. Create one on
-    // the fly in that case, but do not put it in the map: nothing would remove it again, because
-    // a call that is canceled before it starts never gets a callEnd() or callFailed().
+    // canceled() is not part of the call window: OkHttp may deliver it before callStart() and
+    // after callEnd()/callFailed(), because it holds the listener for the whole Call lifetime
+    // while we only keep it for the duration of the call.
     val originalEventListener =
-      originalEventListenerMap[call] ?: originalEventListenerCreator?.invoke(call) ?: return
-    originalEventListener.canceled(call)
+      originalEventListenerMap[call]
+        ?: fixedOriginalEventListener
+        // The call already reached its terminal event, so its listener is gone. Call.cancel() is
+        // documented as a no-op for a completed request, thus there is nothing to report, and
+        // creating a second listener here would break the Factory contract and leak the entry.
+        ?: if (call.isExecuted()) null else getOrCreateEventListener(call)
+    originalEventListener?.canceled(call)
   }
 
   override fun satisfactionFailure(call: Call, response: Response) {
@@ -420,6 +430,13 @@ public open class SentryOkHttpEventListener(
 
   override fun cacheConditionalHit(call: Call, cachedResponse: Response) {
     originalEventListenerMap[call]?.cacheConditionalHit(call, cachedResponse)
+  }
+
+  // computeIfAbsent, so that a cancel racing callStart() cannot make the Factory produce two
+  // listeners for the same Call
+  private fun getOrCreateEventListener(call: Call): EventListener? {
+    val creator = originalEventListenerCreator ?: return null
+    return originalEventListenerMap.computeIfAbsent(call) { creator.invoke(it) }
   }
 
   private fun canCreateEventSpan(originalEventListener: EventListener?): Boolean {

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
@@ -54,17 +54,6 @@ class SentryOkHttpEventListenerDelegationTest {
 
     fun newCall(path: String): Call =
       client.newCall(Request.Builder().url("http://localhost/$path").build())
-
-    // The tests drive the listener by hand, so no call is ever really executed. canceled() branches
-    // on Call.isExecuted() to tell a cancel that precedes callStart() from one that follows the
-    // terminal event, so those cases need a Call that reports the state under test.
-    fun mockCall(path: String, isExecuted: Boolean): Call {
-      val request = Request.Builder().url("http://localhost/$path").build()
-      return mock<Call>().also {
-        whenever(it.request()).thenReturn(request)
-        whenever(it.isExecuted()).thenReturn(isExecuted)
-      }
-    }
   }
 
   private val fixture = Fixture()
@@ -150,25 +139,34 @@ class SentryOkHttpEventListenerDelegationTest {
   }
 
   @Test
-  fun `cancel before callStart binds the listener that callStart then reuses`() {
+  fun `cancel before callStart is not delegated and creates no listener`() {
     val sut = fixture.getSut()
-    val call = fixture.mockCall("1", isExecuted = false)
+    val call = fixture.newCall("1")
+
+    sut.canceled(call)
+
+    assertThat(fixture.listeners).isEmpty()
+  }
+
+  @Test
+  fun `a call canceled before callStart still gets a single listener when it starts`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
 
     sut.canceled(call)
     sut.callStart(call)
-    sut.dnsStart(call, "sentry.io")
-    sut.callEnd(call)
+    sut.callFailed(call, IOException("Canceled"))
 
     assertThat(fixture.listeners).hasSize(1)
     assertThat(fixture.listeners.single().received.map { it.first })
-      .containsExactly("canceled", "callStart", "dnsStart", "callEnd")
+      .containsExactly("callStart", "callFailed")
       .inOrder()
   }
 
   @Test
   fun `cancel after the terminal event is ignored`() {
     val sut = fixture.getSut()
-    val call = fixture.mockCall("1", isExecuted = true)
+    val call = fixture.newCall("1")
 
     sut.callStart(call)
     sut.callEnd(call)
@@ -183,7 +181,7 @@ class SentryOkHttpEventListenerDelegationTest {
   @Test
   fun `cancel after a failed call is ignored`() {
     val sut = fixture.getSut()
-    val call = fixture.mockCall("1", isExecuted = true)
+    val call = fixture.newCall("1")
 
     sut.callStart(call)
     sut.callFailed(call, IOException())
@@ -198,7 +196,7 @@ class SentryOkHttpEventListenerDelegationTest {
   @Test
   fun `a single wrapped listener receives cancels outside of the call window`() {
     whenever(fixture.scopes.options).thenReturn(SentryOptions())
-    val call = fixture.mockCall("1", isExecuted = true)
+    val call = fixture.newCall("1")
     val listener = RecordingListener(call)
     val sut = SentryOkHttpEventListener(fixture.scopes, listener)
 

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
@@ -32,6 +32,10 @@ class SentryOkHttpEventListenerDelegationTest {
       received += "callFailed" to call
     }
 
+    override fun canceled(call: Call) {
+      received += "canceled" to call
+    }
+
     fun mismatches(): List<Pair<String, Call>> = received.filter { it.second !== ownCall }
   }
 
@@ -117,6 +121,73 @@ class SentryOkHttpEventListenerDelegationTest {
 
     assertThat(fixture.listeners.single().received.map { it.first })
       .containsExactly("callStart", "callFailed")
+      .inOrder()
+  }
+
+  @Test
+  fun `cancel during a call is delegated to the listener of that call`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
+
+    sut.callStart(call)
+    sut.canceled(call)
+    sut.callFailed(call, IOException())
+
+    assertThat(fixture.listeners.single().received.map { it.first })
+      .containsExactly("callStart", "canceled", "callFailed")
+      .inOrder()
+  }
+
+  @Test
+  fun `cancel before callStart is delegated`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
+
+    sut.canceled(call)
+
+    assertThat(fixture.listeners.single().received).containsExactly("canceled" to call)
+  }
+
+  @Test
+  fun `cancel after callEnd is delegated`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
+
+    sut.callStart(call)
+    sut.callEnd(call)
+    sut.canceled(call)
+
+    assertThat(fixture.listeners.first().received.map { it.first })
+      .containsExactly("callStart", "callEnd")
+      .inOrder()
+    assertThat(fixture.listeners.last().received).containsExactly("canceled" to call)
+  }
+
+  @Test
+  fun `cancel outside of a call does not bind a listener to the call`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
+
+    sut.canceled(call)
+    sut.dnsStart(call, "sentry.io")
+
+    assertThat(fixture.listeners.single().received.map { it.first }).containsExactly("canceled")
+  }
+
+  @Test
+  fun `a single wrapped listener receives cancels outside of the call window`() {
+    whenever(fixture.scopes.options).thenReturn(SentryOptions())
+    val call = fixture.newCall("1")
+    val listener = RecordingListener(call)
+    val sut = SentryOkHttpEventListener(fixture.scopes, listener)
+
+    sut.canceled(call)
+    sut.callStart(call)
+    sut.callEnd(call)
+    sut.canceled(call)
+
+    assertThat(listener.received.map { it.first })
+      .containsExactly("canceled", "callStart", "callEnd", "canceled")
       .inOrder()
   }
 }

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
@@ -54,6 +54,17 @@ class SentryOkHttpEventListenerDelegationTest {
 
     fun newCall(path: String): Call =
       client.newCall(Request.Builder().url("http://localhost/$path").build())
+
+    // The tests drive the listener by hand, so no call is ever really executed. canceled() branches
+    // on Call.isExecuted() to tell a cancel that precedes callStart() from one that follows the
+    // terminal event, so those cases need a Call that reports the state under test.
+    fun mockCall(path: String, isExecuted: Boolean): Call {
+      val request = Request.Builder().url("http://localhost/$path").build()
+      return mock<Call>().also {
+        whenever(it.request()).thenReturn(request)
+        whenever(it.isExecuted()).thenReturn(isExecuted)
+      }
+    }
   }
 
   private val fixture = Fixture()
@@ -139,45 +150,55 @@ class SentryOkHttpEventListenerDelegationTest {
   }
 
   @Test
-  fun `cancel before callStart is delegated`() {
+  fun `cancel before callStart binds the listener that callStart then reuses`() {
     val sut = fixture.getSut()
-    val call = fixture.newCall("1")
+    val call = fixture.mockCall("1", isExecuted = false)
 
     sut.canceled(call)
+    sut.callStart(call)
+    sut.dnsStart(call, "sentry.io")
+    sut.callEnd(call)
 
-    assertThat(fixture.listeners.single().received).containsExactly("canceled" to call)
+    assertThat(fixture.listeners).hasSize(1)
+    assertThat(fixture.listeners.single().received.map { it.first })
+      .containsExactly("canceled", "callStart", "dnsStart", "callEnd")
+      .inOrder()
   }
 
   @Test
-  fun `cancel after callEnd is delegated`() {
+  fun `cancel after the terminal event is ignored`() {
     val sut = fixture.getSut()
-    val call = fixture.newCall("1")
+    val call = fixture.mockCall("1", isExecuted = true)
 
     sut.callStart(call)
     sut.callEnd(call)
     sut.canceled(call)
 
-    assertThat(fixture.listeners.first().received.map { it.first })
+    assertThat(fixture.listeners).hasSize(1)
+    assertThat(fixture.listeners.single().received.map { it.first })
       .containsExactly("callStart", "callEnd")
       .inOrder()
-    assertThat(fixture.listeners.last().received).containsExactly("canceled" to call)
   }
 
   @Test
-  fun `cancel outside of a call does not bind a listener to the call`() {
+  fun `cancel after a failed call is ignored`() {
     val sut = fixture.getSut()
-    val call = fixture.newCall("1")
+    val call = fixture.mockCall("1", isExecuted = true)
 
+    sut.callStart(call)
+    sut.callFailed(call, IOException())
     sut.canceled(call)
-    sut.dnsStart(call, "sentry.io")
 
-    assertThat(fixture.listeners.single().received.map { it.first }).containsExactly("canceled")
+    assertThat(fixture.listeners).hasSize(1)
+    assertThat(fixture.listeners.single().received.map { it.first })
+      .containsExactly("callStart", "callFailed")
+      .inOrder()
   }
 
   @Test
   fun `a single wrapped listener receives cancels outside of the call window`() {
     whenever(fixture.scopes.options).thenReturn(SentryOptions())
-    val call = fixture.newCall("1")
+    val call = fixture.mockCall("1", isExecuted = true)
     val listener = RecordingListener(call)
     val sut = SentryOkHttpEventListener(fixture.scopes, listener)
 

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerDelegationTest.kt
@@ -1,0 +1,122 @@
+package io.sentry.okhttp
+
+import com.google.common.truth.Truth.assertThat
+import io.sentry.IScopes
+import io.sentry.SentryOptions
+import java.io.IOException
+import kotlin.test.Test
+import okhttp3.Call
+import okhttp3.EventListener
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class SentryOkHttpEventListenerDelegationTest {
+  class RecordingListener(val ownCall: Call) : EventListener() {
+    val received = mutableListOf<Pair<String, Call>>()
+
+    override fun callStart(call: Call) {
+      received += "callStart" to call
+    }
+
+    override fun dnsStart(call: Call, domainName: String) {
+      received += "dnsStart" to call
+    }
+
+    override fun callEnd(call: Call) {
+      received += "callEnd" to call
+    }
+
+    override fun callFailed(call: Call, ioe: IOException) {
+      received += "callFailed" to call
+    }
+
+    fun mismatches(): List<Pair<String, Call>> = received.filter { it.second !== ownCall }
+  }
+
+  class Fixture {
+    val scopes = mock<IScopes>()
+    val client = OkHttpClient()
+    val listeners = mutableListOf<RecordingListener>()
+
+    fun getSut(): SentryOkHttpEventListener {
+      whenever(scopes.options).thenReturn(SentryOptions())
+      return SentryOkHttpEventListener(
+        scopes,
+        EventListener.Factory { call -> RecordingListener(call).also { listeners.add(it) } },
+      )
+    }
+
+    fun newCall(path: String): Call =
+      client.newCall(Request.Builder().url("http://localhost/$path").build())
+  }
+
+  private val fixture = Fixture()
+
+  @Test
+  fun `each call is delegated to the listener created for it`() {
+    val sut = fixture.getSut()
+    val call1 = fixture.newCall("1")
+    val call2 = fixture.newCall("2")
+
+    sut.callStart(call1)
+    sut.callStart(call2)
+    sut.dnsStart(call1, "sentry.io")
+    sut.dnsStart(call2, "sentry.io")
+    sut.callEnd(call1)
+    sut.callEnd(call2)
+
+    val (listener1, listener2) = fixture.listeners
+    assertThat(listener1.mismatches()).isEmpty()
+    assertThat(listener2.mismatches()).isEmpty()
+    assertThat(listener1.received.map { it.first })
+      .containsExactly("callStart", "dnsStart", "callEnd")
+      .inOrder()
+    assertThat(listener2.received.map { it.first })
+      .containsExactly("callStart", "dnsStart", "callEnd")
+      .inOrder()
+  }
+
+  @Test
+  fun `callbacks without a preceding callStart are not delegated`() {
+    val sut = fixture.getSut()
+    val call1 = fixture.newCall("1")
+    val call2 = fixture.newCall("2")
+
+    sut.callStart(call1)
+    sut.dnsStart(call2, "sentry.io")
+    sut.callEnd(call2)
+
+    assertThat(fixture.listeners).hasSize(1)
+    assertThat(fixture.listeners.single().received.map { it.first }).containsExactly("callStart")
+  }
+
+  @Test
+  fun `a finished call is no longer delegated to`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
+
+    sut.callStart(call)
+    sut.callEnd(call)
+    sut.dnsStart(call, "sentry.io")
+
+    assertThat(fixture.listeners.single().received.map { it.first })
+      .containsExactly("callStart", "callEnd")
+      .inOrder()
+  }
+
+  @Test
+  fun `a failed call is no longer delegated to`() {
+    val sut = fixture.getSut()
+    val call = fixture.newCall("1")
+
+    sut.callStart(call)
+    sut.callFailed(call, IOException())
+    sut.dnsStart(call, "sentry.io")
+
+    assertThat(fixture.listeners.single().received.map { it.first })
+      .containsExactly("callStart", "callFailed")
+      .inOrder()
+  }
+}

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerTest.kt
@@ -227,7 +227,7 @@ class SentryOkHttpEventListenerTest {
     val call = sut.newCall(request)
     val response = mock<Response>()
     whenever(response.protocol).thenReturn(Protocol.HTTP_1_1)
-    verifyDelegation(listener, fixture.mockEventListener, call, response)
+    verifyDelegation(listener, fixture.mockEventListener, call, sut.newCall(request), response)
   }
 
   @Test
@@ -238,7 +238,7 @@ class SentryOkHttpEventListenerTest {
     val call = sut.newCall(request)
     val response = mock<Response>()
     whenever(response.protocol).thenReturn(Protocol.HTTP_1_1)
-    verifyDelegation(listener, fixture.mockEventListener, call, response)
+    verifyDelegation(listener, fixture.mockEventListener, call, sut.newCall(request), response)
   }
 
   @Test
@@ -250,7 +250,7 @@ class SentryOkHttpEventListenerTest {
     val call = sut.newCall(request)
     val response = mock<Response>()
     whenever(response.protocol).thenReturn(Protocol.HTTP_1_1)
-    verifyDelegation(listener, originalListener, call, response)
+    verifyDelegation(listener, originalListener, call, sut.newCall(request), response)
   }
 
   @Test
@@ -262,7 +262,7 @@ class SentryOkHttpEventListenerTest {
     val call = sut.newCall(request)
     val response = mock<Response>()
     whenever(response.protocol).thenReturn(Protocol.HTTP_1_1)
-    verifyDelegation(listener, originalListener, call, response)
+    verifyDelegation(listener, originalListener, call, sut.newCall(request), response)
   }
 
   @Test
@@ -304,6 +304,7 @@ class SentryOkHttpEventListenerTest {
     listener: SentryOkHttpEventListener,
     originalListener: EventListener,
     call: Call,
+    failedCall: Call,
     response: Response,
   ) {
     listener.callStart(call)
@@ -352,7 +353,10 @@ class SentryOkHttpEventListenerTest {
     verify(originalListener).responseFailed(eq(call), any())
     listener.callEnd(call)
     verify(originalListener).callEnd(eq(call))
-    listener.callFailed(call, mock())
-    verify(originalListener).callFailed(eq(call), any())
+
+    // callEnd and callFailed are both terminal, so a failing call is a separate one
+    listener.callStart(failedCall)
+    listener.callFailed(failedCall, mock())
+    verify(originalListener).callFailed(eq(failedCall), any())
   }
 }


### PR DESCRIPTION
## :scroll: Description

`SentryOkHttpEventListener` held the wrapped `EventListener` in a single mutable field that
`callStart` overwrote for each call. It is now kept in a per-`Call` map, the same pattern the class
already uses for `eventMap`. No public API change.

## :bulb: Motivation and Context

OkHttp uses one listener instance for all calls, thus concurrent calls were all delegated to the
listener made for the call that started last. This breaks the `EventListener.Factory` contract and
loses the terminal `callEnd`/`callFailed` of every overlapping call.

* resolves: #5967
* resolves: JAVA-695

## :green_heart: How did you test it?

Added unit tests.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps
