### PR TITLE
fix(compose): Prevent dangling spans in SentryTraced + tag composition outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- Prevent `SentryTraced` from producing dangling spans if recomposition is abandoned or drawing fails ([#6049](https://github.com/getsentry/sentry-java/pull/6049))
 - Keep dropped tombstone and ANR events dropped, instead of reporting the same app exit again at every app start ([#6002](https://github.com/getsentry/sentry-java/pull/6002))
 - Apply `Sentry.withScope` and `Sentry.withIsolationScope` data to events captured inside the callback when `globalHubMode` is enabled ([#6004](https://github.com/getsentry/sentry-java/pull/6004))
   - `globalHubMode` is enabled by default on Android, where tags, extras, contexts and level set inside the callback were silently dropped

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -11,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import io.sentry.ISpan
 import io.sentry.Sentry
+import io.sentry.SentryDate
 import io.sentry.SpanOptions
 import io.sentry.compose.SentryModifier.sentryTag
 
@@ -21,14 +23,6 @@ private const val OP_PARENT_RENDER = "ui.compose.rendering"
 private const val OP_RENDER = "ui.render"
 
 private const val OP_TRACE_ORIGIN = "auto.ui.jetpack_compose"
-
-@Immutable private class ImmutableHolder<T>(var item: T)
-
-private fun getRootSpan(): ISpan? {
-  var rootSpan: ISpan? = null
-  Sentry.configureScope { rootSpan = it.transaction }
-  return rootSpan
-}
 
 private val localSentryCompositionParentSpan = compositionLocalOf {
   ImmutableHolder(
@@ -62,6 +56,15 @@ private val localSentryRenderingParentSpan = compositionLocalOf {
   )
 }
 
+@Immutable internal class ImmutableHolder<T>(var item: T)
+
+/**
+ * Creates spans for tracking the time required to compose the wrapped [content], and a span for its
+ * initial draw.
+ *
+ * Spans are approximate and include work performed by any composables [content] invokes. Abandoned
+ * recompositions are ignored.
+ */
 @ExperimentalComposeUiApi
 @Composable
 public fun SentryTraced(
@@ -70,32 +73,72 @@ public fun SentryTraced(
   enableUserInteractionTracing: Boolean = true,
   content: @Composable BoxScope.() -> Unit,
 ) {
-  val parentCompositionSpan = localSentryCompositionParentSpan.current
-  val parentRenderingSpan = localSentryRenderingParentSpan.current
-  val compositionSpan =
-    parentCompositionSpan.item?.startChild(OP_COMPOSE, tag)?.apply {
-      spanContext.origin = OP_TRACE_ORIGIN
-    }
-  val firstRendered = remember { ImmutableHolder(false) }
-
+  val alreadyRendered = remember { ImmutableHolder(false) }
   val baseModifier = if (enableUserInteractionTracing) modifier.sentryTag(tag) else modifier
+
+  val parentCompositionSpan = localSentryCompositionParentSpan.current.item
+  val parentRenderingSpan = localSentryRenderingParentSpan.current.item
+  val dateProvider = Sentry.getCurrentScopes().options.dateProvider
+
+  val compositionStart = dateProvider.now()
 
   Box(
     modifier =
       baseModifier.drawWithContent {
-        val renderSpan =
-          if (!firstRendered.item) {
-            parentRenderingSpan.item?.startChild(OP_RENDER, tag)
-          } else {
-            null
-          }
-        drawContent()
-        firstRendered.item = true
-        renderSpan?.finish()
+        if (alreadyRendered.item) {
+          drawContent()
+        } else {
+          val renderStart = dateProvider.now()
+          drawContent()
+          val renderEnd = dateProvider.now()
+
+          alreadyRendered.item = true
+          recordRenderSpan(parentRenderingSpan, tag, renderStart, renderEnd)
+        }
       },
     propagateMinConstraints = true,
   ) {
     content()
   }
-  compositionSpan?.finish()
+  val compositionEnd = dateProvider.now()
+
+  if (parentCompositionSpan != null) {
+    SideEffect {
+      recordCompositionSpan(
+        parentSpan = parentCompositionSpan,
+        tag = tag,
+        startTimestamp = compositionStart,
+        endTimestamp = compositionEnd,
+      )
+    }
+  }
+}
+
+private fun getRootSpan(): ISpan? {
+  var rootSpan: ISpan? = null
+  Sentry.configureScope { rootSpan = it.transaction }
+  return rootSpan
+}
+
+private fun recordCompositionSpan(
+  parentSpan: ISpan?,
+  tag: String,
+  startTimestamp: SentryDate,
+  endTimestamp: SentryDate,
+) {
+  parentSpan?.startChild(OP_COMPOSE, tag, startTimestamp)?.apply {
+    spanContext.origin = OP_TRACE_ORIGIN
+    finish(null, endTimestamp)
+  }
+}
+
+private fun recordRenderSpan(
+  parentSpan: ISpan?,
+  tag: String,
+  startTimestamp: SentryDate,
+  endTimestamp: SentryDate,
+) {
+  parentSpan?.startChild(OP_RENDER, tag, startTimestamp)?.apply {
+    finish(null, endTimestamp)
+  }
 }

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
@@ -80,12 +80,13 @@ public fun SentryTraced(
   val parentRenderingSpan = localSentryRenderingParentSpan.current.item
   val dateProvider = Sentry.getCurrentScopes().options.dateProvider
 
-  val compositionStart = dateProvider.now()
+  // Only record spans if we have a parent for them.
+  val compositionStart = parentCompositionSpan?.let { dateProvider.now() }
 
   Box(
     modifier =
       baseModifier.drawWithContent {
-        if (alreadyRendered.item) {
+        if (alreadyRendered.item || parentRenderingSpan == null) {
           drawContent()
         } else {
           val renderStart = dateProvider.now()
@@ -100,9 +101,10 @@ public fun SentryTraced(
   ) {
     content()
   }
-  val compositionEnd = dateProvider.now()
 
-  if (parentCompositionSpan != null) {
+  if (compositionStart != null) {
+    val compositionEnd = dateProvider.now()
+
     SideEffect {
       recordCompositionSpan(
         parentSpan = parentCompositionSpan,


### PR DESCRIPTION
## :scroll: Description

PR repairs a few defects in the implementation of `SentryTraced` while aiming to maintain parity with the previous approach. In particular it:

1. Prevents dangling composition spans in cases where the Compose runtime abandons the composition. (We now delay creating the span until a SideEffect executes.)

2. Prevents dangling render spans in cases where drawContent() throws and the host app recovers. (Similarly, we delay creating the span until drawContent() completes successfully.)


## :bulb: Motivation and Context

Dangling spans remain attached to their parent transaction and can delay transaction capture if `waitForChildren` is enabled. They're also confusing in the Sentry dashboard because they look like poor performing compositions, when in fact they will have simply been abandoned in the ordinary course by the Compose runtime.

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## Spans before vs after

I had my clanker exercise SentryTraced composables in our sample app to test span durations before this change vs after. Expand below to see the results (tl;dr they're comparable, which is what we want).

<details>

| Flow | Baseline | Latest rerun |
| --- | --- | --- |
| Stock MainActivity -> Integrations -> Compose | 11 `ui.compose` + 11 `ui.render` child spans | 21 `ui.compose` + 21 `ui.render` child spans |
| Extra `Integrations` spans in stock flow | No | Yes |
| `composition.result` tag | No | No |
| Child `ui.render` origin | `manual` | `manual` |
| ComposeActivity-first child span set | 7 `ui.compose` + 7 `ui.render` | 7 `ui.compose` + 7 `ui.render` |

_Note: We're likely seeing more spans after this PR (21 vs 11) because of a race that's always been present between when the root transaction becomes active vs when we start the composition span. We now start later, which means the transaction has more time to set itself up, and therefore fewer spans are lost. I plan to tackle this problem fully with the introduction of `LocalSentrySpan` in a subsequent PR._

| Span description | Baseline (ms) | Latest rerun (ms) | Delta (ms) |
| --- | ---: | ---: | ---: |
| Jetpack Compose Initial Composition | 106.549 | 113.869 | +7.320 |
| navhost | 10.408 | 16.849 | +6.441 |
| buttons_page | 43.769 | 28.652 | -15.117 |
| button_nav_github | 24.341 | 10.637 | -13.704 |
| button_nav_github_args | 1.702 | 0.755 | -0.947 |
| button_crash | 2.749 | 0.643 | -2.106 |
| button_dialog (first) | 2.671 | 0.770 | -1.901 |
| button_dialog (second) | 8.746 | 14.314 | +5.568 |

| Span description | Baseline (ms) | Latest rerun (ms) | Delta (ms) |
| --- | ---: | ---: | ---: |
| Jetpack Compose Initial Render | 7.311 | 10.561 | +3.250 |
| navhost | 7.311 | 10.561 | +3.250 |
| buttons_page | 7.006 | 10.377 | +3.371 |
| button_nav_github | 3.287 | 2.813 | -0.474 |
| button_nav_github_args | 0.535 | 1.163 | +0.628 |
| button_crash | 0.245 | 0.761 | +0.516 |
| button_dialog (first) | 0.251 | 0.937 | +0.686 |
| button_dialog (second) | 1.902 | 2.842 | +0.940 |
</details>


## :green_heart: How did you test it?

Unit tests and manual tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps

Two more `SentryTraced` related PRs:

1. Behavior changes: Only report a composition span for the first successful composition + include origin info with the render span like we do with the composition span.
3. Fix the currently broken CompositionLocals that lead to the possibility of a stale parent transaction via a new `LocalSentrySpan` CompositionLocal.