### PR TITLE
chore(android): Add product list to Nav2 sample

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2ComposeRoutes.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2ComposeRoutes.kt
@@ -27,11 +27,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -313,16 +315,47 @@ private fun Nav2ComposeHomeRoute(routeSpec: Nav2RouteSpec, onBrowseProducts: () 
   Nav2ComposeActionRoute(routeSpec, buttons = listOf("Browse Products" to onBrowseProducts))
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun Nav2ComposeProductListRoute(
   routeSpec: Nav2RouteSpec,
   onOpenProduct42: () -> Unit,
   onOpenProduct7: () -> Unit,
 ) {
-  Nav2ComposeActionRoute(
-    routeSpec,
-    buttons = listOf("Open Product 42" to onOpenProduct42, "Open Product 7" to onOpenProduct7),
-  )
+  var showProductItems by rememberSaveable { mutableStateOf(false) }
+
+  Nav2ComposeRouteScaffold(
+    routeSpec = routeSpec,
+    cardContent = {
+      SentryTraced(
+        tag = "product_list_actions",
+        modifier = Modifier.fillMaxWidth(),
+        enableUserInteractionTracing = false,
+      ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          Nav2ComposeRouteButton("Open Product 42", onOpenProduct42)
+          Nav2ComposeRouteButton("Open Product 7", onOpenProduct7)
+        }
+      }
+    },
+  ) {
+    Nav2ComposeRouteButton(
+      label = if (showProductItems) "Hide Product Items" else "Show Product Items",
+      onClick = { showProductItems = !showProductItems },
+    )
+
+    if (showProductItems) {
+      SentryTraced(
+        tag = "product_list_items",
+        modifier = Modifier.fillMaxWidth(),
+        enableUserInteractionTracing = false,
+      ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          repeat(PRODUCT_LIST_ITEM_COUNT) { index -> Nav2ComposeProductListItem(index + 1) }
+        }
+      }
+    }
+  }
 }
 
 @Composable
@@ -489,6 +522,7 @@ private fun Nav2ComposeShareSheetRoute(
 @Composable
 private fun Nav2ComposeRouteScaffold(
   routeSpec: Nav2RouteSpec,
+  cardContent: (@Composable ColumnScope.() -> Unit)? = null,
   content: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
   Column(
@@ -501,7 +535,7 @@ private fun Nav2ComposeRouteScaffold(
       fontWeight = FontWeight.Bold,
     )
     routeSpec.description?.let { Text(it, style = MaterialTheme.typography.bodyMedium) }
-    if (content != null) {
+    if (cardContent != null) {
       Card(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
         modifier = Modifier.fillMaxWidth(),
@@ -510,8 +544,32 @@ private fun Nav2ComposeRouteScaffold(
           modifier = Modifier.padding(16.dp),
           verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-          content()
+          cardContent()
         }
+      }
+    }
+    content?.invoke(this)
+  }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun Nav2ComposeProductListItem(index: Int) {
+  SentryTraced(
+    tag = "product_list_item_$index",
+    modifier = Modifier.fillMaxWidth(),
+    enableUserInteractionTracing = false,
+  ) {
+    Card(
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      Row(
+        modifier = Modifier.fillMaxWidth().padding(12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+      ) {
+        Text("Product #$index", fontWeight = FontWeight.Bold)
+        Text("SKU-$index")
       }
     }
   }
@@ -533,6 +591,8 @@ private fun Nav2ComposeRouteButton(
 }
 
 private fun nav2ComposeInteractionTag(label: String): String = "Nav2 Compose $label"
+
+private const val PRODUCT_LIST_ITEM_COUNT = 20
 
 @Composable
 private fun Nav2ComposeRouteInfo(label: String, value: String) {

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2ComposeRoutes.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2ComposeRoutes.kt
@@ -421,12 +421,15 @@ private fun Nav2ComposeActionRoute(
   arguments: Map<String, Any?> = emptyMap(),
   buttons: List<Pair<String, () -> Unit>>,
 ) {
-  Nav2ComposeRouteScaffold(routeSpec) {
-    routeSpec.displayArguments(arguments).forEach { (label, value) ->
-      Nav2ComposeRouteInfo(label, value)
-    }
-    buttons.forEach { (label, onClick) -> Nav2ComposeRouteButton(label, onClick) }
-  }
+  Nav2ComposeRouteScaffold(
+    routeSpec = routeSpec,
+    cardContent = {
+      routeSpec.displayArguments(arguments).forEach { (label, value) ->
+        Nav2ComposeRouteInfo(label, value)
+      }
+      buttons.forEach { (label, onClick) -> Nav2ComposeRouteButton(label, onClick) }
+    },
+  )
 }
 
 @Composable

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2RouteFragment.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2RouteFragment.kt
@@ -68,6 +68,7 @@ class Nav2RouteFragment : Fragment() {
                 activity.navigateTo(Nav2Destination.ProductDetail("7", "product-list"))
               },
             ),
+          trailingContent = { addProductListItemsToggle() },
         )
 
       Nav2RouteNames.PRODUCT_DETAIL -> productDetailLayout(activity)
@@ -131,7 +132,6 @@ class Nav2RouteFragment : Fragment() {
             activity.navigateTo(Nav2Destination.Checkout(productId))
           },
         ),
-      trailingContent = { addProductDetailItemsToggle(productId) },
     )
   }
 
@@ -192,7 +192,7 @@ class Nav2RouteFragment : Fragment() {
     }
   }
 
-  private fun LinearLayout.addProductDetailItemsToggle(productId: String) {
+  private fun LinearLayout.addProductListItemsToggle() {
     var itemsCreated = false
     var itemsVisible = false
     val listContainer =
@@ -215,7 +215,7 @@ class Nav2RouteFragment : Fragment() {
           itemsVisible = !itemsVisible
           text = if (itemsVisible) "Hide Product Items" else "Show Product Items"
           if (itemsVisible && !itemsCreated) {
-            populateProductDetailItems(listContainer, productId)
+            populateProductListItems(listContainer)
             itemsCreated = true
           }
           scrollView.visibility = if (itemsVisible) View.VISIBLE else View.GONE
@@ -226,23 +226,23 @@ class Nav2RouteFragment : Fragment() {
     addView(scrollView)
   }
 
-  private fun populateProductDetailItems(listContainer: LinearLayout, productId: String) {
+  private fun populateProductListItems(listContainer: LinearLayout) {
     val ownerSpan = Sentry.getSpan()
     val compositionParent =
       ownerSpan?.startChild(
         OP_PARENT_COMPOSITION,
-        "Fragment Product Detail Item List Composition",
+        "Fragment Product List Item List Composition",
       )
     try {
-      recordManualUiSpan(compositionParent, OP_COMPOSE, "fragment_product_detail_items") {
-        repeat(PRODUCT_DETAIL_ITEM_COUNT) { index ->
+      recordManualUiSpan(compositionParent, OP_COMPOSE, "fragment_product_list_items") {
+        repeat(PRODUCT_LIST_ITEM_COUNT) { index ->
           val itemNumber = index + 1
           recordManualUiSpan(
             compositionParent,
             OP_COMPOSE,
-            "fragment_product_detail_item_$itemNumber",
+            "fragment_product_list_item_$itemNumber",
           ) {
-            listContainer.addView(productDetailItemRow(productId, itemNumber))
+            listContainer.addView(productListItemRow(itemNumber))
           }
         }
       }
@@ -254,12 +254,12 @@ class Nav2RouteFragment : Fragment() {
       val renderParent =
         ownerSpan?.startChild(
           OP_PARENT_RENDER,
-          "Fragment Product Detail Item List Render",
+          "Fragment Product List Item List Render",
         )
       try {
-        recordManualUiSpan(renderParent, OP_RENDER, "fragment_product_detail_items")
-        repeat(PRODUCT_DETAIL_ITEM_COUNT) { index ->
-          recordManualUiSpan(renderParent, OP_RENDER, "fragment_product_detail_item_${index + 1}")
+        recordManualUiSpan(renderParent, OP_RENDER, "fragment_product_list_items")
+        repeat(PRODUCT_LIST_ITEM_COUNT) { index ->
+          recordManualUiSpan(renderParent, OP_RENDER, "fragment_product_list_item_${index + 1}")
         }
       } finally {
         renderParent?.finish()
@@ -282,14 +282,14 @@ class Nav2RouteFragment : Fragment() {
     }
   }
 
-  private fun productDetailItemRow(productId: String, itemNumber: Int): View =
+  private fun productListItemRow(itemNumber: Int): View =
     LinearLayout(requireContext()).apply {
       orientation = LinearLayout.HORIZONTAL
       setPadding(12.dp)
       setBackgroundColor(color(android.R.color.white))
       addView(
         TextView(context).apply {
-          text = "Product $productId item #$itemNumber"
+          text = "Product #$itemNumber"
           textSize = 14f
           setTypeface(null, Typeface.BOLD)
           layoutParams = LinearLayout.LayoutParams(0, WRAP_CONTENT, 1f)
@@ -297,7 +297,7 @@ class Nav2RouteFragment : Fragment() {
       )
       addView(
         TextView(context).apply {
-          text = "SKU-$productId-$itemNumber"
+          text = "SKU-$itemNumber"
           textSize = 14f
         }
       )
@@ -344,7 +344,7 @@ class Nav2RouteFragment : Fragment() {
   private fun color(id: Int): Int = requireContext().getColor(id)
 
   private companion object {
-    private const val PRODUCT_DETAIL_ITEM_COUNT = 20
+    private const val PRODUCT_LIST_ITEM_COUNT = 20
     private const val OP_PARENT_COMPOSITION = "ui.compose.composition"
     private const val OP_COMPOSE = "ui.compose"
     private const val OP_PARENT_RENDER = "ui.compose.rendering"

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2RouteFragment.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/navigation/Nav2RouteFragment.kt
@@ -7,10 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import io.sentry.ISpan
+import io.sentry.Sentry
 import io.sentry.samples.android.R
 import kotlinx.coroutines.launch
 
@@ -127,6 +131,7 @@ class Nav2RouteFragment : Fragment() {
             activity.navigateTo(Nav2Destination.Checkout(productId))
           },
         ),
+      trailingContent = { addProductDetailItemsToggle(productId) },
     )
   }
 
@@ -163,6 +168,7 @@ class Nav2RouteFragment : Fragment() {
     routeSpec: Nav2RouteSpec,
     arguments: Bundle? = null,
     buttons: List<RouteButton> = emptyList(),
+    trailingContent: (LinearLayout.() -> Unit)? = null,
   ): View {
     val info = routeSpec.displayArguments(arguments)
     return LinearLayout(requireContext()).apply {
@@ -182,8 +188,120 @@ class Nav2RouteFragment : Fragment() {
           }
         )
       }
+      trailingContent?.invoke(this)
     }
   }
+
+  private fun LinearLayout.addProductDetailItemsToggle(productId: String) {
+    var itemsCreated = false
+    var itemsVisible = false
+    val listContainer =
+      LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(0, 8.dp, 0, 0)
+      }
+    val scrollView =
+      ScrollView(context).apply {
+        visibility = View.GONE
+        layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, 280.dp)
+        addView(listContainer, ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT))
+      }
+
+    addView(
+      Button(context).apply {
+        text = "Show Product Items"
+        isAllCaps = false
+        setOnClickListener {
+          itemsVisible = !itemsVisible
+          text = if (itemsVisible) "Hide Product Items" else "Show Product Items"
+          if (itemsVisible && !itemsCreated) {
+            populateProductDetailItems(listContainer, productId)
+            itemsCreated = true
+          }
+          scrollView.visibility = if (itemsVisible) View.VISIBLE else View.GONE
+        }
+        layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+      }
+    )
+    addView(scrollView)
+  }
+
+  private fun populateProductDetailItems(listContainer: LinearLayout, productId: String) {
+    val ownerSpan = Sentry.getSpan()
+    val compositionParent =
+      ownerSpan?.startChild(
+        OP_PARENT_COMPOSITION,
+        "Fragment Product Detail Item List Composition",
+      )
+    try {
+      recordManualUiSpan(compositionParent, OP_COMPOSE, "fragment_product_detail_items") {
+        repeat(PRODUCT_DETAIL_ITEM_COUNT) { index ->
+          val itemNumber = index + 1
+          recordManualUiSpan(
+            compositionParent,
+            OP_COMPOSE,
+            "fragment_product_detail_item_$itemNumber",
+          ) {
+            listContainer.addView(productDetailItemRow(productId, itemNumber))
+          }
+        }
+      }
+    } finally {
+      compositionParent?.finish()
+    }
+
+    listContainer.doOnPreDraw {
+      val renderParent =
+        ownerSpan?.startChild(
+          OP_PARENT_RENDER,
+          "Fragment Product Detail Item List Render",
+        )
+      try {
+        recordManualUiSpan(renderParent, OP_RENDER, "fragment_product_detail_items")
+        repeat(PRODUCT_DETAIL_ITEM_COUNT) { index ->
+          recordManualUiSpan(renderParent, OP_RENDER, "fragment_product_detail_item_${index + 1}")
+        }
+      } finally {
+        renderParent?.finish()
+      }
+    }
+  }
+
+  private fun recordManualUiSpan(
+    parentSpan: ISpan?,
+    operation: String,
+    description: String,
+    block: () -> Unit = {},
+  ) {
+    val span = parentSpan?.startChild(operation, description)
+    span?.setData("sample.nav2_fragment_manual_ui_span", true)
+    try {
+      block()
+    } finally {
+      span?.finish()
+    }
+  }
+
+  private fun productDetailItemRow(productId: String, itemNumber: Int): View =
+    LinearLayout(requireContext()).apply {
+      orientation = LinearLayout.HORIZONTAL
+      setPadding(12.dp)
+      setBackgroundColor(color(android.R.color.white))
+      addView(
+        TextView(context).apply {
+          text = "Product $productId item #$itemNumber"
+          textSize = 14f
+          setTypeface(null, Typeface.BOLD)
+          layoutParams = LinearLayout.LayoutParams(0, WRAP_CONTENT, 1f)
+        }
+      )
+      addView(
+        TextView(context).apply {
+          text = "SKU-$productId-$itemNumber"
+          textSize = 14f
+        }
+      )
+    }
 
   private fun titleText(textValue: String): TextView =
     TextView(requireContext()).apply {
@@ -224,4 +342,12 @@ class Nav2RouteFragment : Fragment() {
     get() = (this * resources.displayMetrics.density).toInt()
 
   private fun color(id: Int): Int = requireContext().getColor(id)
+
+  private companion object {
+    private const val PRODUCT_DETAIL_ITEM_COUNT = 20
+    private const val OP_PARENT_COMPOSITION = "ui.compose.composition"
+    private const val OP_COMPOSE = "ui.compose"
+    private const val OP_PARENT_RENDER = "ui.compose.rendering"
+    private const val OP_RENDER = "ui.render"
+  }
 }


### PR DESCRIPTION
## :scroll: Description

Adds a new hide/show product list button to the Nav2Activity. For the Compose tab, doing so lets us observe the span-producing of multiple SentryTraced composables inside the same nav transaction. 

The list was also added to the Fragments tab to maintain UI parity.


## :bulb: Motivation and Context

Better manual test (and LLM) coverage for SentryTraced.

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?
<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->

By hand.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps

#skip-changelog