### PR TITLE
fix(android): Treat an unpopulated connection cache as stale (JAVA-717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update `SentryTraced` so that it now honors `options.setIgnoredSpanOrigins` ([#6058](https://github.com/getsentry/sentry-java/pull/6058))
 - `SentryTraced` now checks for its owning transaction dynamically rather than once per app process. The latter caused `SentryTraced` spans to be dropped process-wide once the original transaction finished ([#6057](https://github.com/getsentry/sentry-java/pull/6057))
 - Fix typos in Spring GraphQL integration names (`GrahQL` to `GraphQL`) ([#6061](https://github.com/getsentry/sentry-java/pull/6061))
+- Populate the Android connection status cache during the first two minutes after boot, instead of treating the empty cache as up to date ([#6029](https://github.com/getsentry/sentry-java/pull/6029))
 
 ### Internal
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -35,7 +35,6 @@ import io.sentry.android.core.internal.debugmeta.AssetsDebugMetaLoader;
 import io.sentry.android.core.internal.gestures.AndroidViewGestureTargetLocator;
 import io.sentry.android.core.internal.modules.AssetsModulesLoader;
 import io.sentry.android.core.internal.util.AndroidConnectionStatusProvider;
-import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.android.core.performance.AppStartMetrics;
@@ -178,7 +177,7 @@ final class AndroidOptionsInitializer {
     if (options.getConnectionStatusProvider() instanceof NoOpConnectionStatusProvider) {
       options.setConnectionStatusProvider(
           new AndroidConnectionStatusProvider(
-              context, options, buildInfoProvider, AndroidCurrentDateProvider.getInstance()));
+              context, options, buildInfoProvider, options.getMonotonicTicker()));
     }
 
     if (options.getCacheDirPath() != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
@@ -19,10 +19,12 @@ import io.sentry.SentryOptions;
 import io.sentry.android.core.AppState;
 import io.sentry.android.core.BuildInfoProvider;
 import io.sentry.android.core.ContextUtils;
-import io.sentry.transport.ICurrentDateProvider;
+import io.sentry.time.Deadline;
+import io.sentry.time.MonotonicTicker;
 import io.sentry.util.AutoClosableReentrantLock;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -41,7 +43,7 @@ public final class AndroidConnectionStatusProvider
   private final @NotNull Context context;
   private final @NotNull SentryOptions options;
   private final @NotNull BuildInfoProvider buildInfoProvider;
-  private final @NotNull ICurrentDateProvider timeProvider;
+  private final @NotNull MonotonicTicker ticker;
   private final @NotNull List<IConnectionStatusObserver> connectionStatusObservers;
   private final @Nullable Handler handler;
   private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
@@ -66,16 +68,16 @@ public final class AndroidConnectionStatusProvider
 
   private volatile @Nullable NetworkCapabilities cachedNetworkCapabilities;
   private volatile @Nullable Network currentNetwork;
-  private volatile long lastCacheUpdateTime = 0;
-  private static final long CACHE_TTL_MS = 2 * 60 * 1000L; // 2 minutes
+  private volatile @NotNull Deadline cacheFreshUntil;
+  private static final long CACHE_TTL_MINUTES = 2;
   private final @NotNull AtomicBoolean isConnected = new AtomicBoolean(false);
 
   public AndroidConnectionStatusProvider(
       @NotNull Context context,
       @NotNull SentryOptions options,
       @NotNull BuildInfoProvider buildInfoProvider,
-      @NotNull ICurrentDateProvider timeProvider) {
-    this(context, options, buildInfoProvider, timeProvider, null);
+      @NotNull MonotonicTicker ticker) {
+    this(context, options, buildInfoProvider, ticker, null);
   }
 
   @SuppressLint("InlinedApi")
@@ -83,12 +85,13 @@ public final class AndroidConnectionStatusProvider
       @NotNull Context context,
       @NotNull SentryOptions options,
       @NotNull BuildInfoProvider buildInfoProvider,
-      @NotNull ICurrentDateProvider timeProvider,
+      @NotNull MonotonicTicker ticker,
       @Nullable Handler handler) {
     this.context = ContextUtils.getApplicationContext(context);
     this.options = options;
     this.buildInfoProvider = buildInfoProvider;
-    this.timeProvider = timeProvider;
+    this.ticker = ticker;
+    this.cacheFreshUntil = Deadline.passed(ticker);
     this.handler = handler;
     this.connectionStatusObservers = new ArrayList<>();
 
@@ -231,7 +234,7 @@ public final class AndroidConnectionStatusProvider
               try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
                 cachedNetworkCapabilities = null;
                 currentNetwork = null;
-                lastCacheUpdateTime = timeProvider.getCurrentTimeMillis();
+                cacheFreshUntil = Deadline.after(ticker, CACHE_TTL_MINUTES, TimeUnit.MINUTES);
 
                 options
                     .getLogger()
@@ -362,13 +365,13 @@ public final class AndroidConnectionStatusProvider
                     SentryLevel.INFO,
                     "No permission (ACCESS_NETWORK_STATE) to check network status.");
             cachedNetworkCapabilities = null;
-            lastCacheUpdateTime = timeProvider.getCurrentTimeMillis();
+            cacheFreshUntil = Deadline.after(ticker, CACHE_TTL_MINUTES, TimeUnit.MINUTES);
             return;
           }
 
           if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.M) {
             cachedNetworkCapabilities = null;
-            lastCacheUpdateTime = timeProvider.getCurrentTimeMillis();
+            cacheFreshUntil = Deadline.after(ticker, CACHE_TTL_MINUTES, TimeUnit.MINUTES);
             return;
           }
 
@@ -387,7 +390,7 @@ public final class AndroidConnectionStatusProvider
                 null; // Clear cached capabilities if connectivity manager is null
           }
         }
-        lastCacheUpdateTime = timeProvider.getCurrentTimeMillis();
+        cacheFreshUntil = Deadline.after(ticker, CACHE_TTL_MINUTES, TimeUnit.MINUTES);
 
         options
             .getLogger()
@@ -400,13 +403,13 @@ public final class AndroidConnectionStatusProvider
       } catch (Throwable t) {
         options.getLogger().log(SentryLevel.WARNING, "Failed to update connection status cache", t);
         cachedNetworkCapabilities = null;
-        lastCacheUpdateTime = timeProvider.getCurrentTimeMillis();
+        cacheFreshUntil = Deadline.after(ticker, CACHE_TTL_MINUTES, TimeUnit.MINUTES);
       }
     }
   }
 
   private boolean isCacheValid() {
-    return (timeProvider.getCurrentTimeMillis() - lastCacheUpdateTime) < CACHE_TTL_MS;
+    return !cacheFreshUntil.hasPassed();
   }
 
   @Override
@@ -459,7 +462,7 @@ public final class AndroidConnectionStatusProvider
       // Clear cached state
       cachedNetworkCapabilities = null;
       currentNetwork = null;
-      lastCacheUpdateTime = 0;
+      cacheFreshUntil = Deadline.passed(ticker);
     }
     options.getLogger().log(SentryLevel.DEBUG, "Network callback unregistered");
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProviderTest.kt
@@ -144,6 +144,10 @@ class AndroidConnectionStatusProviderTest {
   @Test
   fun `When network is active but not connected with permission, return DISCONNECTED for isConnected`() {
     whenever(networkInfo.isConnected).thenReturn(false)
+    // buildInfo reports API 24, so the provider reads NetworkCapabilities rather than the legacy
+    // activeNetworkInfo. The active network has to report it cannot reach the internet too.
+    whenever(networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET)).thenReturn(false)
+    whenever(networkCapabilities.hasCapability(NET_CAPABILITY_VALIDATED)).thenReturn(false)
 
     assertEquals(
       IConnectionStatusProvider.ConnectionStatus.DISCONNECTED,

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProviderTest.kt
@@ -26,7 +26,8 @@ import io.sentry.android.core.BuildInfoProvider
 import io.sentry.android.core.ContextUtils
 import io.sentry.android.core.SystemEventsBreadcrumbsIntegration
 import io.sentry.test.ImmediateExecutorService
-import io.sentry.transport.ICurrentDateProvider
+import io.sentry.time.TestMonotonicTicker
+import java.util.concurrent.TimeUnit.MINUTES
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -61,14 +62,12 @@ class AndroidConnectionStatusProviderTest {
   private lateinit var connectivityManager: ConnectivityManager
   private lateinit var networkInfo: NetworkInfo
   private lateinit var buildInfo: BuildInfoProvider
-  private lateinit var timeProvider: ICurrentDateProvider
+  private lateinit var ticker: TestMonotonicTicker
   private lateinit var options: SentryOptions
   private lateinit var network: Network
   private lateinit var networkCapabilities: NetworkCapabilities
   private lateinit var logger: ILogger
   private lateinit var contextUtilsStaticMock: MockedStatic<ContextUtils>
-
-  private var currentTime = 1000L
 
   @BeforeTest
   fun beforeTest() {
@@ -96,16 +95,12 @@ class AndroidConnectionStatusProviderTest {
     whenever(networkCapabilities.hasCapability(NET_CAPABILITY_VALIDATED)).thenReturn(true)
     whenever(networkCapabilities.hasTransport(TRANSPORT_WIFI)).thenReturn(true)
 
-    timeProvider = mock()
-    whenever(timeProvider.currentTimeMillis).thenAnswer { currentTime }
+    ticker = TestMonotonicTicker()
 
     logger = mock()
     options = SentryOptions()
     options.setLogger(logger)
     options.executorService = ImmediateExecutorService()
-
-    // Reset current time for each test to ensure cache isolation
-    currentTime = 1000L
 
     // Mock ContextUtils to return foreground importance
     contextUtilsStaticMock = mockStatic(ContextUtils::class.java)
@@ -120,7 +115,7 @@ class AndroidConnectionStatusProviderTest {
     AppState.getInstance().registerLifecycleObserver(options)
 
     connectionStatusProvider =
-      AndroidConnectionStatusProvider(contextMock, options, buildInfo, timeProvider)
+      AndroidConnectionStatusProvider(contextMock, options, buildInfo, ticker)
   }
 
   @AfterTest
@@ -199,7 +194,7 @@ class AndroidConnectionStatusProviderTest {
 
     // Create a new provider with the null connectivity manager
     val providerWithNullConnectivity =
-      AndroidConnectionStatusProvider(nullConnectivityContext, options, buildInfo, timeProvider)
+      AndroidConnectionStatusProvider(nullConnectivityContext, options, buildInfo, ticker)
 
     assertEquals(
       IConnectionStatusProvider.ConnectionStatus.UNKNOWN,
@@ -311,6 +306,27 @@ class AndroidConnectionStatusProviderTest {
   }
 
   @Test
+  fun `an unpopulated cache is not treated as fresh shortly after boot`() {
+    whenever(networkInfo.isConnected).thenReturn(true)
+
+    // elapsedRealtimeNanos() counts from boot, so a provider created moments after boot sees a
+    // tick near zero. The cache is still empty and must not be read as up to date.
+    val provider =
+      AndroidConnectionStatusProvider(contextMock, options, buildInfo, TestMonotonicTicker())
+
+    val callsBefore =
+      mockingDetails(connectivityManager).invocations.count { it.method.name == "getActiveNetwork" }
+
+    assertEquals(IConnectionStatusProvider.ConnectionStatus.CONNECTED, provider.connectionStatus)
+
+    val callsAfter =
+      mockingDetails(connectivityManager).invocations.count { it.method.name == "getActiveNetwork" }
+    assertTrue(callsAfter > callsBefore, "An empty cache must be populated before it is read")
+
+    provider.close()
+  }
+
+  @Test
   fun `cache TTL works correctly`() {
     // Setup: Mock network info to return connected
     whenever(networkInfo.isConnected).thenReturn(true)
@@ -327,7 +343,7 @@ class AndroidConnectionStatusProviderTest {
       mockingDetails(connectivityManager).invocations.count { it.method.name == "getActiveNetwork" }
 
     // Advance time by 1 minute (less than 2 minute TTL)
-    currentTime += 60 * 1000L
+    ticker.advance(1, MINUTES)
 
     // Second call should use cache - no additional calls to getActiveNetwork
     val secondResult = connectionStatusProvider.connectionStatus
@@ -340,7 +356,7 @@ class AndroidConnectionStatusProviderTest {
     assertEquals(initialCallCount, callCountAfterSecond, "Second call should use cache")
 
     // Advance time beyond TTL (total 3 minutes)
-    currentTime += 2 * 60 * 1000L
+    ticker.advance(2, MINUTES)
 
     // Third call should refresh cache - should make new calls to getActiveNetwork
     val thirdResult = connectionStatusProvider.connectionStatus
@@ -547,7 +563,7 @@ class AndroidConnectionStatusProviderTest {
     whenever(connectivityManager.getNetworkCapabilities(any())).thenReturn(goodCaps)
 
     // Force cache invalidation by advancing time beyond TTL
-    currentTime += 3 * 60 * 1000L // 3 minutes
+    ticker.advance(3, MINUTES)
 
     // Should return CONNECTED for good capabilities
     assertEquals(
@@ -564,7 +580,7 @@ class AndroidConnectionStatusProviderTest {
     whenever(connectivityManager.getNetworkCapabilities(any())).thenReturn(unvalidatedCaps)
 
     // Force cache invalidation again
-    currentTime += 3 * 60 * 1000L
+    ticker.advance(3, MINUTES)
 
     assertEquals(
       IConnectionStatusProvider.ConnectionStatus.DISCONNECTED,


### PR DESCRIPTION
## PR Stack (Clock semantics hardening)

- #6028
- #6045
- this PR
- #6030
- #6032
- #6041
- #6043

---

## :scroll: Description

`AndroidConnectionStatusProvider` used `0` to mean "cache never populated", and compared it against `SystemClock.uptimeMillis()`:

```java
private volatile long lastCacheUpdateTime = 0;
private static final long CACHE_TTL_MS = 2 * 60 * 1000L;

private boolean isCacheValid() {
  return (timeProvider.getCurrentTimeMillis() - lastCacheUpdateTime) < CACHE_TTL_MS;
}
```

`uptimeMillis()` is 0 at boot, so `0` does not mean "unset" — it means "populated at boot". For the first two minutes of every boot, an empty cache reads as fresh.

The cache now holds a `Deadline`, so "never populated" is expired by construction and has no numeric value to get wrong.

Stacked on #6028, which adds the clock types this uses.

## :bulb: Motivation and Context

* resolves: JAVA-717

## :green_heart: How did you test it?

A regression test asserts that a provider constructed at tick 0 populates the cache before reading it. It fails if the deadline is constructed fresh instead of passed, which is the shape of the original bug.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.



