### PR TITLE
fix(scopes): apply withScope data to events in globalHubMode

### DIFF
--- a/.cursor/rules/scopes.mdc
+++ b/.cursor/rules/scopes.mdc
@@ -90,15 +90,20 @@ For JVM Backend applications (servers) we discourage enabling `globalHubMode` si
 
 ### Enabled
 
-If `globalHubMode` is enabled, the SDK avoids forking scopes.
+If `globalHubMode` is enabled, the SDK avoids forking scopes _implicitly_.
 
 This means, retrieving current scopes on a thread where specific scopes do not exist yet for the thread, the root scopes are not forked but returned directly.
-The SDK also doesn't fork scopes when `Sentry.pushScope`, `Sentry.pushIsolation`, `Sentry.withScope` or `Sentry.withIsolationScope` are executed.
+`Sentry.pushScope`, `Sentry.pushIsolationScope` and `Sentry.popScope` are no-ops.
+They are unbalanced API: the caller may never restore the previous scopes, or restore them on a different thread, which would corrupt the globally shared scopes.
+
+`Sentry.withScope` and `Sentry.withIsolationScope` do fork, also when `globalHubMode` is enabled.
+They are balanced by construction and always restore the previous scopes before returning, so they cannot corrupt the shared scopes.
+This matches the cross SDK spec ("fork the current scope, invoke callback, discard the fork when done") and what the SDK did before major version 8.
 
 The suppression of forking via `globalHubMode` only applies when using `Sentry` static API or `ScopesAdapter`.
 In case the `Scopes` instance is accessed directly, forking will happen as if `globalHubMode` is disabled.
-However, while it's possible to use `Sentry.setCurrentScopes` it does not have any effect due to `Sentry.getCurrentScopes` directly returning `rootScopes` if `globalHubMode` is enabled.
-This means the forked scopes have to be managed manually, e.g. by keeping a reference and accessing Sentry API via the reference instead of using static API.
+`Sentry.setCurrentScopes`, and thus `Scopes.makeCurrent`, does have an effect when `globalHubMode` is enabled, but only for scopes that descend from the current `rootScopes`.
+`Sentry.getCurrentScopes` ignores all other scopes, because scopes left over from a closed or re-initialized SDK would otherwise be read back from a thread local that the SDK cannot clean up.
 
 `ScopesAdapter` makes use of the static `Sentry` API internally. It allows us to access the correct scopes for the current context without passing it along explicitly. It also makes testing easier.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Prevent duplicated breadcrumbs on tombstone-merged native crash events ([#5888](https://github.com/getsentry/sentry-java/pull/5888))
 - Prevent a class of Session Replay deadlocks by confining lifecycle state changes to Android's main thread ([#5965](https://github.com/getsentry/sentry-java/pull/5965))
 - Symbolicate tombstone native frames for libraries loaded directly from APKs ([#5992](https://github.com/getsentry/sentry-java/pull/5992))
+- Apply `Sentry.withScope` and `Sentry.withIsolationScope` data to events captured inside the callback when `globalHubMode` is enabled ([#PR_NUMBER](https://github.com/getsentry/sentry-java/pull/PR_NUMBER))
+  - `globalHubMode` is enabled by default on Android, where tags, extras, contexts and level set inside the callback were silently dropped
+  - Scopes that are explicitly made current, e.g. via `Sentry.setCurrentScopes` or the `SentryContext` coroutine integration, are now also honoured when `globalHubMode` is enabled
+  - `Sentry.pushScope`, `Sentry.pushIsolationScope` and `Sentry.popScope` remain no-ops when `globalHubMode` is enabled
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Prevent duplicated breadcrumbs on tombstone-merged native crash events ([#5888](https://github.com/getsentry/sentry-java/pull/5888))
 - Prevent a class of Session Replay deadlocks by confining lifecycle state changes to Android's main thread ([#5965](https://github.com/getsentry/sentry-java/pull/5965))
 - Symbolicate tombstone native frames for libraries loaded directly from APKs ([#5992](https://github.com/getsentry/sentry-java/pull/5992))
-- Apply `Sentry.withScope` and `Sentry.withIsolationScope` data to events captured inside the callback when `globalHubMode` is enabled ([#PR_NUMBER](https://github.com/getsentry/sentry-java/pull/PR_NUMBER))
+- Apply `Sentry.withScope` and `Sentry.withIsolationScope` data to events captured inside the callback when `globalHubMode` is enabled ([#6004](https://github.com/getsentry/sentry-java/pull/6004))
   - `globalHubMode` is enabled by default on Android, where tags, extras, contexts and level set inside the callback were silently dropped
   - Scopes that are explicitly made current, e.g. via `Sentry.setCurrentScopes` or the `SentryContext` coroutine integration, are now also honoured when `globalHubMode` is enabled
   - `Sentry.pushScope`, `Sentry.pushIsolationScope` and `Sentry.popScope` remain no-ops when `globalHubMode` is enabled

--- a/sentry-kotlin-extensions/src/test/java/io/sentry/kotlin/SentryContextTest.kt
+++ b/sentry-kotlin-extensions/src/test/java/io/sentry/kotlin/SentryContextTest.kt
@@ -11,18 +11,20 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 class SentryContextTest {
-  // TODO [HSM] In global hub mode SentryContext behaves differently
-  // because Sentry.getCurrentScopes always returns rootScopes
-  // What's the desired behaviour?
+  // SentryContext makes its scopes current, which is honoured in global hub mode as well, so it
+  // isolates the same way there. Only implicit forking stays suppressed, see the last two tests.
+
+  private val dsn = "https://key@sentry.io/123"
 
   @BeforeTest
   fun init() {
-    initForTest("https://key@sentry.io/123")
+    initForTest(dsn)
   }
 
   @AfterTest
@@ -262,6 +264,46 @@ class SentryContextTest {
     val mergedContextElement = SentryContext().mergeForChild(initialContextElement)
 
     assertEquals(initialContextElement, mergedContextElement)
+  }
+
+  @Test
+  fun `current scope is isolated between coroutines in global hub mode`() = runBlocking {
+    initForTest({ it.dsn = dsn }, true)
+    Sentry.configureScope(ScopeType.CURRENT) { scope -> scope.setTag("parent", "parentValue") }
+
+    val c1 =
+      launch(SentryContext()) {
+        Sentry.configureScope(ScopeType.CURRENT) { scope -> scope.setTag("c1", "c1value") }
+        assertEquals("c1value", getTag("c1", ScopeType.CURRENT))
+        assertEquals("parentValue", getTag("parent", ScopeType.CURRENT))
+        assertNull(getTag("c2", ScopeType.CURRENT))
+      }
+    val c2 =
+      launch(SentryContext()) {
+        Sentry.configureScope(ScopeType.CURRENT) { scope -> scope.setTag("c2", "c2value") }
+        assertEquals("c2value", getTag("c2", ScopeType.CURRENT))
+        assertEquals("parentValue", getTag("parent", ScopeType.CURRENT))
+        assertNull(getTag("c1", ScopeType.CURRENT))
+      }
+    listOf(c1, c2).joinAll()
+
+    assertNotNull(getTag("parent", ScopeType.CURRENT))
+    assertNull(getTag("c1", ScopeType.CURRENT))
+    assertNull(getTag("c2", ScopeType.CURRENT))
+  }
+
+  @Test
+  fun `coroutines without SentryContext share the root scopes in global hub mode`() = runBlocking {
+    initForTest({ it.dsn = dsn }, true)
+    Sentry.configureScope(ScopeType.CURRENT) { scope -> scope.setTag("parent", "parentValue") }
+
+    launch(Dispatchers.Default) {
+        assertEquals("parentValue", getTag("parent", ScopeType.CURRENT))
+        Sentry.configureScope(ScopeType.CURRENT) { scope -> scope.setTag("child", "childValue") }
+      }
+      .join()
+
+    assertEquals("childValue", getTag("child", ScopeType.CURRENT))
   }
 
   private fun getTag(tag: String, scopeType: ScopeType = ScopeType.ISOLATION): String? {

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/webflux/SentryWebfluxIntegrationTest.kt
@@ -127,11 +127,14 @@ class SentryWebfluxIntegrationTest {
       .expectStatus()
       .isOk
 
-    verify(transport)
-      .send(
-        checkTransaction { event -> assertEquals("GET /hello", event.transaction) },
-        anyOrNull(),
-      )
+    // the transaction is finished asynchronously, after the response has been sent
+    await.untilAsserted {
+      verify(transport)
+        .send(
+          checkTransaction { event -> assertEquals("GET /hello", event.transaction) },
+          anyOrNull(),
+        )
+    }
   }
 }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
@@ -127,11 +127,14 @@ class SentryWebfluxIntegrationTest {
       .expectStatus()
       .isOk
 
-    verify(transport)
-      .send(
-        checkTransaction { event -> assertEquals("GET /hello", event.transaction) },
-        anyOrNull(),
-      )
+    // the transaction is finished asynchronously, after the response has been sent
+    await.untilAsserted {
+      verify(transport)
+        .send(
+          checkTransaction { event -> assertEquals("GET /hello", event.transaction) },
+          anyOrNull(),
+        )
+    }
   }
 }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -114,21 +114,24 @@ public final class Sentry {
   @ApiStatus.Internal
   @SuppressWarnings("deprecation")
   public static @NotNull IScopes getCurrentScopes(final boolean ensureForked) {
+    // read the volatile rootScopes once, so a concurrent Sentry.init cannot make the check below
+    // disagree with what we return
+    final @NotNull IScopes root = rootScopes;
     @Nullable IScopes scopes = getScopesStorage().get();
     if (globalHubMode) {
       // in global hub mode we never fork implicitly, but scopes that have explicitly been made
       // current (e.g. by withScope) must still be honoured. Anything that did not originate from
       // the present rootScopes is stale (SDK closed or re-initialized) and gets ignored.
-      if (scopes != null && !scopes.isNoOp() && rootScopes.isAncestorOf(scopes)) {
+      if (scopes != null && !scopes.isNoOp() && root.isAncestorOf(scopes)) {
         return scopes;
       }
-      return rootScopes;
+      return root;
     }
     if (scopes == null || scopes.isNoOp()) {
       if (!ensureForked) {
         return NoOpScopes.getInstance();
       } else {
-        scopes = rootScopes.forkedScopes("getCurrentScopes");
+        scopes = root.forkedScopes("getCurrentScopes");
         getScopesStorage().set(scopes);
       }
     }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -114,10 +114,16 @@ public final class Sentry {
   @ApiStatus.Internal
   @SuppressWarnings("deprecation")
   public static @NotNull IScopes getCurrentScopes(final boolean ensureForked) {
+    @Nullable IScopes scopes = getScopesStorage().get();
     if (globalHubMode) {
+      // in global hub mode we never fork implicitly, but scopes that have explicitly been made
+      // current (e.g. by withScope) must still be honoured. Anything that did not originate from
+      // the present rootScopes is stale (SDK closed or re-initialized) and gets ignored.
+      if (scopes != null && !scopes.isNoOp() && rootScopes.isAncestorOf(scopes)) {
+        return scopes;
+      }
       return rootScopes;
     }
-    @Nullable IScopes scopes = getScopesStorage().get();
     if (scopes == null || scopes.isNoOp()) {
       if (!ensureForked) {
         return NoOpScopes.getInstance();
@@ -1060,7 +1066,13 @@ public final class Sentry {
     return getCurrentScopes().getLastEventId();
   }
 
-  /** Pushes a new scope while inheriting the current scope's data. */
+  /**
+   * Pushes a new scope while inheriting the current scope's data.
+   *
+   * <p>This is a no-op in global hub mode, as the caller may never pop the scope again, or pop it
+   * on a different thread, which would corrupt the globally shared scopes. Use {@link
+   * Sentry#withScope(ScopeCallback)} if you need forking that also works in global hub mode.
+   */
   public static @NotNull ISentryLifecycleToken pushScope() {
     // pushScope is no-op in global hub mode
     if (!globalHubMode) {
@@ -1069,7 +1081,12 @@ public final class Sentry {
     return NoOpScopesLifecycleToken.getInstance();
   }
 
-  /** Pushes a new isolation and current scope while inheriting the current scope's data. */
+  /**
+   * Pushes a new isolation and current scope while inheriting the current scope's data.
+   *
+   * <p>This is a no-op in global hub mode, for the same reason as {@link Sentry#pushScope()}. Use
+   * {@link Sentry#withIsolationScope(ScopeCallback)} instead.
+   */
   public static @NotNull ISentryLifecycleToken pushIsolationScope() {
     // pushScope is no-op in global hub mode
     if (!globalHubMode) {
@@ -1093,7 +1110,10 @@ public final class Sentry {
   }
 
   /**
-   * Runs the callback with a new current scope which gets dropped at the end
+   * Runs the callback with a new current scope which gets dropped at the end.
+   *
+   * <p>Unlike {@link Sentry#pushScope()} this also forks in global hub mode, since the previous
+   * scopes are always restored once the callback returns.
    *
    * @param callback the callback
    */
@@ -1104,6 +1124,9 @@ public final class Sentry {
   /**
    * Runs the callback with a new isolation scope which gets dropped at the end. Current scope is
    * also forked.
+   *
+   * <p>Unlike {@link Sentry#pushIsolationScope()} this also forks in global hub mode, since the
+   * previous scopes are always restored once the callback returns.
    *
    * @param callback the callback
    */

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.SentryFeedbackOptions.IFormHandler
 import io.sentry.SentryOptions.ProfilesSamplerCallback
 import io.sentry.SentryOptions.TracesSamplerCallback
@@ -1432,6 +1433,93 @@ class SentryTest {
     val s1 = Sentry.forkedRootScopes("s1")
     val s2 = Sentry.forkedRootScopes("s2")
     assertNotSame(s1, s2)
+  }
+
+  private fun initCapturingEvents(globalHubMode: Boolean): MutableList<SentryEvent> {
+    val events = mutableListOf<SentryEvent>()
+    initForTest(
+      { o ->
+        o.dsn = dsn
+        o.beforeSend = SentryOptions.BeforeSendCallback { event, _ ->
+          events.add(event)
+          null
+        }
+      },
+      globalHubMode,
+    )
+    return events
+  }
+
+  @Test
+  fun `withScope data is applied to events captured inside the callback`() {
+    for (globalHubMode in listOf(false, true)) {
+      val events = initCapturingEvents(globalHubMode)
+
+      Sentry.withScope { scope ->
+        scope.setTag("http-url", "https://example.com")
+        Sentry.captureException(RuntimeException("failed"))
+      }
+
+      assertThat(events.single().tags).containsEntry("http-url", "https://example.com")
+    }
+  }
+
+  @Test
+  fun `withIsolationScope data is applied to events captured inside the callback`() {
+    for (globalHubMode in listOf(false, true)) {
+      val events = initCapturingEvents(globalHubMode)
+
+      Sentry.withIsolationScope { scope ->
+        scope.setTag("http-url", "https://example.com")
+        Sentry.captureException(RuntimeException("failed"))
+      }
+
+      assertThat(events.single().tags).containsEntry("http-url", "https://example.com")
+    }
+  }
+
+  @Test
+  fun `withScope data does not leak into events captured after the callback`() {
+    for (globalHubMode in listOf(false, true)) {
+      val events = initCapturingEvents(globalHubMode)
+
+      Sentry.withScope { scope -> scope.setTag("http-url", "https://example.com") }
+      Sentry.captureException(RuntimeException("failed"))
+
+      assertThat(events.single().tags?.get("http-url")).isNull()
+    }
+  }
+
+  @Test
+  fun `in globalHubMode scopes are not forked for a thread that has none`() {
+    initForTest({ o -> o.dsn = dsn }, true)
+
+    val fromOtherThread = CompletableFuture.supplyAsync { Sentry.getCurrentScopes() }.get()
+
+    assertSame(Sentry.getCurrentScopes(), fromOtherThread)
+  }
+
+  @Test
+  fun `in globalHubMode scopes left over from a closed SDK are ignored`() {
+    initForTest({ o -> o.dsn = dsn }, true)
+    val stale = Sentry.forkedCurrentScope("stale")
+
+    Sentry.close()
+    // close only clears the storage of the calling thread, other threads may still hold stale ones
+    Sentry.setCurrentScopes(stale)
+
+    assertTrue(Sentry.getCurrentScopes().isNoOp)
+  }
+
+  @Test
+  fun `in globalHubMode scopes left over from a previous init are ignored`() {
+    initForTest({ o -> o.dsn = dsn }, true)
+    val stale = Sentry.forkedCurrentScope("stale")
+
+    initForTest({ o -> o.dsn = dsn }, true)
+    Sentry.setCurrentScopes(stale)
+
+    assertNotSame(stale, Sentry.getCurrentScopes())
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

`Sentry.withScope` forks the current scope and makes it current, but `Sentry.getCurrentScopes` short-circuited to `rootScopes` when `globalHubMode` was enabled, so the fork was never read back. Everything set inside the callback was silently dropped.

Honour scopes that were explicitly made current, as long as they descend from the current `rootScopes`. Implicit forking stays suppressed. `pushScope` and `popScope` remain no-ops, since they are unbalanced.

## :bulb: Motivation and Context

`globalHubMode` is on by default on Android, so this affected all Android users since 8.0.0.

* resolves: #5339
* resolves: JAVA-489

## :green_heart: How did you test it?

Unit tests in `SentryTest.kt`, run for `globalHubMode` both `true` and `false`. Verified they fail without the fix.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Hybrid SDKs relying on `withScope` being a no-op under `globalHubMode` should be made aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
