### PR TITLE
fix(core): [Data Collection 23] Support WebSocket URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Support `ws` and `wss` URL parsing for WebSocket instrumentation ([#6064](https://github.com/getsentry/sentry-java/pull/6064))
+
 ## 8.55.0
 
 ### Features

--- a/sentry/src/main/java/io/sentry/util/UrlUtils.java
+++ b/sentry/src/main/java/io/sentry/util/UrlUtils.java
@@ -55,6 +55,11 @@ public final class UrlUtils {
   }
 
   private static boolean isValidAbsoluteUrl(final @NotNull URI uri) {
+    final @Nullable String scheme = uri.getScheme();
+    if ("ws".equalsIgnoreCase(scheme) || "wss".equalsIgnoreCase(scheme)) {
+      return !uri.isOpaque() && uri.getRawAuthority() != null && !uri.getRawAuthority().isEmpty();
+    }
+
     try {
       uri.toURL();
     } catch (Exception e) {

--- a/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
@@ -357,10 +357,36 @@ class UrlUtilsTest {
   }
 
   @Test
-  fun `does not extract details from websockets uri`() {
-    val urlDetails = UrlUtils.parse("wss://example.com/socket")
-    assertNull(urlDetails.url)
-    assertNull(urlDetails.query)
-    assertNull(urlDetails.fragment)
+  fun `extracts details from websocket uri`() {
+    val urlDetails = UrlUtils.parse("ws://example.com/socket?channel=updates#top")
+
+    assertThat(urlDetails.url).isEqualTo("ws://example.com/socket")
+    assertThat(urlDetails.query).isEqualTo("channel=updates")
+    assertThat(urlDetails.fragment).isEqualTo("top")
+  }
+
+  @Test
+  fun `filters query parameters from secure websocket uri`() {
+    val options = SentryOptions().also { it.dataCollection.setUserInfo(false) }
+    val urlDetails =
+      UrlUtils.parse(
+        "wss://example.com/socket?channel=updates&token=secret",
+        options.dataCollectionResolver,
+      )
+
+    assertThat(urlDetails.url).isEqualTo("wss://example.com/socket")
+    assertThat(urlDetails.query).isEqualTo("channel=updates&token=[Filtered]")
+    assertThat(urlDetails.fragment).isNull()
+  }
+
+  @Test
+  fun `does not extract details from websocket uri without authority`() {
+    listOf("ws:example.com/socket", "wss:///socket").forEach { url ->
+      val urlDetails = UrlUtils.parse(url)
+
+      assertThat(urlDetails.url).isNull()
+      assertThat(urlDetails.query).isNull()
+      assertThat(urlDetails.fragment).isNull()
+    }
   }
 }


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Allow `UrlUtils` to parse structurally valid `ws` and `wss` URIs without requiring a JVM `URLStreamHandler`. Keep the existing handler-based validation for every other scheme to preserve support for built-in and customer-installed handlers.

## :bulb: Motivation and Context

Java WebSocket clients consume `URI` directly and generally do not install global URL handlers. Converting a valid WebSocket URI with `URI.toURL()` therefore commonly fails, causing Ktor WebSocket span descriptions and request URLs to fall back to unknown values.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew :sentry:test --tests='io.sentry.util.UrlUtilsTest' --rerun-tasks --no-parallel --no-configuration-cache --max-workers=1`
- `./gradlew spotlessApply apiDump --no-parallel --no-configuration-cache --max-workers=1`
- `git diff --check`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
