### PR TITLE
fix(android): Break the app start extension lock-ordering deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Prevent duplicated breadcrumbs on tombstone-merged native crash events ([#5888](https://github.com/getsentry/sentry-java/pull/5888))
 - Prevent a class of Session Replay deadlocks by confining lifecycle state changes to Android's main thread ([#5965](https://github.com/getsentry/sentry-java/pull/5965))
 - Symbolicate tombstone native frames for libraries loaded directly from APKs ([#5992](https://github.com/getsentry/sentry-java/pull/5992))
+- Prevent a deadlock between the app start extension and the Android performance event processor ([#6007](https://github.com/getsentry/sentry-java/pull/6007))
 
 ### Features
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartExtension.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartExtension.java
@@ -108,11 +108,14 @@ public final class AppStartExtension implements IAppStartExtender {
 
   @Override
   public void finishExtendedAppStart() {
+    final @Nullable ISpan span;
     try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-      final @Nullable ISpan span = extendedSpan;
-      if (span != null && !span.isFinished()) {
-        span.finish(SpanStatus.OK);
-      }
+      span = extendedSpan;
+    }
+    // Finishing runs outside the lock, see the note on finishTransaction. Span.finish() guards
+    // itself with a CAS, so racing callers cannot finish it twice.
+    if (span != null && !span.isFinished()) {
+      span.finish(SpanStatus.OK);
     }
   }
 
@@ -145,15 +148,20 @@ public final class AppStartExtension implements IAppStartExtender {
   }
 
   public void finishTransaction(final @NotNull SentryDate endTimestamp) {
+    final @Nullable ITransaction transaction;
+    final @NotNull SentryDate end;
     try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-      final @Nullable ITransaction transaction = extendedTransaction;
-      if (transaction != null && !transaction.isFinished()) {
-        final @Nullable ISpan span = extendedSpan;
-        final @Nullable SentryDate spanEnd = span == null ? null : span.getFinishDate();
-        final @NotNull SentryDate end =
-            spanEnd != null && spanEnd.isAfter(endTimestamp) ? spanEnd : endTimestamp;
-        transaction.finish(SpanStatus.OK, end);
-      }
+      transaction = extendedTransaction;
+      final @Nullable ISpan span = extendedSpan;
+      final @Nullable SentryDate spanEnd = span == null ? null : span.getFinishDate();
+      end = spanEnd != null && spanEnd.isAfter(endTimestamp) ? spanEnd : endTimestamp;
+    }
+    // Finishing has to run outside the lock: it captures the transaction synchronously, which runs
+    // PerformanceAndroidEventProcessor, which calls back into isExtended()/getExtendedEndTime()
+    // while holding its own lock. Holding this lock across the call would let the two locks be
+    // taken in opposite orders and deadlock.
+    if (transaction != null && !transaction.isFinished()) {
+      transaction.finish(SpanStatus.OK, end);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartExtension.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartExtension.java
@@ -34,6 +34,10 @@ public final class AppStartExtension implements IAppStartExtender {
 
   private final @NotNull AppStartMetrics metrics;
   private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
+  // Serializes the two finish paths against each other. Deliberately separate from `lock`:
+  // finishing re-enters the SDK and that re-entrant path takes `lock`, so the finish cannot run
+  // under `lock` (see finishTransaction). When both are held the order is finishLock, then `lock`.
+  private final @NotNull AutoClosableReentrantLock finishLock = new AutoClosableReentrantLock();
 
   private @Nullable ExtendAppStartListener extendAppStartListener;
   // We hold onto both the span and its transaction because they mean different things and finish
@@ -108,14 +112,15 @@ public final class AppStartExtension implements IAppStartExtender {
 
   @Override
   public void finishExtendedAppStart() {
-    final @Nullable ISpan span;
-    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-      span = extendedSpan;
-    }
-    // Finishing runs outside the lock, see the note on finishTransaction. Span.finish() guards
-    // itself with a CAS, so racing callers cannot finish it twice.
-    if (span != null && !span.isFinished()) {
-      span.finish(SpanStatus.OK);
+    try (final @NotNull ISentryLifecycleToken ignoredFinish = finishLock.acquire()) {
+      final @Nullable ISpan span;
+      try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+        span = extendedSpan;
+      }
+      // Finishing runs outside `lock`, see the note on finishTransaction.
+      if (span != null && !span.isFinished()) {
+        span.finish(SpanStatus.OK);
+      }
     }
   }
 
@@ -148,20 +153,24 @@ public final class AppStartExtension implements IAppStartExtender {
   }
 
   public void finishTransaction(final @NotNull SentryDate endTimestamp) {
-    final @Nullable ITransaction transaction;
-    final @NotNull SentryDate end;
-    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-      transaction = extendedTransaction;
-      final @Nullable ISpan span = extendedSpan;
-      final @Nullable SentryDate spanEnd = span == null ? null : span.getFinishDate();
-      end = spanEnd != null && spanEnd.isAfter(endTimestamp) ? spanEnd : endTimestamp;
-    }
-    // Finishing has to run outside the lock: it captures the transaction synchronously, which runs
+    // Finishing has to run outside `lock`: it captures the transaction synchronously, which runs
     // PerformanceAndroidEventProcessor, which calls back into isExtended()/getExtendedEndTime()
-    // while holding its own lock. Holding this lock across the call would let the two locks be
-    // taken in opposite orders and deadlock.
-    if (transaction != null && !transaction.isFinished()) {
-      transaction.finish(SpanStatus.OK, end);
+    // while holding its own lock. Holding `lock` across the call would let the two be taken in
+    // opposite orders and deadlock. finishLock still serializes this against
+    // finishExtendedAppStart, so the end-time clamp below and the finish stay atomic.
+    try (final @NotNull ISentryLifecycleToken ignoredFinish = finishLock.acquire()) {
+      final @Nullable ITransaction transaction;
+      final @Nullable ISpan span;
+      try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+        transaction = extendedTransaction;
+        span = extendedSpan;
+      }
+      if (transaction != null && !transaction.isFinished()) {
+        final @Nullable SentryDate spanEnd = span == null ? null : span.getFinishDate();
+        final @NotNull SentryDate end =
+            spanEnd != null && spanEnd.isAfter(endTimestamp) ? spanEnd : endTimestamp;
+        transaction.finish(SpanStatus.OK, end);
+      }
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppStartExtensionTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppStartExtensionTest.kt
@@ -8,6 +8,9 @@ import io.sentry.SentryLongDate
 import io.sentry.SentryNanotimeDate
 import io.sentry.SpanStatus
 import io.sentry.android.core.performance.AppStartMetrics
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,6 +20,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -32,6 +36,26 @@ class AppStartExtensionTest {
   private fun extension(windowOpen: Boolean = true): AppStartExtension {
     whenever(metrics.canExtendAppStart()).thenReturn(windowOpen)
     return AppStartExtension(metrics)
+  }
+
+  private class ReentrantCall(val run: () -> Unit, val succeeded: AtomicBoolean)
+
+  /**
+   * Runs [call] on another thread and records whether it completed while the caller is still inside
+   * the stubbed method. Used to prove a lock is not held across that call.
+   */
+  private fun reentrantCallDuring(call: () -> Unit): ReentrantCall {
+    val succeeded = AtomicBoolean(false)
+    val done = CountDownLatch(1)
+    val run = {
+      Thread {
+          call()
+          done.countDown()
+        }
+        .start()
+      succeeded.set(done.await(2, TimeUnit.SECONDS))
+    }
+    return ReentrantCall(run, succeeded)
   }
 
   /** Simulates the integration's listener: hands a transaction + span back to the extension. */
@@ -121,6 +145,40 @@ class AppStartExtensionTest {
     ext.extendAppStart()
     ext.finishExtendedAppStart()
     verify(span, never()).finish(any<SpanStatus>())
+  }
+
+  @Test
+  fun `finishExtendedAppStart releases the lock before finishing the span`() {
+    val ext = extension(windowOpen = true)
+    val span = mock<ISpan>()
+    ext.registerHandOver(span = span)
+    ext.extendAppStart()
+
+    // Finishing the real span captures the transaction synchronously, which runs
+    // PerformanceAndroidEventProcessor, which calls back into the extension while holding its own
+    // lock. Holding this lock across the finish lets the two be taken in opposite orders and
+    // deadlock, so require another thread to get through the extension lock during the finish.
+    val reentered = reentrantCallDuring { ext.isExtended }
+    doAnswer { reentered.run() }.whenever(span).finish(any<SpanStatus>())
+
+    ext.finishExtendedAppStart()
+
+    assertTrue(reentered.succeeded.get(), "extension lock was held while finishing the span")
+  }
+
+  @Test
+  fun `finishTransaction releases the lock before finishing the transaction`() {
+    val ext = extension(windowOpen = true)
+    val txn = mock<ITransaction>()
+    ext.registerHandOver(txn = txn)
+    ext.extendAppStart()
+
+    val reentered = reentrantCallDuring { ext.isExtended }
+    doAnswer { reentered.run() }.whenever(txn).finish(any<SpanStatus>(), any())
+
+    ext.finishTransaction(SentryNanotimeDate())
+
+    assertTrue(reentered.succeeded.get(), "extension lock was held while finishing the transaction")
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppStartExtensionTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppStartExtensionTest.kt
@@ -182,6 +182,34 @@ class AppStartExtensionTest {
   }
 
   @Test
+  fun `finishTransaction and finishExtendedAppStart do not interleave`() {
+    val ext = extension(windowOpen = true)
+    val txn = mock<ITransaction>()
+    val span = mock<ISpan>()
+    ext.registerHandOver(txn = txn, span = span)
+    ext.extendAppStart()
+
+    // The end-time clamp in finishTransaction reads the span's finish date and then finishes the
+    // transaction. If finishExtendedAppStart can finish the span in between, the transaction is
+    // captured with an end earlier than its own child span.
+    val spanFinished = AtomicBoolean(false)
+    val interleaved = AtomicBoolean(false)
+    doAnswer { spanFinished.set(true) }.whenever(span).finish(any<SpanStatus>())
+    doAnswer {
+        val other = Thread { ext.finishExtendedAppStart() }
+        other.start()
+        other.join(1_000)
+        interleaved.set(spanFinished.get())
+      }
+      .whenever(txn)
+      .finish(any<SpanStatus>(), any())
+
+    ext.finishTransaction(SentryNanotimeDate())
+
+    assertFalse(interleaved.get(), "the extended span was finished mid-finishTransaction")
+  }
+
+  @Test
   fun `isActive reflects the transaction state`() {
     val ext = extension(windowOpen = true)
     assertFalse(ext.isActive)


### PR DESCRIPTION
## :scroll: Description

`AppStartExtension` held its own lock while calling `finish()` on the extended span (`finishExtendedAppStart`) and on the standalone `app.start` transaction (`finishTransaction`). This reads the fields under that lock and performs the finish outside it, and serializes the two finish paths with a separate `finishLock` that the re-entrant capture path never acquires.

## :bulb: Motivation and Context

Finishing captures the transaction **synchronously** — `SentryTracer.finish()` calls `scopes.captureTransaction(...)` on the calling thread, which runs `PerformanceAndroidEventProcessor.process()`. That processor takes its own lock and then calls back into `AppStartExtension`. So the two locks are acquired in opposite orders:

| Side | Where, at `cc59f486da` |
|---|---|
| extension lock → processor lock | `AppStartExtension.finishExtendedAppStart():111` and `finishTransaction():148` hold the lock across `span.finish()` / `transaction.finish()`, which capture re-entrantly |
| processor lock → extension lock | `PerformanceAndroidEventProcessor.process()` acquires its lock at :82, then calls `extension.isExtended()` at :112 and `getExtendedEndTime()` at :113 inside it |

Both halves were introduced together in #5604, first released in 8.48.0.

The collision window is the one the feature is built around: the app calls `Sentry.finishExtendedAppStart()` just as the app start deadline fires on the Sentry timer thread. If the app finishes the extended app start on the main thread, this is an ANR.

### Why a second lock

Moving the finish out of `lock` on its own would let `finishTransaction` and `finishExtendedAppStart` interleave, which the bugbot reviews correctly caught. `finishTransaction` reads the extended span's finish date to clamp the transaction end, so a span finishing between that read and `transaction.finish()` captures the transaction with an end earlier than its own child — and both paths could enter `SentryTracer.finish` concurrently, which is not guarded (`hasAllChildrenFinished()` treats a span with a finish date but `isFinished() == false` as finished, so two callers can pass the same guard).

`finishLock` restores that mutual exclusion. It is never acquired by the re-entrant capture path, so it cannot participate in the cycle. Order when both are held: `finishLock`, then `lock`.

This restores parity with the original code rather than perfection — a caller that finishes the span directly via `getExtendedAppStartSpan()` bypasses both locks, exactly as it did before.

## :bar_chart: Evidence in production

`sdk-crashes-java`, last 90 days — ANR events with `AppStartExtension` on the stack:

| Release | ANR events | Customer projects |
|---|---|---|
| 8.48.0 | 13 | 4 |
| 8.49.0 | 751 | 4 |
| 8.50.0 / 8.50.1 | 4 | 3 |
| 8.51.0 | 16 | 6 |

The series starts at 8.48.0 — the release that shipped #5604.

**Blocked waiting for the lock** — [SDK-CRASHES-JAVA-5MBP](https://sentry.sentry.io/issues/SDK-CRASHES-JAVA-5MBP), main thread, foreground app start, SDK 8.49.0:

```
ActivityLifecycleIntegration.onFirstFrameDrawn(:812)
  ActivityLifecycleIntegration.finishAppStartSpan(:992)
    AppStartExtension.finishTransaction(AppStartExtension.java:148)
      AutoClosableReentrantLock.acquire(:37)
        ReentrantLock.lock(:323)   <- parked
```

In the `8.49.0` tag, `AppStartExtension.java:148` is the `lock.acquire()` this PR moves work out of.

**Holding the lock** — [SDK-CRASHES-JAVA-5MEQ](https://sentry.sentry.io/issues/SDK-CRASHES-JAVA-5MEQ), 87 occurrences:

```
AppStartMetrics.lambda$scheduleHeadlessAppStartCheckOnMain$0
  AppStartExtension.finishTransaction
    SentryTracer.finish -> SentryTracer.finish
```

These events contain only the main thread, so the full cycle is not directly visible. What is confirmed is the mechanism this PR removes: the extension lock held across `transaction.finish()`, with real users' main threads blocking on it until the OS files an ANR.

## :green_heart: How did you test it?

Three regression tests in `AppStartExtensionTest`:

- two that stub `finish()` to re-enter the extension from another thread and require that call to complete while the finish is in flight — both fail on `main`, where the lock is held across the finish
- one that requires `finishTransaction` and `finishExtendedAppStart` not to interleave — fails against the first commit of this PR, which is the regression the bugbot reviews found

Full `:sentry-android-core:testReleaseUnitTest` passes.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

`extendAppStart()` still calls the listener under the lock. That path does not capture, so it is not part of this cycle.
