### PR TITLE
fix(core): [Data Collection 24] Narrow utility exception handling

### DIFF
--- a/sentry/src/main/java/io/sentry/util/GraphqlUtils.java
+++ b/sentry/src/main/java/io/sentry/util/GraphqlUtils.java
@@ -4,6 +4,7 @@ import io.sentry.DataCollectionResolver;
 import io.sentry.JsonObjectReader;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ public final class GraphqlUtils {
       final @NotNull StringWriter writer = new StringWriter();
       options.getSerializer().serialize(filtered, writer);
       return writer.toString();
-    } catch (Throwable e) {
+    } catch (IOException | NumberFormatException e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to filter GraphQL request body.", e);
       return null;
     }

--- a/sentry/src/main/java/io/sentry/util/HttpUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HttpUtils.java
@@ -4,6 +4,7 @@ import static io.sentry.util.UrlUtils.SENSITIVE_DATA_SUBSTITUTE;
 
 import io.sentry.HttpStatusCodeRange;
 import io.sentry.KeyValueCollectionBehavior;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -127,7 +128,7 @@ public final class HttpUtils {
   private static @NotNull String decodeQueryParamName(final @NotNull String name) {
     try {
       return URLDecoder.decode(name, "UTF-8");
-    } catch (Throwable ignored) {
+    } catch (IllegalArgumentException | UnsupportedEncodingException ignored) {
       return name;
     }
   }

--- a/sentry/src/test/java/io/sentry/util/GraphqlUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/GraphqlUtilsTest.kt
@@ -82,6 +82,15 @@ class GraphqlUtilsTest {
     assertThat(result).isNull()
   }
 
+  @Test
+  fun `returns null for a GraphQL request body containing a malformed unicode escape`() {
+    val options = SentryOptions().also { it.dataCollection.graphql.setDocument(false) }
+
+    val result = GraphqlUtils.filterRequestBody("""{"query":"\u12G4"}""", options)
+
+    assertThat(result).isNull()
+  }
+
   private companion object {
     const val REQUEST_BODY =
       """{"operationName":"GetUser","variables":{"id":"123"},"query":"query { viewer { name } }"}"""


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Narrow the exception handlers used while filtering GraphQL request bodies and decoding query parameter names. Keep malformed GraphQL Unicode escapes fail-closed by catching the vendored JSON reader's documented `NumberFormatException` alongside `IOException`.

## :bulb: Motivation and Context

The previous `catch (Throwable)` blocks could swallow fatal JVM errors such as `OutOfMemoryError` and `ThreadDeath`. These handlers now catch only the recoverable failures produced by their parsing operations while preserving the existing fallback behavior for malformed input.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew :sentry:test --tests io.sentry.util.GraphqlUtilsTest --tests io.sentry.util.HttpUtilsTest --rerun-tasks`
- `./gradlew spotlessApply apiDump`
- `git diff --check`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
