### PR TITLE
Fix typos in Spring GraphQL integration names (GrahQL to GraphQL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix typos in Spring GraphQL integration names (`GrahQL` to `GraphQL`)
+
 ## 8.55.0
 
 ### Features

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/graphql/SentryDgsSubscriptionHandler.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/graphql/SentryDgsSubscriptionHandler.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Flux;
 public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHandler {
 
   public SentryDgsSubscriptionHandler() {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7NetflixDGSGrahQL");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7NetflixDGSGraphQL");
   }
 
   @Override

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/graphql/SentryGraphql22Configuration.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/graphql/SentryGraphql22Configuration.java
@@ -23,7 +23,7 @@ public class SentryGraphql22Configuration {
   public SentryInstrumentation sentryInstrumentationWebMvc(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebMVC");
     return createInstrumentation(beforeSpanCallback, false);
   }
 
@@ -33,7 +33,7 @@ public class SentryGraphql22Configuration {
   public SentryInstrumentation sentryInstrumentationWebflux(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebFlux");
     return createInstrumentation(beforeSpanCallback, true);
   }
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/graphql/SentryGraphqlConfiguration.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/graphql/SentryGraphqlConfiguration.java
@@ -23,7 +23,7 @@ public class SentryGraphqlConfiguration {
   public SentryInstrumentation sentryInstrumentationWebMvc(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebMVC");
     return createInstrumentation(beforeSpanCallback, false);
   }
 
@@ -33,7 +33,7 @@ public class SentryGraphqlConfiguration {
   public SentryInstrumentation sentryInstrumentationWebflux(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebFlux");
     return createInstrumentation(beforeSpanCallback, true);
   }
 

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/graphql/SentryGraphql22AutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/graphql/SentryGraphql22AutoConfiguration.java
@@ -28,7 +28,7 @@ public class SentryGraphql22AutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebMVC");
     return createInstrumentation(sentryProperties, beforeSpanCallback, false);
   }
 
@@ -39,7 +39,7 @@ public class SentryGraphql22AutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebFlux");
     return createInstrumentation(sentryProperties, beforeSpanCallback, true);
   }
 

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/graphql/SentryGraphqlAutoConfiguration.java
@@ -28,7 +28,7 @@ public class SentryGraphqlAutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebMVC");
     return createInstrumentation(sentryProperties, beforeSpanCallback, false);
   }
 
@@ -39,7 +39,7 @@ public class SentryGraphqlAutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring7GraphQLWebFlux");
     return createInstrumentation(sentryProperties, beforeSpanCallback, true);
   }
 

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphql22AutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphql22AutoConfiguration.java
@@ -28,7 +28,7 @@ public class SentryGraphql22AutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebMVC");
     return createInstrumentation(sentryProperties, beforeSpanCallback, false);
   }
 
@@ -39,7 +39,7 @@ public class SentryGraphql22AutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebFlux");
     return createInstrumentation(sentryProperties, beforeSpanCallback, true);
   }
 

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration.java
@@ -28,7 +28,7 @@ public class SentryGraphqlAutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebMVC");
     return createInstrumentation(sentryProperties, beforeSpanCallback, false);
   }
 
@@ -39,7 +39,7 @@ public class SentryGraphqlAutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebFlux");
     return createInstrumentation(sentryProperties, beforeSpanCallback, true);
   }
 

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration.java
@@ -28,7 +28,7 @@ public class SentryGraphqlAutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GraphQLWebMVC");
     return createInstrumentation(sentryProperties, beforeSpanCallback, false);
   }
 
@@ -39,7 +39,7 @@ public class SentryGraphqlAutoConfiguration {
       final @NotNull SentryProperties sentryProperties,
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GraphQLWebFlux");
     return createInstrumentation(sentryProperties, beforeSpanCallback, true);
   }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryDgsSubscriptionHandler.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryDgsSubscriptionHandler.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Flux;
 public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHandler {
 
   public SentryDgsSubscriptionHandler() {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6NetflixDGSGrahQL");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6NetflixDGSGraphQL");
   }
 
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryGraphql22Configuration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryGraphql22Configuration.java
@@ -23,7 +23,7 @@ public class SentryGraphql22Configuration {
   public SentryInstrumentation sentryInstrumentationWebMvc(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebMVC");
     return createInstrumentation(beforeSpanCallback, false);
   }
 
@@ -33,7 +33,7 @@ public class SentryGraphql22Configuration {
   public SentryInstrumentation sentryInstrumentationWebflux(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebFlux");
     return createInstrumentation(beforeSpanCallback, true);
   }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryGraphqlConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryGraphqlConfiguration.java
@@ -23,7 +23,7 @@ public class SentryGraphqlConfiguration {
   public SentryInstrumentation sentryInstrumentationWebMvc(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebMVC");
     return createInstrumentation(beforeSpanCallback, false);
   }
 
@@ -33,7 +33,7 @@ public class SentryGraphqlConfiguration {
   public SentryInstrumentation sentryInstrumentationWebflux(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GraphQLWebFlux");
     return createInstrumentation(beforeSpanCallback, true);
   }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryDgsSubscriptionHandler.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryDgsSubscriptionHandler.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Flux;
 public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHandler {
 
   public SentryDgsSubscriptionHandler() {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5NetflixDGSGrahQL");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5NetflixDGSGraphQL");
   }
 
   @Override

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryGraphqlConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryGraphqlConfiguration.java
@@ -23,7 +23,7 @@ public class SentryGraphqlConfiguration {
   public SentryInstrumentation sentryInstrumentationWebMvc(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GrahQLWebMVC");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GraphQLWebMVC");
     return createInstrumentation(beforeSpanCallback, false);
   }
 
@@ -33,7 +33,7 @@ public class SentryGraphqlConfiguration {
   public SentryInstrumentation sentryInstrumentationWebflux(
       final @NotNull ObjectProvider<SentryGraphqlInstrumentation.BeforeSpanCallback>
               beforeSpanCallback) {
-    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GrahQLWebFlux");
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GraphQLWebFlux");
     return createInstrumentation(beforeSpanCallback, true);
   }
 


### PR DESCRIPTION
Fixes #4668.

Renames misspelled integration telemetry names (`GrahQL` to `GraphQL`) across Spring 5/6/7 modules: WebMVC, WebFlux and Netflix DGS variants (13 files, 23 string literals). String-only change, no tests reference these names. CHANGELOG entry added under Unreleased.