### PR TITLE
ref(time): Deprecate the legacy date and clock providers (JAVA-571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Behavioral Changes
 
 - Measure HTTP rate-limit backoff on a monotonic clock instead of the wall clock, so that a device time change no longer lifts or extends an active rate limit ([#6030](https://github.com/getsentry/sentry-java/pull/6030))
+- Deprecate `DateUtils.getCurrentDateTime()` in favor of `options.getDateProvider().now()`, which is configurable and resolves finer than a millisecond ([#6043](https://github.com/getsentry/sentry-java/pull/6043))
 
 ### Fixes
 
@@ -24,6 +25,7 @@
 - Add an internal `MonotonicTicker` abstraction with `Deadline` and `Stopwatch` primitives ([#6028](https://github.com/getsentry/sentry-java/pull/6028))
 - Add internal `Timestamp`, `EpochClock` and `AnchoredClock`, so related instants project from one wall-clock reading instead of each reading the clock ([#6045](https://github.com/getsentry/sentry-java/pull/6045))
 - Deprecate `RateLimiter(ICurrentDateProvider, SentryOptions)` in favor of `RateLimiter(SentryOptions)`, whose backoff is measured on a monotonic ticker ([#6030](https://github.com/getsentry/sentry-java/pull/6030))
+- Deprecate `ICurrentDateProvider.getCurrentTimeMillis()`, `CurrentDateProvider.getInstance()`, `AndroidCurrentDateProvider.getInstance()` and `AndroidDateUtils.getCurrentSentryDateTime()` in favor of `MonotonicTicker` and `SentryDateProvider` ([#6043](https://github.com/getsentry/sentry-java/pull/6043))
 
 ### Dependencies
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -81,6 +81,8 @@ final class ANRWatchDog extends Thread {
         context);
   }
 
+  // TODO [MAJOR]: measure the stall on a MonotonicTicker instead of an injected wall clock
+  @SuppressWarnings("deprecation")
   @TestOnly
   ANRWatchDog(
       @NotNull final ICurrentDateProvider timeProvider,
@@ -116,6 +118,7 @@ final class ANRWatchDog extends Thread {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void run() {
     // right when the watchdog gets started, let's assume there's no ANR

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -549,6 +549,9 @@ public final class ActivityLifecycleIntegration
     }
   }
 
+  // TODO [MAJOR]: replace AndroidDateUtils.getCurrentSentryDateTime() with
+  // options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   @Override
   public void onActivityPreCreated(
       final @NotNull Activity activity, final @Nullable Bundle savedInstanceState) {
@@ -604,6 +607,9 @@ public final class ActivityLifecycleIntegration
     }
   }
 
+  // TODO [MAJOR]: replace AndroidDateUtils.getCurrentSentryDateTime() with
+  // options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   @Override
   public void onActivityPreStarted(final @NotNull Activity activity) {
     final ActivityLifecycleSpanHelper helper = activitySpanHelpers.get(activity);
@@ -672,6 +678,9 @@ public final class ActivityLifecycleIntegration
     // empty override, required to avoid a api-level breaking super.onActivityPostResumed() calls
   }
 
+  // TODO [MAJOR]: replace AndroidDateUtils.getCurrentSentryDateTime() with
+  // options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   @Override
   public void onActivityPrePaused(@NotNull Activity activity) {
     // only executed if API >= 29 otherwise it happens on onActivityPaused
@@ -1094,6 +1103,9 @@ public final class ActivityLifecycleIntegration
    * Standalone-only: this is only registered as a listener when standalone app start tracing is
    * enabled.
    */
+  // TODO [MAJOR]: replace AndroidDateUtils.getCurrentSentryDateTime() with
+  // options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   private @Nullable AppStartExtension.ExtendedAppStart onExtendAppStartRequested() {
     if (scopes == null
         || options == null

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidDateUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidDateUtils.java
@@ -17,7 +17,10 @@ public final class AndroidDateUtils {
    * invocations.
    *
    * @return the UTC SentryDate
+   * @deprecated use {@code options.getDateProvider()}. This static holder cannot be configured or
+   *     stubbed, which is why the note above already asked callers to prefer the options.
    */
+  @Deprecated
   public static @NotNull SentryDate getCurrentSentryDateTime() {
     return dateProvider.now();
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -401,6 +401,9 @@ final class AndroidOptionsInitializer {
     }
   }
 
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider or
+  // MonotonicTicker
+  @SuppressWarnings("deprecation")
   static void installDefaultIntegrations(
       final @NotNull Context context,
       final @NotNull SentryAndroidOptions options,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
@@ -117,6 +117,8 @@ public class AndroidProfiler {
   }
 
   @SuppressLint("NewApi")
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public @Nullable ProfileStartData start() {
     try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       // intervalUs is 0 only if there was a problem in the init

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -89,6 +89,8 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
         () -> executorService);
   }
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public AndroidTransactionProfiler(
       final @NotNull Context context,
       final @NotNull BuildInfoProvider buildInfoProvider,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -50,6 +50,9 @@ public class AnrV2Integration implements Integration, Closeable {
   private final @NotNull ICurrentDateProvider dateProvider;
   private @Nullable SentryAndroidOptions options;
 
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider; the epoch
+  // comparison it feeds must stay wall time
+  @SuppressWarnings("deprecation")
   public AnrV2Integration(final @NotNull Context context) {
     // using CurrentDateProvider instead of AndroidCurrentDateProvider as AppExitInfo uses
     // System.currentTimeMillis

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -34,6 +34,8 @@ public final class AppComponentsBreadcrumbsIntegration
   private @Nullable IScopes scopes;
   private @Nullable SentryAndroidOptions options;
 
+  // TODO [MAJOR]: replace AndroidCurrentDateProvider with MonotonicTicker
+  @SuppressWarnings("deprecation")
   private final @NotNull Debouncer trimMemoryDebouncer =
       new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationExitInfoHistoryDispatcher.java
@@ -36,6 +36,9 @@ final class ApplicationExitInfoHistoryDispatcher implements Runnable {
   private final @NotNull ApplicationExitInfoPolicy policy;
   private final long threshold;
 
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider; the epoch
+  // comparison it feeds must stay wall time
+  @SuppressWarnings("deprecation")
   ApplicationExitInfoHistoryDispatcher(
       final @NotNull Context context,
       final @NotNull IScopes scopes,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
@@ -28,6 +28,9 @@ final class LifecycleWatcher implements AppState.AppStateListener {
 
   private final @NotNull ICurrentDateProvider currentDateProvider;
 
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider; the epoch
+  // comparison it feeds must stay wall time
+  @SuppressWarnings("deprecation")
   LifecycleWatcher(
       final @NotNull IScopes scopes,
       final long sessionIntervalMillis,
@@ -60,6 +63,9 @@ final class LifecycleWatcher implements AppState.AppStateListener {
     addAppBreadcrumb("foreground");
   }
 
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider; the epoch
+  // comparison it feeds must stay wall time
+  @SuppressWarnings("deprecation")
   private void startSession() {
     cancelTask();
 
@@ -90,6 +96,9 @@ final class LifecycleWatcher implements AppState.AppStateListener {
 
   // App went to background and triggered this callback after 700ms
   // as no new screen was shown
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider; the epoch
+  // comparison it feeds must stay wall time
+  @SuppressWarnings("deprecation")
   @Override
   public void onBackground() {
     final long currentTimeMillis = currentDateProvider.getCurrentTimeMillis();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -47,6 +47,8 @@ public final class ScreenshotEventProcessor implements EventProcessor {
   private final boolean isReplayAvailable;
   private final AtomicBoolean isReplayModuleAbsenceLogged = new AtomicBoolean(false);
 
+  // TODO [MAJOR]: replace AndroidCurrentDateProvider with MonotonicTicker
+  @SuppressWarnings("deprecation")
   public ScreenshotEventProcessor(
       final @NotNull SentryAndroidOptions options,
       final @NotNull BuildInfoProvider buildInfoProvider,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -298,6 +298,9 @@ public final class SystemEventsBreadcrumbsIntegration
     private static final long DEBOUNCE_WAIT_TIME_MS = 60 * 1000;
     private final @NotNull IScopes scopes;
     private final @NotNull SentryAndroidOptions options;
+
+    // TODO [MAJOR]: replace AndroidCurrentDateProvider with MonotonicTicker
+    @SuppressWarnings("deprecation")
     private final @NotNull Debouncer batteryChangedDebouncer =
         new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -54,6 +54,9 @@ public class TombstoneIntegration implements Integration, Closeable {
   private final @NotNull ICurrentDateProvider dateProvider;
   private @Nullable SentryAndroidOptions options;
 
+  // TODO [MAJOR]: replace CurrentDateProvider (wall clock) with SentryDateProvider; the epoch
+  // comparison it feeds must stay wall time
+  @SuppressWarnings("deprecation")
   public TombstoneIntegration(final @NotNull Context context) {
     // using CurrentDateProvider instead of AndroidCurrentDateProvider as AppExitInfo uses
     // System.currentTimeMillis

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -46,6 +46,8 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
   private static final long DEBOUNCE_WAIT_TIME_MS = 2000;
   private static final int DEBOUNCE_MAX_EXECUTIONS = 3;
 
+  // TODO [MAJOR]: replace AndroidCurrentDateProvider with MonotonicTicker
+  @SuppressWarnings("deprecation")
   public ViewHierarchyEventProcessor(final @NotNull SentryAndroidOptions options) {
     this.options = Objects.requireNonNull(options, "SentryAndroidOptions is required");
     this.debouncer =

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -38,6 +38,8 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
 
   private final @NotNull ICurrentDateProvider currentDateProvider;
 
+  // TODO [MAJOR]: replace AndroidCurrentDateProvider with MonotonicTicker
+  @SuppressWarnings("deprecation")
   public AndroidEnvelopeCache(final @NotNull SentryAndroidOptions options) {
     this(options, AndroidCurrentDateProvider.getInstance());
   }
@@ -63,6 +65,9 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
     return storeInternalAndroid(envelope, hint);
   }
 
+  // TODO [MAJOR]: this reading must stay paired with AppStartMetrics.getStartUptimeMs(),
+  // which is SystemClock.uptimeMillis(), so MonotonicTicker is not a drop-in replacement
+  @SuppressWarnings("deprecation")
   private boolean storeInternalAndroid(@NotNull SentryEnvelope envelope, @NotNull Hint hint) {
     final boolean didStore = super.storeEnvelope(envelope, hint);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
@@ -4,11 +4,24 @@ import android.os.SystemClock;
 import io.sentry.transport.ICurrentDateProvider;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * An uptime clock: {@link SystemClock#uptimeMillis()} excludes time the device spent in deep sleep,
+ * which the name does not say.
+ *
+ * <p>Superseded by {@link io.sentry.time.MonotonicTicker}, which counts deep sleep and says so in
+ * its name.
+ */
 @ApiStatus.Internal
 public final class AndroidCurrentDateProvider implements ICurrentDateProvider {
 
+  @SuppressWarnings("deprecation")
   private static final ICurrentDateProvider instance = new AndroidCurrentDateProvider();
 
+  /**
+   * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval.
+   */
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public static ICurrentDateProvider getInstance() {
     return instance;
   }
@@ -16,6 +29,7 @@ public final class AndroidCurrentDateProvider implements ICurrentDateProvider {
   private AndroidCurrentDateProvider() {}
 
   @Override
+  @SuppressWarnings("deprecation")
   public long getCurrentTimeMillis() {
     return SystemClock.uptimeMillis();
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/Debouncer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/Debouncer.java
@@ -30,6 +30,8 @@ public class Debouncer {
    * @return true if the execution should be debounced due to maxExecutions executions being made
    *     within waitTimeMs, otherwise false.
    */
+  // TODO [MAJOR]: replace AndroidCurrentDateProvider with MonotonicTicker
+  @SuppressWarnings("deprecation")
   public boolean checkForDebounce() {
     final long now = timeProvider.getCurrentTimeMillis();
     if (lastExecutionTime.get() == 0 || (lastExecutionTime.get() + waitTimeMs) <= now) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/ActivityLifecycleSpanHelper.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/ActivityLifecycleSpanHelper.java
@@ -69,6 +69,9 @@ public class ActivityLifecycleSpanHelper {
     return onStartStartTimestamp;
   }
 
+  // TODO [MAJOR]: replace AndroidDateUtils.getCurrentSentryDateTime() with
+  // options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public void saveSpanToAppStartMetrics() {
     if (onCreateSpan == null || onStartSpan == null) {
       return;

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -97,7 +97,8 @@ public final class Breadcrumb implements JsonUnknown, JsonSerializable, Comparab
    * @param options - the sentry options
    * @return the breadcrumb
    */
-  @SuppressWarnings("unchecked")
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings({"unchecked", "deprecation"})
   public static Breadcrumb fromMap(
       @NotNull Map<String, Object> map, @NotNull SentryOptions options) {
 
@@ -882,7 +883,8 @@ public final class Breadcrumb implements JsonUnknown, JsonSerializable, Comparab
   }
 
   public static final class Deserializer implements JsonDeserializer<Breadcrumb> {
-    @SuppressWarnings("unchecked")
+    // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+    @SuppressWarnings({"unchecked", "deprecation"})
     @Override
     public @NotNull Breadcrumb deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -19,8 +19,12 @@ public final class DateUtils {
    * Get the current Date (UTC)
    *
    * @return the UTC Date
+   * @deprecated use {@code options.getDateProvider().now()}, which is configurable and resolves
+   *     finer than a millisecond.
    */
-  @SuppressWarnings("JavaUtilDate")
+  @Deprecated
+  // not @InlineMe: the replacement is options.getDateProvider().now(), not this method's body
+  @SuppressWarnings({"JavaUtilDate", "InlineMeSuggester"})
   public static @NotNull Date getCurrentDateTime() {
     return new Date();
   }

--- a/sentry/src/main/java/io/sentry/ProfilingTraceData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTraceData.java
@@ -75,6 +75,8 @@ public final class ProfilingTraceData implements JsonUnknown, JsonSerializable {
     this(new File("dummy"), NoOpTransaction.getInstance());
   }
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public ProfilingTraceData(
       final @NotNull File traceFile, final @NotNull ITransaction transaction) {
     this(

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -103,6 +103,8 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
     this.throwable = throwable;
   }
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public SentryEvent() {
     this(new SentryId(), DateUtils.getCurrentDateTime());
   }

--- a/sentry/src/main/java/io/sentry/SentryReplayEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayEvent.java
@@ -52,6 +52,8 @@ public final class SentryReplayEvent extends SentryBaseEvent
   private @Nullable List<String> segmentNames;
   private @Nullable Map<String, Object> unknown;
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public SentryReplayEvent() {
     super();
     this.replayId = new SentryId();

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -112,6 +112,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
     this.abnormalMechanism = abnormalMechanism;
   }
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public Session(
       @Nullable String distinctId,
       final @Nullable User user,
@@ -221,6 +223,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
    *
    * @return whether the session was updated, i.e. false if it had already reached a terminal state
    */
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   @ApiStatus.Internal
   public boolean recordNonTerminatingUnhandledError() {
     try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
@@ -242,6 +246,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
   }
 
   /** Ends a session and update its values */
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public void end() {
     end(DateUtils.getCurrentDateTime());
   }
@@ -251,6 +257,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
    *
    * @param timestamp the timestamp or null
    */
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public void end(final @Nullable Date timestamp) {
     try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
       init = null;
@@ -301,6 +309,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
    * @param abnormalMechanism the mechanism which caused the session to be abnormal
    * @return if the session has been updated
    */
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   public boolean update(
       final @Nullable State status,
       final @Nullable String userAgent,

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -279,6 +279,8 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
   }
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   private void writeCrashMarkerFile() {
     final File crashMarkerFile = new File(options.getCacheDirPath(), CRASH_MARKER_FILE);
     try (final OutputStream outputStream = new FileOutputStream(crashMarkerFile)) {

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
@@ -164,6 +164,8 @@ public final class ClientReportRecorder implements IClientReportRecorder {
     return itemCount != null ? itemCount : 1L;
   }
 
+  // TODO [MAJOR]: replace DateUtils.getCurrentDateTime() with options.getDateProvider().now()
+  @SuppressWarnings("deprecation")
   @Nullable
   ClientReport resetCountsAndGenerateClientReport() {
     final Date currentDate = DateUtils.getCurrentDateTime();

--- a/sentry/src/main/java/io/sentry/transport/CurrentDateProvider.java
+++ b/sentry/src/main/java/io/sentry/transport/CurrentDateProvider.java
@@ -2,11 +2,24 @@ package io.sentry.transport;
 
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * The wall clock, which jumps when the device time changes.
+ *
+ * <p>Superseded by {@link io.sentry.SentryDateProvider} for timestamps and {@link
+ * io.sentry.time.MonotonicTicker} for intervals.
+ */
 @ApiStatus.Internal
 public final class CurrentDateProvider implements ICurrentDateProvider {
 
+  @SuppressWarnings("deprecation")
   private static final ICurrentDateProvider instance = new CurrentDateProvider();
 
+  /**
+   * @deprecated use {@link io.sentry.SentryDateProvider} for a timestamp, or {@link
+   *     io.sentry.time.MonotonicTicker} to measure an interval.
+   */
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public static ICurrentDateProvider getInstance() {
     return instance;
   }
@@ -14,6 +27,7 @@ public final class CurrentDateProvider implements ICurrentDateProvider {
   private CurrentDateProvider() {}
 
   @Override
+  @SuppressWarnings("deprecation")
   public final long getCurrentTimeMillis() {
     return System.currentTimeMillis();
   }

--- a/sentry/src/main/java/io/sentry/transport/ICurrentDateProvider.java
+++ b/sentry/src/main/java/io/sentry/transport/ICurrentDateProvider.java
@@ -2,7 +2,13 @@ package io.sentry.transport;
 
 import org.jetbrains.annotations.ApiStatus;
 
-/** Date Provider to make the Transport unit testable */
+/**
+ * Date Provider to make the Transport unit testable
+ *
+ * <p>Superseded by {@link io.sentry.time.MonotonicTicker}. The name here does not say which clock
+ * the value comes from, and implementations disagreed: {@link CurrentDateProvider} returns wall
+ * time while {@code AndroidCurrentDateProvider} returns uptime, through this one type.
+ */
 @ApiStatus.Internal
 public interface ICurrentDateProvider {
 
@@ -10,6 +16,9 @@ public interface ICurrentDateProvider {
    * Returns the current time in millis
    *
    * @return the time in millis
+   * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval, or {@link
+   *     io.sentry.SentryDateProvider} for a wall-clock timestamp.
    */
+  @Deprecated
   long getCurrentTimeMillis();
 }


### PR DESCRIPTION
## PR Stack (Clock semantics hardening)

- #6028
- #6045
- #6029
- #6030
- #6032
- #6041
- this PR

---

## :scroll: Description

Marks the legacy date and clock surface as deprecated, now that the internal consumers that could
move have moved (#6029, #6030, #6032, #6041). Nothing is migrated here and nothing is removed — the
point is to start the warning cycle before the next major, so users and the `9.x.x` branch get a
full release of notice.

| Deprecated | Replacement |
|---|---|
| `ICurrentDateProvider.getCurrentTimeMillis()` | `MonotonicClock` for an interval, `SentryDateProvider` for a timestamp |
| `CurrentDateProvider.getInstance()` | `SentryDateProvider` for a timestamp, `MonotonicClock` for an interval |
| `AndroidCurrentDateProvider.getInstance()` | `MonotonicClock` (this one was `SystemClock.uptimeMillis()` all along) |
| `DateUtils.getCurrentDateTime()` | `options.getDateProvider().now()` |
| `AndroidDateUtils.getCurrentSentryDateTime()` | `options.getDateProvider()` |

The `DateUtils` **class** is deliberately not deprecated: only `getCurrentDateTime()` reads a clock,
while its other fourteen statics are pure conversion and formatting helpers used all over the SDK.

### Two deviations from the plan, both forced

**1. The annotations sit on members, not on the types.** The plan called for deprecating
`ICurrentDateProvider`, `CurrentDateProvider` and `AndroidCurrentDateProvider` as types. That cannot
compile here: the Android modules build at Java 8, where javac still emits a deprecation warning for
an `import` of a deprecated type (JEP 211 elides those only from source 9 on), `-Xlint:all -Werror`
turns it into an error, and an import declaration cannot carry a `@SuppressWarnings` — a class-level
suppression does not cover it either. I verified both halves of that empirically. Thirteen Java files
in `sentry-android-core` import these types; the alternative was writing
`io.sentry.transport.ICurrentDateProvider` inline at ~40 use sites until the next major.

Deprecating `getCurrentTimeMillis()` and `getInstance()` warns any caller just as loudly, and every
warning it produces lands somewhere a suppression can go. The type-level javadoc still names the
replacement, so IDEs and Javadoc readers see it.

**2. Kotlin call sites are left warning, not suppressed.** `-Werror` applies to `JavaCompile` only,
so the 17 warnings in `sentry-android-replay` and `sentry-okhttp` do not break anything. They are the
live migration list for JAVA-575; suppressing them would trade a checklist for a comment. That module
already carries other deprecation warnings, so this is not a new kind of noise. Say the word if you'd
rather have them suppressed.

## :bulb: Motivation and Context

`ICurrentDateProvider` is the defect JAVA-571 was filed about. One interface carried two
incompatible clocks — `CurrentDateProvider` is `System.currentTimeMillis()`, `AndroidCurrentDateProvider`
is `SystemClock.uptimeMillis()` — and nothing in the name or the type said which. A field declared
`ICurrentDateProvider` accepts either, and the two disagree by however long the device has been
suspended.

Each of the 21 Java suppressions carries a `// TODO [MAJOR]` naming the replacement that site should
take, because a suppressed warning stops being a checklist entry. Nearly all of them are frozen until
the next major because they produce serialized timestamps — `SentryEvent`, `Breadcrumb`, `Session`,
`SentryReplayEvent`, `ProfilingTraceData`, both profilers, the activity-lifecycle span helpers. Only
`ClientReportRecorder` and `EnvelopeCache` are internal. That is expected: this PR marks the surface,
it does not migrate it.

Four sites must stay on the wall clock and say so: `AnrV2Integration`, `TombstoneIntegration` and
`ApplicationExitInfoHistoryDispatcher` compare against epoch `ApplicationExitInfo` timestamps, and
`LifecycleWatcher` against `Session.getStarted()`.

* resolves: JAVA-571

## :green_heart: How did you test it?

No behaviour changes, so no new tests — this is annotations plus suppressions.

`./gradlew :sentry:test :sentry:apiCheck :sentry-android-core:testReleaseUnitTest
:sentry-android-core:apiCheck :sentry-android-replay:testReleaseUnitTest :sentry-okhttp:test
:sentry-apache-http-client-5:test` — green.

`./gradlew spotlessApply apiDump` produces no `.api` diff: BCV does not record annotations.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

The removals, and the serialized-value migrations behind every `// TODO [MAJOR]` here, belong to the
`9.x.x` branch: JAVA-572 (span durations), JAVA-575 (replay timings), JAVA-577 (session durations),
JAVA-578 (profiler re-anchoring), JAVA-642 (app-start spans).

> :warning: **Merge this PR using a merge commit** (not squash), so the rest of the stack keeps a clean history.


