### PR TITLE
fix(graphql): support specification error types

### DIFF
--- a/sentry-graphql-core/src/main/java/io/sentry/graphql/SentryGraphqlInstrumentation.java
+++ b/sentry-graphql-core/src/main/java/io/sentry/graphql/SentryGraphqlInstrumentation.java
@@ -25,6 +25,7 @@ import io.sentry.Sentry;
 import io.sentry.SpanOptions;
 import io.sentry.SpanStatus;
 import io.sentry.TypeCheckHint;
+import io.sentry.util.ExceptionUtils;
 import io.sentry.util.StringUtils;
 import java.util.Arrays;
 import java.util.List;
@@ -123,8 +124,7 @@ public final class SentryGraphqlInstrumentation {
       final @NotNull List<GraphQLError> errors = result.getErrors();
       if (errors != null) {
         for (GraphQLError error : errors) {
-          String errorType = getErrorType(error);
-          if (!isIgnored(errorType)) {
+          if (!isIgnored(error)) {
             exceptionReporter.captureThrowable(
                 new RuntimeException(error.getMessage()),
                 new ExceptionReporter.ExceptionDetails(
@@ -154,19 +154,35 @@ public final class SentryGraphqlInstrumentation {
         || ignoredErrorTypes.contains(errorType);
   }
 
-  private @Nullable String getErrorType(final @Nullable GraphQLError error) {
+  private boolean isIgnored(final @Nullable GraphQLError error) {
     if (error == null) {
-      return null;
+      return false;
     }
     final @Nullable ErrorClassification errorType = error.getErrorType();
     if (errorType != null) {
-      return errorType.toString();
+      if (isIgnored(errorType.toString())) {
+        return true;
+      }
+      try {
+        final @Nullable Object specification = errorType.toSpecification(error);
+        if (specification instanceof String && isIgnored((String) specification)) {
+          return true;
+        }
+        if (specification instanceof Map) {
+          final @Nullable Object specificationType = ((Map<?, ?>) specification).get("type");
+          return specificationType instanceof String && isIgnored((String) specificationType);
+        }
+      } catch (Throwable throwable) {
+        ExceptionUtils.rethrowIfFatal(throwable);
+        // Fall back to capturing the error if a custom classification cannot be serialized.
+      }
+      return false;
     }
     final @Nullable Map<String, Object> extensions = error.getExtensions();
     if (extensions != null) {
-      return StringUtils.toString(extensions.get("errorType"));
+      return isIgnored(StringUtils.toString(extensions.get("errorType")));
     }
-    return null;
+    return false;
   }
 
   public void beginExecuteOperation(

--- a/sentry-graphql-core/src/test/kotlin/io/sentry/graphql/SentryGraphqlInstrumentationTest.kt
+++ b/sentry-graphql-core/src/test/kotlin/io/sentry/graphql/SentryGraphqlInstrumentationTest.kt
@@ -1,0 +1,150 @@
+package io.sentry.graphql
+
+import graphql.ErrorClassification
+import graphql.ExecutionResultImpl
+import graphql.GraphQLContext
+import graphql.GraphQLError
+import graphql.GraphqlErrorException
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
+import io.sentry.IScopes
+import kotlin.test.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SentryGraphqlInstrumentationTest {
+  private val scopes = mock<IScopes>()
+  private val exceptionReporter = mock<ExceptionReporter>()
+  private val parameters = mock<InstrumentationExecutionParameters>()
+
+  init {
+    whenever(parameters.graphQLContext)
+      .thenReturn(
+        GraphQLContext.newContext()
+          .of(SentryGraphqlInstrumentation.SENTRY_SCOPES_CONTEXT_KEY, scopes)
+          .build()
+      )
+  }
+
+  @Test
+  fun `ignores error by classification string`() {
+    captureError(
+      error(CustomErrorClassification("SOME_ERROR", mapOf("type" to "OTHER_ERROR"))),
+      ignoredErrorTypes = listOf("SOME_ERROR"),
+    )
+
+    verify(exceptionReporter, never()).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `ignores error by classification specification type`() {
+    captureError(
+      error(
+        CustomErrorClassification(
+          "graphql.validation.interpolation.ResourceBundleMessageInterpolator\$ValidationErrorType@1",
+          mapOf("type" to "ExtendedValidationError"),
+        )
+      ),
+      ignoredErrorTypes = listOf("ExtendedValidationError"),
+    )
+
+    verify(exceptionReporter, never()).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `ignores error by string classification specification`() {
+    captureError(
+      error(CustomErrorClassification("SOME_ERROR", "SPECIFICATION_ERROR")),
+      ignoredErrorTypes = listOf("SPECIFICATION_ERROR"),
+    )
+
+    verify(exceptionReporter, never()).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `captures error when classification specification has no type`() {
+    captureError(error(CustomErrorClassification("SOME_ERROR", mapOf("constraint" to "@Size"))))
+
+    verify(exceptionReporter).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `captures error when classification specification is null`() {
+    captureError(error(CustomErrorClassification("SOME_ERROR", null)))
+
+    verify(exceptionReporter).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `captures error when classification specification type is unexpected`() {
+    captureError(error(CustomErrorClassification("SOME_ERROR", mapOf("type" to 42))))
+
+    verify(exceptionReporter).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `captures error when classification specification throws`() {
+    captureError(error(ThrowingErrorClassification))
+
+    verify(exceptionReporter).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `ignores error by extensions when classification is null`() {
+    val error = mock<GraphQLError>()
+    whenever(error.errorType).thenReturn(null)
+    whenever(error.extensions).thenReturn(mapOf("errorType" to "EXTENSION_ERROR"))
+
+    captureError(error, ignoredErrorTypes = listOf("EXTENSION_ERROR"))
+
+    verify(exceptionReporter, never()).captureThrowable(any(), any(), any())
+  }
+
+  @Test
+  fun `captures non-ignored error`() {
+    captureError(
+      error(CustomErrorClassification("SOME_ERROR", mapOf("type" to "SPECIFICATION_ERROR"))),
+      ignoredErrorTypes = listOf("OTHER_ERROR"),
+    )
+
+    verify(exceptionReporter).captureThrowable(any(), any(), any())
+  }
+
+  private fun captureError(error: GraphQLError, ignoredErrorTypes: List<String> = emptyList()) {
+    val instrumentation =
+      SentryGraphqlInstrumentation(
+        null,
+        NoOpSubscriptionHandler.getInstance(),
+        exceptionReporter,
+        ignoredErrorTypes,
+        "manual.test",
+      )
+    val result = ExecutionResultImpl.newExecutionResult().addError(error).build()
+
+    instrumentation.instrumentExecutionResultComplete(parameters, result, null)
+  }
+
+  private fun error(errorClassification: ErrorClassification): GraphQLError =
+    GraphqlErrorException.newErrorException()
+      .message("exception message")
+      .errorClassification(errorClassification)
+      .build()
+
+  private class CustomErrorClassification(
+    private val stringValue: String,
+    private val specification: Any?,
+  ) : ErrorClassification {
+    override fun toSpecification(error: GraphQLError): Any? = specification
+
+    override fun toString(): String = stringValue
+  }
+
+  private object ThrowingErrorClassification : ErrorClassification {
+    override fun toSpecification(error: GraphQLError): Any =
+      throw AssertionError("failed to create specification")
+
+    override fun toString(): String = "SOME_ERROR"
+  }
+}


### PR DESCRIPTION
## :scroll: Description

Allow GraphQL `ignored-error-types` to match semantic error classifications exposed through `ErrorClassification.toSpecification(error)`.

The integration now checks:

- the existing `ErrorClassification.toString()` value;
- a string returned directly by `toSpecification(error)`;
- the `"type"` value from a specification map;
- the existing extensions-based fallback when no classification is available.

Malformed or unusable specifications fall back to capturing the error. Non-fatal failures from third-party classification implementations are handled safely, while fatal failures are rethrown through `ExceptionUtils.rethrowIfFatal`.

## :bulb: Motivation and Context

Custom classifications such as those used by `graphql-java-extended-validation` expose their semantic type through a specification map:

```json
{
  "type": "ExtendedValidationError"
}
```

Previously, filtering relied on `ErrorClassification.toString()`, which can return an unstable object identity string. This prevented `ExtendedValidationError` from being configured through `ignored-error-types`.

resolves: #6020
resolves: JAVA-713

## :green_heart: How did you test it?

- Added regression tests covering:
  - legacy `toString()` matching;
  - direct string specifications;
  - map-based `"type"` specifications;
  - `ExtendedValidationError`;
  - null, missing, unexpected, and throwing specifications;
  - extensions fallback;
  - non-ignored error capture.
- Ran all tests for `sentry-graphql-core`, `sentry-graphql`, and `sentry-graphql-22`.
- Ran module-level formatting, API compatibility, Animal Sniffer, and `check` tasks.
- Confirmed no public API dump changes.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

None.