### PR TITLE
feat(core): [Data Collection 25] Apply file path policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   | `graphql.document` | `true` | Collects GraphQL documents. |
   | `graphql.variables` | `true` | Collects GraphQL variables. |
   | `databaseQueryData` | `true` | Allows collection of associated query data, such as bound parameters, write payloads, and results, where supported. Sanitized query statements and structural database metadata remain available. |
+  | `filePaths` | `true` | Allows file-system instrumentation to collect file and directory paths. File extensions and byte counts remain available when disabled. |
 
   Cookies, HTTP headers, and URL query parameters support three modes:
 
@@ -29,7 +30,7 @@
 
   Matching is case-insensitive and partial. The built-in sensitive deny-list contains `auth`, `token`, `secret`, `password`, `passwd`, `pwd`, `key`, `jwt`, `bearer`, `sso`, `saml`, `csrf`, `xsrf`, `credentials`, `session`, `sid`, and `identity`. Filtered values are replaced with `"[Filtered]"`. Custom deny-list terms extend rather than replace this list.
 
-  Configure all HTTP body types, a custom cookie deny-list, a request-header allow-list, and disable URL query parameter collection in an options callback:
+  Configure all HTTP body types, a custom cookie deny-list, a request-header allow-list, and disable URL query parameter and file path collection in an options callback:
 
   ```java
   Sentry.init(
@@ -55,6 +56,7 @@
         options
             .getDataCollection()
             .setUrlQueryParams(KeyValueCollectionBehavior.off());
+        options.getDataCollection().setFilePaths(false);
       });
   ```
 
@@ -67,6 +69,7 @@
   data-collection.http-headers.request.mode=allow_list
   data-collection.http-headers.request.terms=content-type,x-request-id
   data-collection.url-query-params.mode=off
+  data-collection.file-paths=false
   ```
 
   Configure them with Spring Boot properties:
@@ -78,6 +81,7 @@
   sentry.data-collection.http-headers.request.mode=allow-list
   sentry.data-collection.http-headers.request.terms=content-type,x-request-id
   sentry.data-collection.url-query-params.mode=off
+  sentry.data-collection.file-paths=false
   ```
 
   Configure them in `AndroidManifest.xml`:
@@ -101,6 +105,9 @@
   <meta-data
       android:name="io.sentry.data-collection.url-query-params.mode"
       android:value="off" />
+  <meta-data
+      android:name="io.sentry.data-collection.file-paths"
+      android:value="false" />
   ```
 
   See the [Data Collection documentation](https://docs.sentry.io/platforms/java/configuration/options/#dataCollection) for all configuration keys, supported integrations, and migration guidance.

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -126,6 +126,7 @@ final class ManifestMetadataReader {
       "io.sentry.data-collection.graphql.variables";
   static final String DATA_COLLECTION_DATABASE_QUERY_DATA =
       "io.sentry.data-collection.database-query-data";
+  static final String DATA_COLLECTION_FILE_PATHS = "io.sentry.data-collection.file-paths";
 
   static final String PERFORM_FRAMES_TRACKING = "io.sentry.traces.frames-tracking";
 
@@ -886,6 +887,10 @@ final class ManifestMetadataReader {
           readBool(metadata, logger, DATA_COLLECTION_DATABASE_QUERY_DATA, false));
     }
 
+    if (containsKey(metadata, DATA_COLLECTION_FILE_PATHS)) {
+      dataCollection.setFilePaths(readBool(metadata, logger, DATA_COLLECTION_FILE_PATHS, false));
+    }
+
     return dataCollection.isExplicitlyConfigured() ? dataCollection : null;
   }
 
@@ -917,6 +922,9 @@ final class ManifestMetadataReader {
     }
     if (source.getDatabaseQueryData() != null) {
       target.setDatabaseQueryData(source.getDatabaseQueryData());
+    }
+    if (source.getFilePaths() != null) {
+      target.setFilePaths(source.getFilePaths());
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1485,6 +1485,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.DATA_COLLECTION_GRAPHQL_DOCUMENT to false,
         ManifestMetadataReader.DATA_COLLECTION_GRAPHQL_VARIABLES to true,
         ManifestMetadataReader.DATA_COLLECTION_DATABASE_QUERY_DATA to false,
+        ManifestMetadataReader.DATA_COLLECTION_FILE_PATHS to false,
       )
     val context = fixture.getContext(metaData = bundle)
 
@@ -1504,6 +1505,7 @@ class ManifestMetadataReaderTest {
     assertThat(dataCollection.graphql.document).isFalse()
     assertThat(dataCollection.graphql.variables).isTrue()
     assertThat(dataCollection.databaseQueryData).isFalse()
+    assertThat(dataCollection.filePaths).isFalse()
   }
 
   @Test
@@ -1519,6 +1521,7 @@ class ManifestMetadataReaderTest {
         graphql.setDocument(true)
         graphql.setVariables(false)
         setDatabaseQueryData(true)
+        setFilePaths(true)
       }
     val bundle =
       bundleOf(
@@ -1543,6 +1546,7 @@ class ManifestMetadataReaderTest {
     assertThat(dataCollection.graphql.document).isTrue()
     assertThat(dataCollection.graphql.variables).isFalse()
     assertThat(dataCollection.databaseQueryData).isTrue()
+    assertThat(dataCollection.filePaths).isTrue()
   }
 
   @Test

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -308,7 +308,7 @@ class SentryAutoConfigurationTest {
   }
 
   @Test
-  fun `data collection key value properties are applied to SentryOptions`() {
+  fun `data collection properties are applied to SentryOptions`() {
     contextRunner
       .withPropertyValues(
         "sentry.dsn=http://key@localhost/proj",
@@ -319,6 +319,7 @@ class SentryAutoConfigurationTest {
         "sentry.data-collection.http-headers.request.terms=forwarded,-ip",
         "sentry.data-collection.http-headers.response.mode=allow-list",
         "sentry.data-collection.http-headers.response.terms=content-type,x-request-id",
+        "sentry.data-collection.file-paths=false",
       )
       .run {
         val dataCollection = it.getBean(SentryProperties::class.java).dataCollection
@@ -333,6 +334,7 @@ class SentryAutoConfigurationTest {
           .isEqualTo(KeyValueCollectionBehavior.Mode.ALLOW_LIST)
         assertThat(dataCollection.httpHeaders.response!!.terms)
           .containsExactly("content-type", "x-request-id")
+        assertThat(dataCollection.filePaths).isFalse()
       }
   }
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -316,7 +316,7 @@ class SentryAutoConfigurationTest {
   }
 
   @Test
-  fun `data collection key value properties are applied to SentryOptions`() {
+  fun `data collection properties are applied to SentryOptions`() {
     contextRunner
       .withPropertyValues(
         "sentry.dsn=http://key@localhost/proj",
@@ -327,6 +327,7 @@ class SentryAutoConfigurationTest {
         "sentry.data-collection.http-headers.request.terms=forwarded,-ip",
         "sentry.data-collection.http-headers.response.mode=allow-list",
         "sentry.data-collection.http-headers.response.terms=content-type,x-request-id",
+        "sentry.data-collection.file-paths=false",
       )
       .run {
         val dataCollection = it.getBean(SentryProperties::class.java).dataCollection
@@ -341,6 +342,7 @@ class SentryAutoConfigurationTest {
           .isEqualTo(KeyValueCollectionBehavior.Mode.ALLOW_LIST)
         assertThat(dataCollection.httpHeaders.response!!.terms)
           .containsExactly("content-type", "x-request-id")
+        assertThat(dataCollection.filePaths).isFalse()
       }
   }
 

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -314,7 +314,7 @@ class SentryAutoConfigurationTest {
   }
 
   @Test
-  fun `data collection key value properties are applied to SentryOptions`() {
+  fun `data collection properties are applied to SentryOptions`() {
     contextRunner
       .withPropertyValues(
         "sentry.dsn=http://key@localhost/proj",
@@ -325,6 +325,7 @@ class SentryAutoConfigurationTest {
         "sentry.data-collection.http-headers.request.terms=forwarded,-ip",
         "sentry.data-collection.http-headers.response.mode=allow-list",
         "sentry.data-collection.http-headers.response.terms=content-type,x-request-id",
+        "sentry.data-collection.file-paths=false",
       )
       .run {
         val dataCollection = it.getBean(SentryProperties::class.java).dataCollection
@@ -339,6 +340,7 @@ class SentryAutoConfigurationTest {
           .isEqualTo(KeyValueCollectionBehavior.Mode.ALLOW_LIST)
         assertThat(dataCollection.httpHeaders.response!!.terms)
           .containsExactly("content-type", "x-request-id")
+        assertThat(dataCollection.filePaths).isFalse()
       }
   }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -390,6 +390,7 @@ public final class io/sentry/DataCollection {
 	public fun <init> (Z)V
 	public fun getCookies ()Lio/sentry/KeyValueCollectionBehavior;
 	public fun getDatabaseQueryData ()Ljava/lang/Boolean;
+	public fun getFilePaths ()Ljava/lang/Boolean;
 	public fun getGraphql ()Lio/sentry/DataCollection$Graphql;
 	public fun getHttpBodies ()Ljava/util/Set;
 	public fun getHttpHeaders ()Lio/sentry/DataCollection$HttpHeaders;
@@ -398,6 +399,7 @@ public final class io/sentry/DataCollection {
 	public fun isExplicitlyConfigured ()Z
 	public fun setCookies (Lio/sentry/KeyValueCollectionBehavior;)V
 	public fun setDatabaseQueryData (Z)V
+	public fun setFilePaths (Z)V
 	public fun setHttpBodies (Ljava/util/Set;)V
 	public fun setUrlQueryParams (Lio/sentry/KeyValueCollectionBehavior;)V
 	public fun setUserInfo (Z)V
@@ -426,6 +428,7 @@ public final class io/sentry/DataCollectionResolver {
 	public fun getUrlQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
 	public fun isDataCollectionConfigured ()Z
 	public fun isDatabaseQueryData ()Z
+	public fun isFilePaths ()Z
 	public fun isGraphqlDocument ()Z
 	public fun isGraphqlDocumentWithLegacyAlways ()Z
 	public fun isGraphqlDocumentWithLegacyBodyGate ()Z

--- a/sentry/src/main/java/io/sentry/DataCollection.java
+++ b/sentry/src/main/java/io/sentry/DataCollection.java
@@ -17,6 +17,7 @@ public final class DataCollection {
   private @Nullable KeyValueCollectionBehavior urlQueryParams;
   private @Nullable Set<HttpBodyType> httpBodies;
   private @Nullable Boolean databaseQueryData;
+  private @Nullable Boolean filePaths;
   private final @NotNull HttpHeaders httpHeaders = new HttpHeaders();
   private final @NotNull Graphql graphql = new Graphql();
 
@@ -74,6 +75,14 @@ public final class DataCollection {
     this.databaseQueryData = databaseQueryData;
   }
 
+  public @Nullable Boolean getFilePaths() {
+    return filePaths;
+  }
+
+  public void setFilePaths(final boolean filePaths) {
+    this.filePaths = filePaths;
+  }
+
   public @NotNull HttpHeaders getHttpHeaders() {
     return httpHeaders;
   }
@@ -90,6 +99,7 @@ public final class DataCollection {
         || urlQueryParams != null
         || httpBodies != null
         || databaseQueryData != null
+        || filePaths != null
         || httpHeaders.hasOverrides()
         || graphql.hasOverrides();
   }

--- a/sentry/src/main/java/io/sentry/DataCollectionResolver.java
+++ b/sentry/src/main/java/io/sentry/DataCollectionResolver.java
@@ -27,6 +27,10 @@ public final class DataCollectionResolver {
     return explicitOrSendDefaultPii(options.getDataCollection().getDatabaseQueryData(), true);
   }
 
+  public boolean isFilePaths() {
+    return explicitOrSendDefaultPii(options.getDataCollection().getFilePaths(), true);
+  }
+
   public boolean isGraphqlDocument() {
     return explicitOrSendDefaultPii(options.getDataCollection().getGraphql().getDocument(), true);
   }

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -305,6 +305,11 @@ public final class ExternalOptions {
       dataCollection.setDatabaseQueryData(databaseQueryData);
     }
 
+    final Boolean filePaths = propertiesProvider.getBooleanProperty("data-collection.file-paths");
+    if (filePaths != null) {
+      dataCollection.setFilePaths(filePaths);
+    }
+
     return dataCollection.isExplicitlyConfigured() ? dataCollection : null;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3844,6 +3844,9 @@ public class SentryOptions {
     if (externalDataCollection.getDatabaseQueryData() != null) {
       dataCollection.setDatabaseQueryData(externalDataCollection.getDatabaseQueryData());
     }
+    if (externalDataCollection.getFilePaths() != null) {
+      dataCollection.setFilePaths(externalDataCollection.getFilePaths());
+    }
   }
 
   private @NotNull SdkVersion createSdkVersion() {

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -95,7 +95,7 @@ final class FileIOSpanManager {
       if (file != null) {
         final String description = getDescription(file);
         currentSpan.setDescription(description);
-        if (options.isSendDefaultPii()) {
+        if (options.getDataCollectionResolver().isFilePaths()) {
           currentSpan.setData("file.path", file.getAbsolutePath());
         }
       } else {
@@ -115,7 +115,7 @@ final class FileIOSpanManager {
   private @NotNull String getDescription(final @NotNull File file) {
     final String byteCountToString = StringUtils.byteCountToString(byteCount);
     // if we send PII, we can send the file name directly
-    if (options.isSendDefaultPii()) {
+    if (options.getDataCollectionResolver().isFilePaths()) {
       return file.getName() + " (" + byteCountToString + ")";
     }
     final int lastDotIndex = file.getName().lastIndexOf('.');

--- a/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
@@ -63,6 +63,7 @@ class DataCollectionResolverTest {
 
     assertThat(options.dataCollectionResolver.isUserInfo).isTrue()
     assertThat(options.dataCollectionResolver.isDatabaseQueryData).isTrue()
+    assertThat(options.dataCollectionResolver.isFilePaths).isTrue()
     assertThat(options.dataCollectionResolver.isGraphqlDocument).isTrue()
     assertThat(options.dataCollectionResolver.isGraphqlVariables).isTrue()
   }
@@ -90,6 +91,31 @@ class DataCollectionResolverTest {
     options.dataCollection.setDatabaseQueryData(true)
 
     assertThat(options.dataCollectionResolver.isDatabaseQueryData).isTrue()
+  }
+
+  @Test
+  fun `file paths use sendDefaultPii when Data Collection is absent`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isFilePaths).isFalse()
+
+    options.isSendDefaultPii = true
+
+    assertThat(options.dataCollectionResolver.isFilePaths).isTrue()
+  }
+
+  @Test
+  fun `file paths use configured Data Collection value`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    options.dataCollection.setFilePaths(false)
+
+    assertThat(options.dataCollectionResolver.isFilePaths).isFalse()
+
+    options.isSendDefaultPii = false
+    options.dataCollection.setFilePaths(true)
+
+    assertThat(options.dataCollectionResolver.isFilePaths).isTrue()
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/DataCollectionTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionTest.kt
@@ -14,6 +14,7 @@ class DataCollectionTest {
     assertThat(dataCollection.urlQueryParams).isNull()
     assertThat(dataCollection.httpBodies).isNull()
     assertThat(dataCollection.databaseQueryData).isNull()
+    assertThat(dataCollection.filePaths).isNull()
     assertThat(dataCollection.httpHeaders.request).isNull()
     assertThat(dataCollection.httpHeaders.response).isNull()
     assertThat(dataCollection.graphql.document).isNull()
@@ -78,6 +79,16 @@ class DataCollectionTest {
     dataCollection.setDatabaseQueryData(false)
 
     assertThat(dataCollection.databaseQueryData).isFalse()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `file paths false is distinct from unset`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.setFilePaths(false)
+
+    assertThat(dataCollection.filePaths).isFalse()
     assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
   }
 

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -37,6 +37,7 @@ class ExternalOptionsTest {
         "data-collection.graphql.document=false",
         "data-collection.graphql.variables=true",
         "data-collection.database-query-data=false",
+        "data-collection.file-paths=false",
       )
     ) { options ->
       val dataCollection = options.dataCollection
@@ -55,6 +56,7 @@ class ExternalOptionsTest {
       assertThat(dataCollection.graphql.document).isFalse()
       assertThat(dataCollection.graphql.variables).isTrue()
       assertThat(dataCollection.databaseQueryData).isFalse()
+      assertThat(dataCollection.filePaths).isFalse()
     }
   }
 
@@ -88,12 +90,14 @@ class ExternalOptionsTest {
         "data-collection.graphql.document=invalid",
         "data-collection.graphql.variables=invalid",
         "data-collection.database-query-data=invalid",
+        "data-collection.file-paths=invalid",
       )
     ) { options ->
       assertThat(options.dataCollection!!.userInfo).isFalse()
       assertThat(options.dataCollection!!.graphql.document).isFalse()
       assertThat(options.dataCollection!!.graphql.variables).isFalse()
       assertThat(options.dataCollection!!.databaseQueryData).isFalse()
+      assertThat(options.dataCollection!!.filePaths).isFalse()
     }
   }
 

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -124,6 +124,7 @@ class SentryOptionsTest {
         graphql.setDocument(false)
         graphql.setVariables(false)
         setDatabaseQueryData(false)
+        setFilePaths(false)
       }
     val options = SentryOptions()
 
@@ -143,6 +144,7 @@ class SentryOptionsTest {
     assertThat(options.dataCollection.graphql.document).isFalse()
     assertThat(options.dataCollection.graphql.variables).isFalse()
     assertThat(options.dataCollection.databaseQueryData).isFalse()
+    assertThat(options.dataCollection.filePaths).isFalse()
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
@@ -81,6 +81,36 @@ class SentryFileReaderTest {
   }
 
   @Test
+  fun `configured file paths false overrides sendDefaultPii true`() {
+    val reader =
+      fixture.getSut(tmpFile) {
+        it.isSendDefaultPii = true
+        it.dataCollection.setFilePaths(false)
+      }
+    reader.readText()
+    reader.close()
+
+    val fileIOSpan = fixture.sentryTracer.children.first()
+    assertEquals(fileIOSpan.spanContext.description, "***.txt (4 B)")
+    assertNull(fileIOSpan.data["file.path"])
+  }
+
+  @Test
+  fun `configured file paths true overrides sendDefaultPii false`() {
+    val reader =
+      fixture.getSut(tmpFile) {
+        it.isSendDefaultPii = false
+        it.dataCollection.setFilePaths(true)
+      }
+    reader.readText()
+    reader.close()
+
+    val fileIOSpan = fixture.sentryTracer.children.first()
+    assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+    assertNotNull(fileIOSpan.data["file.path"])
+  }
+
+  @Test
   fun `captures only file extension in description when isSendDefaultPii is false`() {
     val reader = fixture.getSut(tmpFile) { it.isSendDefaultPii = false }
     reader.readText()


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Add the specification-defined `dataCollection.filePaths` option, defaulting to `true` in explicit Data Collection mode. Support programmatic, external, Spring Boot, and Android manifest configuration.

Apply the resolved policy to automatic file names and paths captured by File I/O instrumentation. When Data Collection is absent, the resolver continues to use `sendDefaultPii`, preserving existing behavior. Disabling file path collection retains non-identifying metadata such as file extensions and byte counts.

## :bulb: Motivation and Context

File and directory paths can contain user names, tenant identifiers, and document names. This gives File I/O instrumentation a dedicated privacy control instead of leaving it governed only by the coarse legacy option.

Implements the candidate specification from [sentry-docs#18819](https://github.com/getsentry/sentry-docs/pull/18819).

Refs #5666

## :green_heart: How did you test it?

- `./gradlew :sentry:test --tests='*DataCollectionTest*' --tests='*DataCollectionResolverTest*' --tests='*ExternalOptionsTest*' --tests='*SentryOptionsTest*' --tests='*SentryFileReaderTest*' --info`
- `./gradlew :sentry:test --tests='io.sentry.instrumentation.file.*' --info`
- `./gradlew :sentry-android-core:testReleaseUnitTest --tests='*ManifestMetadataReaderTest*' --info`
- `./gradlew :sentry-spring-boot:test :sentry-spring-boot-jakarta:test :sentry-spring-boot-4:test --tests='*SentryAutoConfigurationTest*' --info`
- `./gradlew spotlessApply apiDump`
- `git diff --check`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Merge this PR into the collection branch before squash-merging the collection PR into `main`.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
