### PR TITLE
chore(deps): Bump navigation and compose UI deps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 animalsniffer = "2.0.1"
 apollo = "2.5.9"
 androidxLifecycle = "2.2.0"
-androidxNavigation = "2.4.2"
+androidxNavigation = "2.9.8"
 androidxTestCore = "1.7.0"
-androidxCompose = "1.6.3"
+androidxCompose = "1.9.5"
 asyncProfiler = "4.4"
 camerax = "1.4.0"
 composeCompiler = "1.5.14"
@@ -86,7 +86,7 @@ apollo4-kotlin = { module = "com.apollographql.apollo:apollo-runtime", version =
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.3.0" }
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }
 androidx-activity = { module = "androidx.activity:activity", version = "1.8.2" }
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.8.2" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.3" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidxCompose" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidxCompose" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version = "1.4.0" }
@@ -241,7 +241,7 @@ tomcat-embed-jasper-jakarta = { module = "org.apache.tomcat.embed:tomcat-embed-j
 
 # test libraries
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version = "1.4.1" }
-androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.9.5" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.10.5" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -241,7 +241,7 @@ tomcat-embed-jasper-jakarta = { module = "org.apache.tomcat.embed:tomcat-embed-j
 
 # test libraries
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version = "1.4.1" }
-androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.10.5" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.9.5" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }

--- a/sentry-android-integration-tests/sentry-uitest-android-critical/src/main/java/io/sentry/uitest/android/critical/MainActivity.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android-critical/src/main/java/io/sentry/uitest/android/critical/MainActivity.kt
@@ -29,7 +29,7 @@ import java.io.File
 import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
-  private lateinit var requestPermissionLauncher: ActivityResultLauncher<String?>
+  private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
 
   override fun onCreate(savedInstanceState: Bundle?) {
     setTheme(android.R.style.Theme_DeviceDefault_NoActionBar)

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -62,8 +62,6 @@ kotlin {
     }
     getByName("androidUnitTest") {
       dependencies {
-        implementation(libs.androidx.compose.foundation)
-        implementation(libs.androidx.compose.foundation.layout)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.navigation.compose)
         implementation(libs.androidx.test.ext.junit)


### PR DESCRIPTION
## :scroll: Description

PR bumps the (stale) Compose / Navigation baseline in `sentry-compose` enough to remove the old Robolectric test workaround discussed with @runningcode [here](https://github.com/getsentry/sentry-java/pull/6057#discussion_r3940036434).

The final versions are limited to a coherent set that fixes the issue and still behaves well:

- `androidxNavigation` -> `2.9.8`
- `androidxCompose` -> `1.9.5`
- `androidx.activity:activity-compose` -> `1.9.3`

I initially tried pushing Navigation Compose to `2.10.0`, but that raised the sample app floor through `navigation-runtime-android` and broke the sample app install path (`minSdk 23` vs `24`).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Let's us avoid introducing compose test deps all over the place just to keep Robolectric happy, and gets us off compose libraries from 2022.

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## ⚠️ Callouts

- PR doesn't change our published API or ABI surface.
- Our compose deps are compileOnly, so consumers' dependency graphs won't be affected

## :green_heart: How did you test it?

Existing test suite still succeeds. 

Compared runtime behavior pre- and post-bump via the sample app + golden flows. No observed differences.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps

#skip-changlog