### PR TITLE
feat(logback): [Data Collection 26] Add unencoded message opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `dataCollection`, a fine-grained replacement for `sendDefaultPii`, for controlling data collected automatically by SDK integrations ([#5759](https://github.com/getsentry/sentry-java/pull/5759))
   - `sendDefaultPii` remains supported for backwards compatibility. When `dataCollection` is not configured, the SDK preserves the existing `sendDefaultPii` behavior.
   - Configuring any `dataCollection` option makes it the source of truth. `sendDefaultPii` is then ignored, and omitted `dataCollection` options use the defaults below.
+  - The Logback appender is a compatibility exception. When an encoder is configured, `sendDefaultPii=true` continues to include the original message template and parameters. To opt in independently of `sendDefaultPii`, set `<includeUnencodedMessage>true</includeUnencodedMessage>` on the Sentry appender in `logback.xml` or `logback-spring.xml`.
   - Data explicitly supplied through APIs such as `Sentry.setUser`, scopes, event processors, or `beforeSend` is not affected.
 
   | Option | Default | Behavior |

--- a/sentry-logback/api/sentry-logback.api
+++ b/sentry-logback/api/sentry-logback.api
@@ -11,10 +11,10 @@ public class io/sentry/logback/SentryAppender : ch/qos/logback/core/Unsynchroniz
 	protected fun captureLog (Lch/qos/logback/classic/spi/ILoggingEvent;)V
 	protected fun createBreadcrumb (Lch/qos/logback/classic/spi/ILoggingEvent;)Lio/sentry/Breadcrumb;
 	protected fun createEvent (Lch/qos/logback/classic/spi/ILoggingEvent;)Lio/sentry/SentryEvent;
+	public fun getIncludeUnencodedMessage ()Z
 	public fun getMinimumBreadcrumbLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumEventLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumLevel ()Lch/qos/logback/classic/Level;
-	public fun isIncludeUnencodedMessage ()Z
 	public fun setEncoder (Lch/qos/logback/core/encoder/Encoder;)V
 	public fun setIncludeUnencodedMessage (Z)V
 	public fun setMinimumBreadcrumbLevel (Lch/qos/logback/classic/Level;)V

--- a/sentry-logback/api/sentry-logback.api
+++ b/sentry-logback/api/sentry-logback.api
@@ -14,7 +14,9 @@ public class io/sentry/logback/SentryAppender : ch/qos/logback/core/Unsynchroniz
 	public fun getMinimumBreadcrumbLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumEventLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumLevel ()Lch/qos/logback/classic/Level;
+	public fun isIncludeUnencodedMessage ()Z
 	public fun setEncoder (Lch/qos/logback/core/encoder/Encoder;)V
+	public fun setIncludeUnencodedMessage (Z)V
 	public fun setMinimumBreadcrumbLevel (Lch/qos/logback/classic/Level;)V
 	public fun setMinimumEventLevel (Lch/qos/logback/classic/Level;)V
 	public fun setMinimumLevel (Lch/qos/logback/classic/Level;)V

--- a/sentry-logback/build.gradle.kts
+++ b/sentry-logback/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   testImplementation(projects.sentryTestSupport)
   testImplementation(kotlin(Config.kotlinStdLib))
   testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.google.truth)
   testImplementation(libs.logback.classic)
   testImplementation(libs.mockito.kotlin)
 }

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -344,7 +344,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   /**
    * Whether to include the original message template and parameters when an encoder is configured.
    */
-  public boolean isIncludeUnencodedMessage() {
+  public boolean getIncludeUnencodedMessage() {
     return includeUnencodedMessage;
   }
 

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -53,6 +53,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @NotNull Level minimumEventLevel = Level.ERROR;
   private @NotNull Level minimumLevel = Level.INFO;
   private @Nullable Encoder<ILoggingEvent> encoder;
+  private boolean includeUnencodedMessage = false;
 
   static {
     SentryIntegrationPackageStorage.getInstance()
@@ -118,7 +119,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     final Message message = new Message();
 
     // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
-    if (encoder == null || ScopesAdapter.getInstance().getOptions().isSendDefaultPii()) {
+    if (shouldIncludeUnencodedMessage()) {
       message.setMessage(loggingEvent.getMessage());
       message.setParams(toParams(loggingEvent.getArgumentArray()));
     }
@@ -177,7 +178,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     final @NotNull String formattedMessage = formatted(loggingEvent);
 
     // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
-    if (encoder == null || ScopesAdapter.getInstance().getOptions().isSendDefaultPii()) {
+    if (shouldIncludeUnencodedMessage()) {
       final @Nullable String nonFormattedMessage = loggingEvent.getMessage();
       if (nonFormattedMessage != null && !formattedMessage.equals(nonFormattedMessage)) {
         attributes.add(
@@ -195,6 +196,12 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     params.setOrigin("auto.log.logback");
 
     Sentry.logger().log(sentryLevel, params, formattedMessage, arguments);
+  }
+
+  private boolean shouldIncludeUnencodedMessage() {
+    return encoder == null
+        || includeUnencodedMessage
+        || ScopesAdapter.getInstance().getOptions().isSendDefaultPii();
   }
 
   private String formatted(@NotNull ILoggingEvent loggingEvent) {
@@ -330,5 +337,22 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   public void setEncoder(Encoder<ILoggingEvent> encoder) {
     this.encoder = encoder;
+  }
+
+  /**
+   * Whether to include the original message template and parameters when an encoder is configured.
+   */
+  public boolean isIncludeUnencodedMessage() {
+    return includeUnencodedMessage;
+  }
+
+  /**
+   * Sets whether to include the original message template and parameters when an encoder is
+   * configured.
+   *
+   * @param includeUnencodedMessage whether to include the original message and parameters
+   */
+  public void setIncludeUnencodedMessage(final boolean includeUnencodedMessage) {
+    this.includeUnencodedMessage = includeUnencodedMessage;
   }
 }

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -118,7 +118,8 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     final SentryEvent event = new SentryEvent(DateUtils.getDateTime(loggingEvent.getTimeStamp()));
     final Message message = new Message();
 
-    // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
+    // Encoders may mask or strip PII. When one is configured, include the original message and
+    // parameters only if includeUnencodedMessage or the legacy sendDefaultPii option is enabled.
     if (shouldIncludeUnencodedMessage()) {
       message.setMessage(loggingEvent.getMessage());
       message.setParams(toParams(loggingEvent.getArgumentArray()));
@@ -177,7 +178,8 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     final @NotNull SentryAttributes attributes = SentryAttributes.of();
     final @NotNull String formattedMessage = formatted(loggingEvent);
 
-    // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
+    // Encoders may mask or strip PII. When one is configured, include the original message and
+    // parameters only if includeUnencodedMessage or the legacy sendDefaultPii option is enabled.
     if (shouldIncludeUnencodedMessage()) {
       final @Nullable String nonFormattedMessage = loggingEvent.getMessage();
       if (nonFormattedMessage != null && !formattedMessage.equals(nonFormattedMessage)) {

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -280,8 +280,8 @@ class SentryAppenderTest {
     fixture = Fixture(minimumEventLevel = Level.DEBUG, includeUnencodedMessage = true)
     fixture.logger.info("testing encoding {}", "param1")
 
-    assertThat(SentryAppender().isIncludeUnencodedMessage).isFalse()
-    assertThat(fixture.appender.isIncludeUnencodedMessage).isTrue()
+    assertThat(SentryAppender().includeUnencodedMessage).isFalse()
+    assertThat(fixture.appender.includeUnencodedMessage).isTrue()
     verify(fixture.transport)
       .send(
         checkEvent { event ->

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -10,6 +10,7 @@ import ch.qos.logback.classic.spi.ThrowableProxy
 import ch.qos.logback.core.encoder.Encoder
 import ch.qos.logback.core.encoder.EncoderBase
 import ch.qos.logback.core.status.Status
+import com.google.common.truth.Truth.assertThat
 import io.sentry.ITransportFactory
 import io.sentry.InitPriority
 import io.sentry.Sentry
@@ -53,6 +54,7 @@ class SentryAppenderTest {
     minimumLevel: Level? = null,
     contextTags: List<String>? = null,
     encoder: Encoder<ILoggingEvent>? = null,
+    includeUnencodedMessage: Boolean = false,
     sendDefaultPii: Boolean = false,
     enableLogs: Boolean = false,
     options: SentryOptions = SentryOptions(),
@@ -85,6 +87,7 @@ class SentryAppenderTest {
       appender.setTransportFactory(transportFactory)
       encoder?.context = loggerContext
       appender.setEncoder(encoder)
+      appender.setIncludeUnencodedMessage(includeUnencodedMessage)
       val rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
       rootLogger.level = Level.TRACE
       rootLogger.addAppender(appender)
@@ -200,6 +203,91 @@ class SentryAppenderTest {
             assertNull(message.params)
           }
           assertEquals("io.sentry.logback.SentryAppenderTest", event.logger)
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
+  fun `includes unencoded message and params if explicitly enabled`() {
+    val encoder = PatternLayoutEncoder()
+    encoder.pattern = "encoded %msg"
+    fixture =
+      Fixture(
+        minimumEventLevel = Level.DEBUG,
+        encoder = encoder,
+        includeUnencodedMessage = true,
+      )
+    fixture.logger.info("testing encoding {}", "param1")
+
+    verify(fixture.transport)
+      .send(
+        checkEvent { event ->
+          assertThat(event.message?.formatted).isEqualTo("encoded testing encoding param1")
+          assertThat(event.message?.message).isEqualTo("testing encoding {}")
+          assertThat(event.message?.params).containsExactly("param1")
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
+  fun `data collection does not include unencoded message`() {
+    val encoder = PatternLayoutEncoder()
+    encoder.pattern = "encoded %msg"
+    val options = SentryOptions().apply { dataCollection.setFilePaths(false) }
+    fixture = Fixture(minimumEventLevel = Level.DEBUG, encoder = encoder, options = options)
+    fixture.logger.info("testing encoding {}", "param1")
+
+    verify(fixture.transport)
+      .send(
+        checkEvent { event ->
+          assertThat(event.message?.formatted).isEqualTo("encoded testing encoding param1")
+          assertThat(event.message?.message).isNull()
+          assertThat(event.message?.params).isNull()
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
+  fun `sendDefaultPii includes unencoded message when data collection is configured`() {
+    val encoder = PatternLayoutEncoder()
+    encoder.pattern = "encoded %msg"
+    val options = SentryOptions().apply { dataCollection.setFilePaths(false) }
+    fixture =
+      Fixture(
+        minimumEventLevel = Level.DEBUG,
+        encoder = encoder,
+        sendDefaultPii = true,
+        options = options,
+      )
+    fixture.logger.info("testing encoding {}", "param1")
+
+    verify(fixture.transport)
+      .send(
+        checkEvent { event ->
+          assertThat(event.message?.formatted).isEqualTo("encoded testing encoding param1")
+          assertThat(event.message?.message).isEqualTo("testing encoding {}")
+          assertThat(event.message?.params).containsExactly("param1")
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
+  fun `include unencoded message defaults to false and has no effect without encoder`() {
+    fixture = Fixture(minimumEventLevel = Level.DEBUG, includeUnencodedMessage = true)
+    fixture.logger.info("testing encoding {}", "param1")
+
+    assertThat(SentryAppender().isIncludeUnencodedMessage).isFalse()
+    assertThat(fixture.appender.isIncludeUnencodedMessage).isTrue()
+    verify(fixture.transport)
+      .send(
+        checkEvent { event ->
+          assertThat(event.message?.formatted).isEqualTo("testing encoding param1")
+          assertThat(event.message?.message).isEqualTo("testing encoding {}")
+          assertThat(event.message?.params).containsExactly("param1")
         },
         anyOrNull(),
       )
@@ -802,6 +890,33 @@ class SentryAppenderTest {
           assertEquals("encoded testing message param", log.body)
           assertNull(log.attributes?.get("sentry.message.template"))
           assertNull(log.attributes?.get("sentry.message.parameter.0"))
+        }
+      )
+  }
+
+  @Test
+  fun `sets template and attributes on log with encoder when unencoded message is included`() {
+    val encoder = PatternLayoutEncoder()
+    encoder.pattern = "encoded %msg"
+    fixture =
+      Fixture(
+        minimumLevel = Level.ERROR,
+        enableLogs = true,
+        encoder = encoder,
+        includeUnencodedMessage = true,
+      )
+    fixture.logger.error("testing message {}", "param")
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertThat(log.body).isEqualTo("encoded testing message param")
+          assertThat(log.attributes?.get("sentry.message.template")?.value)
+            .isEqualTo("testing message {}")
+          assertThat(log.attributes?.get("sentry.message.parameter.0")?.value).isEqualTo("param")
         }
       )
   }


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Add `includeUnencodedMessage` to the Logback `SentryAppender`. When an encoder is configured, this explicit integration option includes the original message template and parameters alongside the encoded output.

Keep `sendDefaultPii=true` as a temporary compatibility opt-in, including when Data Collection is configured. Without an encoder, the appender preserves its existing behavior and includes the original message data.

## :bulb: Motivation and Context

Logback encoders can mask or remove PII before Sentry receives the formatted message. The existing guard relies only on the broad legacy `sendDefaultPii` option. This adds a narrow Logback-specific opt-in without introducing a Data Collection category for raw log messages.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew :sentry-logback:check`
- `./gradlew spotlessApply apiDump`
- `.venv/bin/python test/system-test-runner.py test --module sentry-samples-logback --agent false --auto-init true --build true`
- One-off Logback system test with a regex-masking encoder and `includeUnencodedMessage=true`, verifying encoded bodies and original event/log template parameters
- `git diff --check`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Merge this PR into the previous stack branch before merging the remaining Data Collection stack into the collection branch.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
