### PR TITLE
ref(android): Remove unused TimeSpan.start()

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -883,7 +883,6 @@ public class io/sentry/android/core/performance/TimeSpan : java/lang/Comparable 
 	public fun setStartedAt (J)V
 	public fun setStoppedAt (J)V
 	public fun setup (Ljava/lang/String;JJJ)V
-	public fun start ()V
 	public fun stop ()V
 }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -35,12 +35,6 @@ public class TimeSpan implements Comparable<TimeSpan> {
     this.stopUptimeMs = stopUptimeMs;
   }
 
-  /** Start the time span */
-  public void start() {
-    startUptimeMs = SystemClock.uptimeMillis();
-    startUnixTimeMs = System.currentTimeMillis();
-  }
-
   /**
    * @param uptimeMs the uptime in ms, provided by {@link SystemClock#uptimeMillis()}
    */

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.view.View
 import android.view.ViewTreeObserver
 import androidx.test.core.app.ApplicationProvider
@@ -106,7 +107,7 @@ class ActivityLifecycleIntegrationTest {
 
       val metrics = AppStartMetrics.getInstance()
       metrics.isAppLaunchedInForeground = true
-      metrics.appStartTimeSpan.start()
+      metrics.appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
 
       // We let the ActivityLifecycleIntegration create the proper transaction here
       val optionCaptor = argumentCaptor<TransactionOptions>()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -61,10 +61,10 @@ class AppStartMetricsTest {
   @Test
   fun `metrics are properly cleared`() {
     val metrics = AppStartMetrics.getInstance()
-    metrics.appStartTimeSpan.start()
-    metrics.sdkInitTimeSpan.start()
+    metrics.appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
+    metrics.sdkInitTimeSpan.setStartedAt(SystemClock.uptimeMillis())
     metrics.appStartType = AppStartMetrics.AppStartType.WARM
-    metrics.applicationOnCreateTimeSpan.start()
+    metrics.applicationOnCreateTimeSpan.setStartedAt(SystemClock.uptimeMillis())
     metrics.addActivityLifecycleTimeSpans(ActivityLifecycleTimeSpan())
     AppStartMetrics.onApplicationCreate(mock<Application>())
     AppStartMetrics.onContentProviderCreate(mock<ContentProvider>())
@@ -92,7 +92,7 @@ class AppStartMetricsTest {
   fun `if perf-2 is enabled and app start time span is started, appStartTimeSpanWithFallback returns it`() {
     val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
     AppStartMetrics.getInstance().appStartType = AppStartMetrics.AppStartType.WARM
-    appStartTimeSpan.start()
+    appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
 
     val options = SentryAndroidOptions().apply { isEnablePerformanceV2 = true }
 
@@ -143,7 +143,7 @@ class AppStartMetricsTest {
     AppStartMetrics.getInstance().appStartType = AppStartMetrics.AppStartType.COLD
 
     val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
-    appStartTimeSpan.start()
+    appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
     assertTrue(appStartTimeSpan.hasStarted())
     AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
     waitForMainLooperIdle()
@@ -198,8 +198,8 @@ class AppStartMetricsTest {
   @Test
   fun `if app is launched in background, the first created activity assumes a warm start`() {
     val metrics = AppStartMetrics.getInstance()
-    metrics.appStartTimeSpan.start()
-    metrics.sdkInitTimeSpan.start()
+    metrics.appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
+    metrics.sdkInitTimeSpan.setStartedAt(SystemClock.uptimeMillis())
     metrics.registerLifecycleCallbacks(mock<Application>())
 
     // when the handler callback is executed and the start is headless
@@ -390,8 +390,6 @@ class AppStartMetricsTest {
   @Test
   fun `if app start span is at most 1 minute, appStartTimeSpanWithFallback returns the app start span`() {
     val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
-    appStartTimeSpan.start()
-    appStartTimeSpan.stop()
     appStartTimeSpan.setStartedAt(1)
     appStartTimeSpan.setStoppedAt(TimeUnit.MINUTES.toMillis(1) + 1)
     assertTrue(appStartTimeSpan.hasStarted())
@@ -475,8 +473,6 @@ class AppStartMetricsTest {
   @Test
   fun `if app start span is longer than 1 minute, appStartTimeSpanWithFallback returns an empty span`() {
     val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
-    appStartTimeSpan.start()
-    appStartTimeSpan.stop()
     appStartTimeSpan.setStartedAt(1)
     appStartTimeSpan.setStoppedAt(TimeUnit.MINUTES.toMillis(1) + 2)
     assertTrue(appStartTimeSpan.hasStarted())
@@ -531,8 +527,6 @@ class AppStartMetricsTest {
   @Test
   fun `isColdStartValid is false if app launched in more than 1 minute`() {
     val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
-    appStartTimeSpan.start()
-    appStartTimeSpan.stop()
     appStartTimeSpan.setStartedAt(1)
     appStartTimeSpan.setStoppedAt(TimeUnit.MINUTES.toMillis(1) + 2)
     AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
@@ -578,8 +572,8 @@ class AppStartMetricsTest {
   @Test
   fun `provider sets both appstart and sdk init start + end times`() {
     val metrics = AppStartMetrics.getInstance()
-    metrics.appStartTimeSpan.start()
-    metrics.sdkInitTimeSpan.start()
+    metrics.appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
+    metrics.sdkInitTimeSpan.setStartedAt(SystemClock.uptimeMillis())
 
     assertFalse(metrics.appStartTimeSpan.hasStopped())
     assertFalse(metrics.sdkInitTimeSpan.hasStopped())
@@ -614,7 +608,8 @@ class AppStartMetricsTest {
     val metrics = AppStartMetrics.getInstance()
     assertEquals(AppStartMetrics.AppStartType.UNKNOWN, AppStartMetrics.getInstance().appStartType)
     val app = mock<Application>()
-    metrics.appStartTimeSpan.start() // Need to start the span for timeout check to work
+    // the span needs to be started for the timeout check to work
+    metrics.appStartTimeSpan.setStartedAt(SystemClock.uptimeMillis())
     metrics.registerLifecycleCallbacks(app)
 
     // when an activity is created later with a null bundle

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/TimeSpanTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/TimeSpanTest.kt
@@ -122,9 +122,9 @@ class TimeSpanTest {
   }
 
   @Test
-  fun `span start starts the timespan`() {
+  fun `setStartedAt starts the timespan`() {
     val span = TimeSpan()
-    span.start()
+    span.setStartedAt(1)
 
     assertTrue(span.hasStarted())
     assertFalse(span.hasNotStarted())
@@ -133,7 +133,7 @@ class TimeSpanTest {
   @Test
   fun `span stop stops the timespan`() {
     val span = TimeSpan()
-    span.start()
+    span.setStartedAt(1)
 
     assertFalse(span.hasStopped())
 


### PR DESCRIPTION
## :scroll: Description

Removes `TimeSpan.start()`, which had no production callers, along with its 13 test call sites.

## :bulb: Motivation and Context

Dead code 
## :green_heart: How did you test it?

`:sentry-android-core:testReleaseUnitTest` for the touched classes — 211 tests, all passing. `spotlessApply apiDump` is clean.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

#skip-changelog
