### PR TITLE
fix(compose): Ensure SentryTraced spans respect ignore-by-origin requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Update `SentryTraced` so that it now honors `options.setIgnoredSpanOrigins` ([#6058](https://github.com/getsentry/sentry-java/pull/6058))
 - `SentryTraced` now checks for its owning transaction dynamically rather than once per app process. The latter caused `SentryTraced` spans to be dropped process-wide once the original transaction finished ([#6057](https://github.com/getsentry/sentry-java/pull/6057))
 - Fix typos in Spring GraphQL integration names (`GrahQL` to `GraphQL`) ([#6061](https://github.com/getsentry/sentry-java/pull/6061))
 

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
@@ -125,10 +125,15 @@ private fun recordCompositionSpan(
 ) {
   val bucketSpan = BucketSpans.getOrCreateCompositionSpan(ownerSpan, startTimestamp) ?: return
 
-  bucketSpan.startChild(OP_COMPOSITION_SPAN, tag, startTimestamp).apply {
-    spanContext.origin = OP_TRACE_ORIGIN
-    finish(null, endTimestamp)
-  }
+  bucketSpan
+    .startChild(
+      OP_COMPOSITION_SPAN,
+      tag,
+      startTimestamp,
+      Instrumenter.SENTRY,
+      SpanOptions().apply { origin = OP_TRACE_ORIGIN },
+    )
+    .run { finish(null, endTimestamp) }
 }
 
 /**
@@ -145,10 +150,15 @@ private fun recordRenderSpan(
 ) {
   val bucketSpan = BucketSpans.getOrCreateRenderSpan(ownerSpan, startTimestamp) ?: return
 
-  bucketSpan.startChild(OP_RENDER_SPAN, tag, startTimestamp).apply {
-    spanContext.origin = OP_TRACE_ORIGIN
-    finish(null, endTimestamp)
-  }
+  bucketSpan
+    .startChild(
+      OP_RENDER_SPAN,
+      tag,
+      startTimestamp,
+      Instrumenter.SENTRY,
+      SpanOptions().apply { origin = OP_TRACE_ORIGIN },
+    )
+    .run { finish(null, endTimestamp) }
 }
 
 /**
@@ -237,6 +247,7 @@ private class BucketSpans {
         startTimestamp,
         Instrumenter.SENTRY,
         SpanOptions().apply {
+          origin = OP_TRACE_ORIGIN
           isTrimStart = true
           isTrimEnd = true
           isIdle = true
@@ -246,8 +257,6 @@ private class BucketSpans {
     if (bucketSpan.dropsChildSpans) {
       return null
     }
-
-    bucketSpan.spanContext.origin = OP_TRACE_ORIGIN
     setCached(WeakReference(bucketSpan))
     return bucketSpan
   }

--- a/sentry-compose/src/androidUnitTest/kotlin/io/sentry/compose/SentryTracedTest.kt
+++ b/sentry-compose/src/androidUnitTest/kotlin/io/sentry/compose/SentryTracedTest.kt
@@ -129,6 +129,26 @@ class SentryTracedTest {
   }
 
   @Test
+  fun `does not create spans when origin is ignored`() {
+    val tx =
+      initSentryAndStartTransaction("tx") { options ->
+        options.setIgnoredSpanOrigins(listOf(OP_TRACE_ORIGIN))
+      }
+
+    rule.setContent {
+      SentryTraced(tag = "product_info") { Box(Modifier.size(1.dp).testTag("content")) }
+    }
+    rule.waitForIdle()
+    drawContent()
+
+    rule.onNodeWithTag("content").assertExists()
+    assertThat(tx.countSpans(OP_PARENT_COMPOSITION)).isEqualTo(0)
+    assertThat(tx.countSpans(OP_COMPOSE)).isEqualTo(0)
+    assertThat(tx.countSpans(OP_PARENT_RENDER)).isEqualTo(0)
+    assertThat(tx.countSpans(OP_RENDER)).isEqualTo(0)
+  }
+
+  @Test
   fun `sibling traced composables with the same owner share the composition parent`() {
     val tx = initSentryAndStartTransaction("tx")
 
@@ -381,13 +401,17 @@ class SentryTracedTest {
     assertThat(renderingTx.countSpans(OP_RENDER)).isEqualTo(0)
   }
 
-  private fun initSentryAndStartTransaction(name: String): ITransaction {
+  private fun initSentryAndStartTransaction(
+    name: String,
+    configureOptions: (SentryOptions) -> Unit = {},
+  ): ITransaction {
     lateinit var tx: ITransaction
     rule.runOnUiThread {
       Sentry.init(
         { options: SentryOptions ->
           options.dsn = "https://key@sentry.io/proj"
           options.tracesSampleRate = 1.0
+          configureOptions(options)
         },
         true,
       )


### PR DESCRIPTION
## :scroll: Description

Fixes a bug where we set span origins for SentryTraced after their creation via the span context, resulting in our ignore-span-origins logic not being able to see them and spans being produced when they should have been ignored / suppressed.

## :bulb: Motivation and Context

This issue has been with us for a while, but was discovered (along with a number of others) in connection with my Nav3 work. 

The general rule is that we need to set span origins during creation and not afterwards via span context or else checks list `ignoreSpanOrigins` will be ignored.

## What went wrong?

SentryTracer checks `ignoredSpanOrigins` during span creation, before the returned span can be mutated:

```java
if (SpanUtils.isIgnored(scopes.getOptions().getIgnoredSpanOrigins(), spanOptions.getOrigin())) {
  return NoOpSpan.getInstance();
}
```

That check reads SpanOptions.origin, not the SpanContext.origin we were setting after creation.

So if a host app did this...

```kotlin
options.setIgnoredSpanOrigins(listOf("auto.ui.jetpack_compose"))
```

...it would no-op and the Compose spans were created nonetheless.

The issue affected both levels of the SentryTraced span hierarchy (ie, both parent spans and child spans).

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?
<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->

Unit regression test + I had my clanker verify the fix works and is correct via our Android sample apps.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
