### PR TITLE
build: Bump AGP to 9.4.0

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agp: [ '9.0.0', '9.1.1', '9.2.1' ]
+        agp: [ '9.0.0', '9.2.1', '9.4.0' ]
         integrations: [ true, false ]
 
     name: AGP Matrix Release - AGP ${{ matrix.agp }} - Integrations ${{ matrix.integrations }}

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,6 +1,6 @@
 
 object Config {
-    val AGP = System.getenv("VERSION_AGP") ?: "9.2.1"
+    val AGP = System.getenv("VERSION_AGP") ?: "9.4.0"
     val kotlinStdLib = "stdlib-jdk8"
     val kotlinStdLibVersionAndroid = "1.9.24"
     val kotlinTestJunit = "test-junit"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.useAndroidX=true
 # AGP 9+ migration opt-outs until we remove kotlin-android plugin and adopt built-in Kotlin.
 android.builtInKotlin=false
 android.newDsl=false
-android.experimental.lint.version=9.2.1
+android.experimental.lint.version=9.4.0
 
 # Release information
 versionName=8.55.0


### PR DESCRIPTION
## :scroll: Description

Bumps the default Android Gradle Plugin from `9.2.1` to `9.4.0`, the latest stable release.

- `Config.AGP` default fallback: `9.2.1` → `9.4.0`
- `android.experimental.lint.version`: `9.2.1` → `9.4.0`, kept in lockstep with AGP as it has been since it was introduced
- AGP compatibility matrix: `9.0.0 / 9.1.1 / 9.2.1` → `9.0.0 / 9.2.1 / 9.4.0`

The matrix keeps the minimum supported version (`9.0.0`) and the new default (`9.4.0`). `9.1.1` gives way to the previous default `9.2.1` so the matrix stays at three jobs; happy to pick a different middle version if you'd rather keep `9.1.1`.

No source or API changes were needed — `apiDump` produced no diff.

## :bulb: Motivation and Context

Keep the toolchain on the current stable AGP.

## :green_heart: How did you test it?

Locally on JDK 17:

- `./gradlew assembleRelease` — [build scan](https://gradle.com/s/euc4ophwi2zke)
- `./gradlew lint` — clean, no new findings from lint 9.4.0 — [build scan](https://gradle.com/s/az36t6mcxzqcs)
- `./gradlew :sentry-android-core:testReleaseUnitTest` — [build scan](https://gradle.com/s/b46gx6xtjd4fq)
- `./gradlew spotlessApply apiDump` — no changes produced

The AGP matrix workflow exercises the full 9.0.0 / 9.2.1 / 9.4.0 range on CI.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.
