### PR TITLE
chore(compose): Update SentryTraced to emit a span only for initial composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Improvements
 
+- Emit a single `ui.compose` span per `SentryTraced` on initial composition instead of one on every recomposition, and set the origin on `ui.render` spans ([#6051](https://github.com/getsentry/sentry-java/pull/6051))
 - Move ANR profiling out of experimental ([#6042](https://github.com/getsentry/sentry-java/pull/6042))
 
 ### Fixes

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
@@ -3,7 +3,6 @@ package io.sentry.compose
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
@@ -25,45 +24,67 @@ private const val OP_RENDER = "ui.render"
 private const val OP_TRACE_ORIGIN = "auto.ui.jetpack_compose"
 
 private val localSentryCompositionParentSpan = compositionLocalOf {
-  ImmutableHolder(
-    getRootSpan()
-      ?.startChild(
-        OP_PARENT_COMPOSITION,
-        "Jetpack Compose Initial Composition",
-        SpanOptions().apply {
-          isTrimStart = true
-          isTrimEnd = true
-          isIdle = true
-        },
-      )
-      ?.apply { spanContext.origin = OP_TRACE_ORIGIN }
-  )
+  getRootSpan()
+    // Create a single parent span to own composition spans emitted by all SentryTraced composables
+    // during the root's lifetime.
+    ?.startChild(
+      OP_PARENT_COMPOSITION,
+      "Jetpack Compose Initial Composition",
+      SpanOptions().apply {
+        isTrimStart = true
+        isTrimEnd = true
+        isIdle = true
+      },
+    )
+    ?.apply { spanContext.origin = OP_TRACE_ORIGIN }
 }
 
 private val localSentryRenderingParentSpan = compositionLocalOf {
-  ImmutableHolder(
-    getRootSpan()
-      ?.startChild(
-        OP_PARENT_RENDER,
-        "Jetpack Compose Initial Render",
-        SpanOptions().apply {
-          isTrimStart = true
-          isTrimEnd = true
-          isIdle = true
-        },
-      )
-      ?.apply { spanContext.origin = OP_TRACE_ORIGIN }
-  )
+  getRootSpan()
+    // Create a single parent span to own render spans emitted by all SentryTraced composables
+    // during the root's lifetime.
+    ?.startChild(
+      OP_PARENT_RENDER,
+      "Jetpack Compose Initial Render",
+      SpanOptions().apply {
+        isTrimStart = true
+        isTrimEnd = true
+        isIdle = true
+      },
+    )
+    ?.apply { spanContext.origin = OP_TRACE_ORIGIN }
 }
 
-@Immutable internal class ImmutableHolder<T>(var item: T)
+/**
+ * A substitute for Compose's `MutableState` that doesn't register itself with the snapshot system,
+ * so mutating [value] never triggers recomposition.
+ */
+private class MutableRef<T>(var value: T)
 
 /**
- * Creates spans for tracking the time required to compose the wrapped [content], and a span for its
- * initial draw.
+ * Creates a single span for tracking the time required to compose the wrapped [content], and a span
+ * for its initial draw.
  *
  * Spans are approximate and include work performed by any composables [content] invokes. Abandoned
  * recompositions are ignored.
+ *
+ * Spans live under a set of parents shared by all `SentryTraced` composables. Every `SentryTraced`
+ * contributes at most one `ui.compose` child and one `ui.render` child per parent lifetime:
+ * ```
+ * Root span
+ * │
+ * ├─ ui.compose.composition  "Jetpack Compose Initial Composition"
+ * │   ├─ ui.compose   "product_info"
+ * │   └─ ui.compose   "add_to_cart_button"
+ * │
+ * └─ ui.compose.rendering    "Jetpack Compose Initial Render"
+ *     ├─ ui.render    "product_info"
+ *     └─ ui.render    "add_to_cart_button"
+ * ```
+ *
+ * Here `ui.compose.composition` and `ui.compose.rendering` are the shared parents. A `SentryTraced`
+ * generates the "product_info" spans, and a separate `SentryTraced` generates the
+ * "add_to_cart_button" spans.
  */
 @ExperimentalComposeUiApi
 @Composable
@@ -73,27 +94,30 @@ public fun SentryTraced(
   enableUserInteractionTracing: Boolean = true,
   content: @Composable BoxScope.() -> Unit,
 ) {
-  val alreadyRendered = remember { ImmutableHolder(false) }
   val baseModifier = if (enableUserInteractionTracing) modifier.sentryTag(tag) else modifier
 
-  val parentCompositionSpan = localSentryCompositionParentSpan.current.item
-  val parentRenderingSpan = localSentryRenderingParentSpan.current.item
+  val parentCompositionSpan = localSentryCompositionParentSpan.current
+  val parentRenderingSpan = localSentryRenderingParentSpan.current
+
+  val alreadyComposed = remember(parentCompositionSpan) { MutableRef(false) }
+  val alreadyRendered = remember(parentRenderingSpan) { MutableRef(false) }
   val dateProvider = Sentry.getCurrentScopes().options.dateProvider
 
   // Only record spans if we have a parent for them.
-  val compositionStart = parentCompositionSpan?.let { dateProvider.now() }
+  val compositionStart =
+    if (!alreadyComposed.value) parentCompositionSpan?.let { dateProvider.now() } else null
 
   Box(
     modifier =
       baseModifier.drawWithContent {
-        if (alreadyRendered.item || parentRenderingSpan == null) {
+        if (alreadyRendered.value || parentRenderingSpan == null) {
           drawContent()
         } else {
           val renderStart = dateProvider.now()
           drawContent()
           val renderEnd = dateProvider.now()
 
-          alreadyRendered.item = true
+          alreadyRendered.value = true
           recordRenderSpan(parentRenderingSpan, tag, renderStart, renderEnd)
         }
       },
@@ -112,6 +136,8 @@ public fun SentryTraced(
         startTimestamp = compositionStart,
         endTimestamp = compositionEnd,
       )
+
+      alreadyComposed.value = true
     }
   }
 }
@@ -141,6 +167,7 @@ private fun recordRenderSpan(
   endTimestamp: SentryDate,
 ) {
   parentSpan?.startChild(OP_RENDER, tag, startTimestamp)?.apply {
+    spanContext.origin = OP_TRACE_ORIGIN
     finish(null, endTimestamp)
   }
 }


### PR DESCRIPTION
## :scroll: Description

PR updates SentryTraced to:

1. emit a span _only_ for initial composition, rather than for every composition of the wrapped composable; and
2. add an origin to `ui.render` spans, just like we already do for composition spans.

I've also cleaned up use of ImmutableHolder and renamed it to MutableRef in response to @runningcode's reasonable thoughts [here](https://github.com/getsentry/sentry-java/pull/6049#discussion_r3922636110).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These are behavior changes to follow the fixes in [#6049](https://github.com/getsentry/sentry-java/pull/6049).

⚠️ Item (1):

- matches the current description we apply to the composition spans' parent ("Jetpack Compose **_Initial_** Composition"); 
- helps prevent the composition parent from getting overcrowded (see the diagram in the SentryTraced KDoc for why that's the case);
- reflects (AFAICT) the original intent of [#2507](https://github.com/getsentry/sentry-java/pull/2507); and
- is what I'd expect developers to actually care about (chime in if you think differently!).

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?
<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->

I had my clanker exercise SentryTraced composables in our sample app and verify the output.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps

Fix the currently broken CompositionLocals that lead to the possibility of a stale parent transaction.