### PR TITLE
docs(metrics): Explain metric unit API design

### DIFF
--- a/sentry/src/main/java/io/sentry/metrics/MetricsUnit.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsUnit.java
@@ -3,10 +3,13 @@ package io.sentry.metrics;
 /**
  * String constants for metric units.
  *
- * <p>These constants represent the API names of measurement units that can be used with metrics.
- * Metrics APIs intentionally accept strings instead of {@link io.sentry.MeasurementUnit} because it
- * contains units that metrics do not support. Strings also let older SDK versions use units
- * introduced after their release.
+ * <p>These constants are for the Metrics product and the {@link IMetricsApi} exposed through {@link
+ * io.sentry.Sentry#metrics()} and {@link io.sentry.IScopes#metrics()}. {@link
+ * io.sentry.MeasurementUnit} is instead used by transaction and span measurement APIs, including
+ * mobile vitals.
+ *
+ * <p>Metrics APIs accept strings so older SDK versions can use units introduced after their
+ * release.
  */
 public final class MetricsUnit {
 

--- a/sentry/src/main/java/io/sentry/metrics/MetricsUnit.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsUnit.java
@@ -4,6 +4,9 @@ package io.sentry.metrics;
  * String constants for metric units.
  *
  * <p>These constants represent the API names of measurement units that can be used with metrics.
+ * Metrics APIs intentionally accept strings instead of {@link io.sentry.MeasurementUnit} because it
+ * contains units that metrics do not support. Strings also let older SDK versions use units
+ * introduced after their release.
  */
 public final class MetricsUnit {
 


### PR DESCRIPTION
## :scroll: Description

Document why `MetricsUnit` provides string constants while `MetricsApi` accepts string units instead of reusing `MeasurementUnit`.

## :bulb: Motivation and Context

The distinction is otherwise easy to mistake for accidental duplication. `MeasurementUnit` includes units unsupported by metrics, while accepting strings lets older SDK releases use units introduced later.

This records the rationale from [#5022](https://github.com/getsentry/sentry-java/pull/5022).

## :green_heart: How did you test it?

Ran `./gradlew spotlessApply apiDump`.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.

#skip-changelog
