### PR TITLE
ref(checkin): Measure check-in durations with Stopwatch (JAVA-576)

### DIFF
--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java
@@ -9,6 +9,7 @@ import io.sentry.ISentryLifecycleToken;
 import io.sentry.ScopesAdapter;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
+import io.sentry.time.Stopwatch;
 import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
@@ -91,7 +92,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       TracingUtils.startNewTrace(scopes);
 
       @Nullable SentryId checkInId = null;
-      final long startTime = System.nanoTime();
+      final @NotNull Stopwatch stopwatch =
+          Stopwatch.started(scopes.getOptions().getMonotonicTicker());
       boolean didError = false;
 
       try {
@@ -105,7 +107,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       } finally {
         final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
         CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
-        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(stopwatch.elapsedNanos()));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
@@ -9,6 +9,7 @@ import io.sentry.ISentryLifecycleToken;
 import io.sentry.ScopesAdapter;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
+import io.sentry.time.Stopwatch;
 import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
@@ -91,7 +92,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       TracingUtils.startNewTrace(scopes);
 
       @Nullable SentryId checkInId = null;
-      final long startTime = System.nanoTime();
+      final @NotNull Stopwatch stopwatch =
+          Stopwatch.started(scopes.getOptions().getMonotonicTicker());
       boolean didError = false;
 
       try {
@@ -105,7 +107,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       } finally {
         final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
         CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
-        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(stopwatch.elapsedNanos()));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -9,6 +9,7 @@ import io.sentry.ISentryLifecycleToken;
 import io.sentry.ScopesAdapter;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
+import io.sentry.time.Stopwatch;
 import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
@@ -94,7 +95,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       TracingUtils.startNewTrace(scopes);
 
       @Nullable SentryId checkInId = null;
-      final long startTime = System.nanoTime();
+      final @NotNull Stopwatch stopwatch =
+          Stopwatch.started(scopes.getOptions().getMonotonicTicker());
       boolean didError = false;
 
       try {
@@ -108,7 +110,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       } finally {
         final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
         CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
-        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(stopwatch.elapsedNanos()));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry/src/main/java/io/sentry/util/CheckInUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CheckInUtils.java
@@ -9,6 +9,7 @@ import io.sentry.ISentryLifecycleToken;
 import io.sentry.MonitorConfig;
 import io.sentry.Sentry;
 import io.sentry.protocol.SentryId;
+import io.sentry.time.Stopwatch;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.jetbrains.annotations.ApiStatus;
@@ -37,7 +38,8 @@ public final class CheckInUtils {
     try (final @NotNull ISentryLifecycleToken ignored =
             Sentry.forkedScopes("CheckInUtils").makeCurrent()) {
       final @NotNull IScopes scopes = Sentry.getCurrentScopes();
-      final long startTime = System.nanoTime();
+      final @NotNull Stopwatch stopwatch =
+          Stopwatch.started(scopes.getOptions().getMonotonicTicker());
       boolean didError = false;
 
       TracingUtils.startNewTrace(scopes);
@@ -61,7 +63,7 @@ public final class CheckInUtils {
         if (environment != null) {
           checkIn.setEnvironment(environment);
         }
-        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(stopwatch.elapsedNanos()));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.util
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.CheckInStatus
 import io.sentry.FilterString
 import io.sentry.IScopes
@@ -143,6 +144,7 @@ class CheckInUtilsTest {
       sentry.`when`<Any> { Sentry.forkedScopes(any()) }.then { scopes.forkedScopes("test") }
       whenever(scopes.forkedScopes(any())).thenReturn(scopes)
       whenever(scopes.makeCurrent()).thenReturn(lifecycleToken)
+      whenever(scopes.options).thenReturn(SentryOptions())
 
       try {
         CheckInUtils.withCheckIn("monitor-1") { throw RuntimeException("thrown on purpose") }
@@ -311,5 +313,20 @@ class CheckInUtilsTest {
       assertEquals(30, monitorConfig.maxRuntime)
       assertEquals("America/Los_Angeles", monitorConfig.timezone)
     }
+  }
+
+  @Test
+  fun `resolves a ticker that ticks on System nanoTime`() {
+    // The clock the check-in path reads. Bracketing a tick between two System.nanoTime() readings
+    // pins the source, not just the resolution: a ticker on any other monotonic source reports a
+    // different epoch and would fall outside the bracket.
+    val ticker = SentryOptions().monotonicTicker
+
+    val before = System.nanoTime()
+    val tick = ticker.tickNanos()
+    val after = System.nanoTime()
+
+    assertThat(tick).isAtLeast(before)
+    assertThat(tick).isAtMost(after)
   }
 }

--- a/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.util
 
 import com.google.common.truth.Truth.assertThat
+import io.sentry.CheckIn
 import io.sentry.CheckInStatus
 import io.sentry.FilterString
 import io.sentry.IScopes
@@ -10,18 +11,26 @@ import io.sentry.MonitorSchedule
 import io.sentry.MonitorScheduleUnit
 import io.sentry.Sentry
 import io.sentry.SentryOptions
+import io.sentry.time.MonotonicTicker
+import io.sentry.time.TestMonotonicTicker
 import java.lang.AssertionError
 import java.lang.RuntimeException
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.TimeUnit.SECONDS
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class CheckInUtilsTest {
@@ -328,5 +337,64 @@ class CheckInUtilsTest {
 
     assertThat(tick).isAtLeast(before)
     assertThat(tick).isAtMost(after)
+  }
+
+  @Test
+  fun `reports the duration the ticker advanced by`() {
+    val ticker = TestMonotonicTicker()
+
+    val checkIns =
+      captureCheckIns(ticker) {
+        CheckInUtils.withCheckIn("monitor-1") { ticker.advance(1500, MILLISECONDS) }
+      }
+
+    assertThat(checkIns.map { it.status })
+      .containsExactly(CheckInStatus.IN_PROGRESS.apiName(), CheckInStatus.OK.apiName())
+      .inOrder()
+    assertThat(checkIns.first().duration).isNull()
+    assertThat(checkIns.last().duration).isEqualTo(1.5)
+  }
+
+  @Test
+  fun `reports the duration when the callable throws`() {
+    val ticker = TestMonotonicTicker()
+
+    val checkIns =
+      captureCheckIns(ticker) {
+        assertFailsWith<RuntimeException> {
+          CheckInUtils.withCheckIn("monitor-1") {
+            ticker.advance(2, SECONDS)
+            throw RuntimeException("thrown on purpose")
+          }
+        }
+      }
+
+    assertThat(checkIns.last().status).isEqualTo(CheckInStatus.ERROR.apiName())
+    assertThat(checkIns.last().duration).isEqualTo(2.0)
+  }
+
+  /**
+   * Runs [block] against scopes whose options tick on [ticker], and returns every check-in it
+   * captured, in order.
+   */
+  private fun captureCheckIns(ticker: MonotonicTicker, block: () -> Unit): List<CheckIn> {
+    Mockito.mockStatic(Sentry::class.java).use { sentry ->
+      val scopes = mock<IScopes>()
+      val options =
+        object : SentryOptions() {
+          override fun getMonotonicTicker(): MonotonicTicker = ticker
+        }
+      sentry.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(scopes)
+      sentry.`when`<Any> { Sentry.forkedScopes(any()) }.then { scopes.forkedScopes("test") }
+      whenever(scopes.forkedScopes(any())).thenReturn(scopes)
+      whenever(scopes.makeCurrent()).thenReturn(mock<ISentryLifecycleToken>())
+      whenever(scopes.options).thenReturn(options)
+
+      block()
+
+      val captor = argumentCaptor<CheckIn>()
+      verify(scopes, times(2)).captureCheckIn(captor.capture())
+      return captor.allValues
+    }
   }
 }


### PR DESCRIPTION
## :scroll: Description

Switch CheckIns to use Stopwatch to measure durations. This makes the code easier to reason about and makes the code more testable. This has no logical changes since this is only used in Java and the monotonic clock uses the same `System.nanoTime()` under the hood.

## :bulb: Motivation and Context

This is a pure refactor to make the code easier to reason about and easier to test.


* resolves: JAVA-576

## :green_heart: How did you test it?

Existing tests pass and added new ones.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
