### PR TITLE
fix(core): Clear the persisted replay id when resetting the scope cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Keep dropped tombstone and ANR events dropped, instead of reporting the same app exit again at every app start ([#6002](https://github.com/getsentry/sentry-java/pull/6002))
+- Clear the persisted replay id on SDK init, so a replay id from a previous process is no longer attached to ANR events from the current one ([#6033](https://github.com/getsentry/sentry-java/pull/6033))
 - Apply `Sentry.withScope` and `Sentry.withIsolationScope` data to events captured inside the callback when `globalHubMode` is enabled ([#6004](https://github.com/getsentry/sentry-java/pull/6004))
   - `globalHubMode` is enabled by default on Android, where tags, extras, contexts and level set inside the callback were silently dropped
   - Scopes that are explicitly made current, e.g. via `Sentry.setCurrentScopes` or the `SentryContext` coroutine integration, are now also honoured when `globalHubMode` is enabled

--- a/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
+++ b/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
@@ -378,5 +378,8 @@ public final class PersistingScopeObserver extends ScopeObserverAdapter {
     delete(TAGS_FILENAME);
     delete(TRACE_FILENAME);
     delete(TRANSACTION_FILENAME);
+    // the replay this id points at belongs to the previous process, so it must not be attached to
+    // events from this one; the replay integration writes a fresh id once it starts recording
+    delete(REPLAY_FILENAME);
   }
 }

--- a/sentry/src/test/java/io/sentry/cache/PersistingScopeObserverBatchingTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/PersistingScopeObserverBatchingTest.kt
@@ -6,7 +6,9 @@ import io.sentry.ISentryExecutorService
 import io.sentry.ISerializer
 import io.sentry.SentryOptions
 import io.sentry.cache.PersistingScopeObserver.BREADCRUMBS_FILENAME
+import io.sentry.cache.PersistingScopeObserver.REPLAY_FILENAME
 import io.sentry.cache.PersistingScopeObserver.TRANSACTION_FILENAME
+import io.sentry.protocol.SentryId
 import io.sentry.test.DeferredExecutorService
 import java.io.Writer
 import java.util.concurrent.atomic.AtomicBoolean
@@ -27,6 +29,9 @@ class PersistingScopeObserverBatchingTest {
 
   private fun PersistingScopeObserver.readTransaction(): String? =
     read(options, TRANSACTION_FILENAME, String::class.java)
+
+  private fun PersistingScopeObserver.readReplayId(): String? =
+    read(options, REPLAY_FILENAME, String::class.java)
 
   @Suppress("UNCHECKED_CAST")
   private fun PersistingScopeObserver.readBreadcrumbs(): List<Breadcrumb> =
@@ -116,6 +121,20 @@ class PersistingScopeObserverBatchingTest {
       }
       delegate.serialize(entity, writer)
     }
+  }
+
+  @Test
+  fun `resetCache clears the replay id left behind by the previous process`() {
+    val executor = DeferredExecutorService()
+    val sut = getSut(executor)
+
+    sut.setReplayId(SentryId("afcb46b1140ade5187c4bbb5daa804df"))
+    executor.runAll()
+    assertThat(sut.readReplayId()).isEqualTo("afcb46b1140ade5187c4bbb5daa804df")
+
+    sut.resetCache()
+
+    assertThat(sut.readReplayId()).isNull()
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

`PersistingScopeObserver.resetCache()` runs on SDK init and clears the persisted scope so values from the previous process don't leak into the new one. It deletes user, level, request, fingerprint, contexts, extras, tags, trace and transaction, and clears the breadcrumb queue — but it has never touched `replay.json`.

This adds `delete(REPLAY_FILENAME)` alongside the others, plus a test in `PersistingScopeObserverBatchingTest`.

## :bulb: Motivation and Context

A replay id points at a replay recorded by the process that wrote it. Leaving it on disk across an init means `ApplicationExitInfoEventProcessor` can read a stale id and attach it to an ANR event from the current process. The impact is bounded — the processor falls back to scanning for the newest `replay_*` folder when the id's folder is gone, and the replay integration overwrites the file once it starts recording — but the id should not survive the reset in the first place.

The intent was there from the start: the comment at the `resetCache()` call site in `Sentry.notifyOptionsObservers` already gives `replayId` as its example of a value that must not reach new events. The implementation just never included it.

Split out of #6031, which is a test-only flakiness fix. Joining a previously discarded `Future` there revived an assertion that had been silently swallowed since #4181 and turned out never to have been satisfiable, which is how this gap surfaced.

### Why it's safe to delete

`replay.json` is used during init to finalize the replay from the previous process. That handoff is already finished by the time the reset runs, because all three steps are queued on the same single-threaded executor, in this order:

1. `AnrV2Integration.register()` — ANR enrichment reads the replay id and writes back the one it resolved
2. `ReplayIntegration.register()` — `finalizePreviousReplay()` reads it and finalizes that replay
3. `notifyOptionsObservers()` — `resetCache()` deletes it

Steps 1 and 2 are deliberately ordered: `AndroidOptionsInitializer` has a comment that Anr must be installed before Replay "as ReplayIntegration relies on it to set the replayId in case of an ANR". Step 3 has always come last, which is why AnrV2 events still get the previous process's replay id today.

Nothing reads the file after step 3, so deleting there only affects the next init — which is the point.

Deleting also doesn't introduce a new state to handle. `replay.json` can already hold `EMPTY_ID` today, written by the replay integration when a replay stops, and both readers treat a missing file exactly like `EMPTY_ID`: `finalizePreviousReplay()` calls `cleanupReplays()` either way, and `ApplicationExitInfoEventProcessor` looks for a `replay_<id>` folder that doesn't exist either way and takes the same fallback.

## :green_heart: How did you test it?

New test `resetCache clears the replay id left behind by the previous process` in `PersistingScopeObserverBatchingTest`. Verified it fails without the one-line change (`expected: null` / `but was: <afcb46b1140ade5187c4bbb5daa804df>`) and passes with it.

Ran `:sentry:test`, `:sentry-android-core:testReleaseUnitTest` and `:sentry-android-replay:testReleaseUnitTest` — all pass.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.
