### PR TITLE
docs: Add a concurrency section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,54 @@ Apply that pattern only where a broad catch is genuinely unavoidable — an entr
 arbitrary user code or third-party callbacks. Everywhere else, name the exception types. Say in the
 PR description why the broad catch is necessary.
 
+### Concurrency
+
+**Never hold a lock across a call that can re-enter the SDK.** Read what you need under the lock,
+release it, then make the call.
+
+Finishing a span or transaction, capturing an event, and invoking a user-supplied callback all run
+arbitrary SDK code on the calling thread. `SentryTracer.finish()` calls `scopes.captureTransaction(...)`
+synchronously, which runs every registered `EventProcessor` — and those processors take their own
+locks and call back into SDK components. A lock held across such a call is therefore acquired in the
+opposite order from the processor's, which is a deadlock. On Android the blocked thread is usually
+the main thread, so it surfaces to users as an ANR rather than a hang.
+
+```java
+// Wrong: the lock is held while finish() captures the transaction and runs event processors,
+// which take their own lock and then call back into this class.
+try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+  final @Nullable ITransaction transaction = ownedTransaction;
+  if (transaction != null && !transaction.isFinished()) {
+    transaction.finish(SpanStatus.OK);
+  }
+}
+
+// Right: read the field under the lock, call finish() outside it.
+final @Nullable ITransaction transaction;
+try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+  transaction = ownedTransaction;
+}
+if (transaction != null && !transaction.isFinished()) {
+  transaction.finish(SpanStatus.OK);
+}
+```
+
+The same applies to logging through `options.getLogger()`, invoking a listener, and any
+`ISpan`/`IScopes` call reachable from a component that locks.
+
+Moving the call out can break a compound operation that was atomic only because the lock spanned
+it. When that happens, do not widen the original lock again — serialize the callers with a second
+lock that the re-entrant path never acquires, and document the order the two are taken in.
+
+Two more rules that catch most of the rest:
+
+- **Mark a field `volatile` when it is written on one thread and read on another without a lock.**
+  A plain field read is a data race, not merely a stale value.
+- **Read mutable shared state once per operation.** Re-reading the same field for several
+  decisions in one pass lets it change mid-pass, so the results disagree with each other.
+
+Prefer `AutoClosableReentrantLock` over `synchronized`, matching the rest of the codebase.
+
 ### Testing Requirements
 - Write comprehensive unit tests for new features
 - Android modules require both unit tests and instrumented tests where applicable


### PR DESCRIPTION
## :scroll: Description

Adds a **Concurrency** section to `AGENTS.md`, next to the existing exception-handling guidance. The core rule: never hold a lock across a call that can re-enter the SDK — read what you need under the lock, release it, then make the call.

Also covers the second-lock escape hatch for compound operations that were only atomic because the lock spanned them, plus two supporting rules (`volatile` for cross-thread fields, and reading mutable shared state once per operation).

## :bulb: Motivation and Context

Requested by @buenaflor while reviewing #6007.

Two production ANRs came from the same mistake. In #6007, `AppStartExtension` held its lock while calling `finish()` on the app start transaction; finishing captures synchronously and runs `PerformanceAndroidEventProcessor`, which takes its own lock and then calls back into `AppStartExtension` — opposite lock order, main thread blocked, ANR. JAVA-553 was the same shape in `ReplayIntegration`. The `volatile` and single-read rules come from #6006, where `AppStartMetrics.appStartType` was read three times in one pass and could disagree with itself.

The exception-handling section already establishes the format for this kind of repository-wide rule, so this follows it: the rule, why it fails, a wrong/right code pair, and the scope.

## :green_heart: How did you test it?

Documentation only. `./gradlew spotlessApply` is clean.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Independent of #6007 — this documents the rule, that PR fixes the instance.

#skip-changelog
