### PR TITLE
test(android): Stabilize InternalSentrySdk session persistence tests

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -30,6 +30,7 @@ import io.sentry.protocol.Contexts
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.createTestScopes
 import io.sentry.transport.ITransport
 import io.sentry.transport.RateLimiter
@@ -38,7 +39,6 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStreamReader
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -62,6 +62,8 @@ class InternalSentrySdkTest {
       initForTest(context) { options ->
         this@Fixture.options = options
         options.dsn = "https://key@host/proj"
+        // Finish startup session rotation before tests persist and read the current session.
+        options.executorService = ImmediateExecutorService()
         options.setTransportFactory { _, _ ->
           object : ITransport {
             override fun close(isRestarting: Boolean) {
@@ -613,14 +615,6 @@ class InternalSentrySdkTest {
     assertThat(activeSession.get().sessionId).isNotEqualTo(oldSid)
   }
 
-  // Flaky: intermittently fails with FileNotFoundException reading session.json at the
-  // `sessionFile.reader()` call below, i.e. persistCurrentSession() did not leave a session file
-  // on disk by the time this test reads it back. Seen across unrelated PRs, e.g.:
-  // https://scans.gradle.com/s/55fnn6xhtfyfq/tests/task/:sentry-android-core:testReleaseUnitTest/details/io.sentry.android.core.InternalSentrySdkTest/updateSessionForDroppedEventNonTerminating%20flags%20an%20unhandled%20error%20without%20sending%20an%20envelope?top-execution=1
-  // https://scans.gradle.com/s/ojzzz4yxag7rw/tests/task/:sentry-android-core:testReleaseUnitTest/details/io.sentry.android.core.InternalSentrySdkTest/updateSessionForDroppedEventNonTerminating%20flags%20an%20unhandled%20error%20without%20sending%20an%20envelope?top-execution=1
-  // Disabling until root-caused; see https://github.com/getsentry/sentry-java/pull/5990 for the
-  // code under test.
-  @Ignore("Flaky: intermittently fails to find the persisted session.json, needs root-causing")
   @Test
   fun `updateSessionForDroppedEventNonTerminating flags an unhandled error without sending an envelope`() {
     val fixture = Fixture()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -9,6 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import io.sentry.Breadcrumb
 import io.sentry.Hint
 import io.sentry.IScope
+import io.sentry.ISentryExecutorService
 import io.sentry.Scope
 import io.sentry.ScopeType
 import io.sentry.Sentry
@@ -58,12 +59,12 @@ class InternalSentrySdkTest {
     val capturedEnvelopes = mutableListOf<SentryEnvelope>()
     lateinit var options: SentryOptions
 
-    fun init(context: Context) {
+    fun init(context: Context, executorService: ISentryExecutorService? = null) {
       initForTest(context) { options ->
         this@Fixture.options = options
         options.dsn = "https://key@host/proj"
-        // Finish startup session rotation before tests persist and read the current session.
-        options.executorService = ImmediateExecutorService()
+        // Session persistence tests can finish startup rotation before writing session.json.
+        executorService?.let { options.executorService = it }
         options.setTransportFactory { _, _ ->
           object : ITransport {
             override fun close(isRestarting: Boolean) {
@@ -486,7 +487,7 @@ class InternalSentrySdkTest {
   @Test
   fun `captureEnvelopeNonTerminating keeps the session Ok and flags the unhandled error`() {
     val fixture = Fixture()
-    fixture.init(context)
+    fixture.init(context, executorService = ImmediateExecutorService())
 
     val originalSid = AtomicReference<String>()
     Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }
@@ -618,7 +619,7 @@ class InternalSentrySdkTest {
   @Test
   fun `updateSessionForDroppedEventNonTerminating flags an unhandled error without sending an envelope`() {
     val fixture = Fixture()
-    fixture.init(context)
+    fixture.init(context, executorService = ImmediateExecutorService())
 
     val originalSid = AtomicReference<String>()
     Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }
@@ -647,7 +648,7 @@ class InternalSentrySdkTest {
   @Test
   fun `updateSessionForDroppedEventNonTerminating increments errors for a handled error without sending an envelope`() {
     val fixture = Fixture()
-    fixture.init(context)
+    fixture.init(context, executorService = ImmediateExecutorService())
 
     val originalSid = AtomicReference<String>()
     Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }


### PR DESCRIPTION
## :scroll: Description

Re-enable the ignored `InternalSentrySdkTest` for dropped unhandled errors. Make the fixture's executor configurable and opt into `ImmediateExecutorService` only in the three tests that read the persisted session. Other tests keep the default executor.

## :bulb: Motivation and Context

The test added in #5990 was disabled in #6078 after intermittent `FileNotFoundException` failures. SDK initialization queues `MovePreviousSession` asynchronously; if it runs after the test persists its live session, it renames `session.json` to `previous_session.json` before the test reads it. Completing startup work synchronously in the affected tests removes that timing dependency.

## :green_heart: How did you test it?

- Ran `:sentry-android-core:testReleaseUnitTest --tests='*InternalSentrySdkTest*' --rerun --no-daemon --no-configuration-cache` on commit `13c17fac5700048893de0dd4af5f7e90e47c95d4` 10 consecutive times, forcing fresh executions: all 24 tests passed in every run (240 test executions total), with zero failures, errors, or skips.
- `spotlessApply apiDump`: passed.
- During investigation, a deferred executor deterministically reproduced the missing-file exception by running queued startup work between the session write and read.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Follow up separately on the SDK's runtime ordering between startup session rotation and synchronous session persistence.

#skip-changelog
