### PR TITLE
fix(android): Anchor the frame-metrics time projection (JAVA-579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Place wall-clock-stamped spans, such as app start spans, on the frame timeline using a fixed anchor, so that a device time change or time spent suspended no longer shifts the frame data attributed to them ([#6098](https://github.com/getsentry/sentry-java/pull/6098))
+
 ## 8.56.0
 
 ### Behavioral Changes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -1,6 +1,5 @@
 package io.sentry.android.core;
 
-import io.sentry.DateUtils;
 import io.sentry.IPerformanceContinuousCollector;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.ISpan;
@@ -12,6 +11,10 @@ import io.sentry.SentryNanotimeDate;
 import io.sentry.SpanDataConvention;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.protocol.MeasurementValue;
+import io.sentry.time.EpochClock;
+import io.sentry.time.JavaMonotonicTicker;
+import io.sentry.time.MonotonicTicker;
+import io.sentry.time.SystemEpochClock;
 import io.sentry.util.AutoClosableReentrantLock;
 import java.util.Iterator;
 import java.util.SortedSet;
@@ -68,12 +71,35 @@ public class SpanFrameMetricsCollector
   // assume 60fps until we get a value reported by the system
   private long lastKnownFrameDurationNanos = 16_666_666L;
 
+  // One wall-clock reading paired with one tick, both taken at construction, used to place
+  // wall-stamped span dates on the frame timeline. See toNanoTime.
+  private final long wallAnchorNanos;
+  private final long tickAnchorNanos;
+
   public SpanFrameMetricsCollector(
       final @NotNull SentryAndroidOptions options,
       final @NotNull SentryFrameMetricsCollector frameMetricsCollector) {
+    // Deliberately not options.getMonotonicTicker(), which is elapsedRealtimeNanos on Android:
+    // frames are stamped by Choreographer on System.nanoTime(), and the two bases drift apart by
+    // however long the device spends suspended.
+    this(
+        options,
+        frameMetricsCollector,
+        SystemEpochClock.getInstance(),
+        JavaMonotonicTicker.getInstance());
+  }
+
+  SpanFrameMetricsCollector(
+      final @NotNull SentryAndroidOptions options,
+      final @NotNull SentryFrameMetricsCollector frameMetricsCollector,
+      final @NotNull EpochClock epochClock,
+      final @NotNull MonotonicTicker frameTicker) {
     this.frameMetricsCollector = frameMetricsCollector;
 
     enabled = options.isEnablePerformanceV2() && options.isEnableFramesTracking();
+
+    this.wallAnchorNanos = epochClock.now().epochNanos();
+    this.tickAnchorNanos = frameTicker.tickNanos();
   }
 
   @Override
@@ -312,18 +338,22 @@ public class SpanFrameMetricsCollector
    * @param date the input date
    * @return a non-unix timestamp in nano precision, similar to {@link System#nanoTime()}.
    */
-  private static long toNanoTime(final @NotNull SentryDate date) {
+  private long toNanoTime(final @NotNull SentryDate date) {
     // SentryNanotimeDate nanotime is based on System.nanotime(), like EMPTY_NANO_TIME,
     // thus diff will simply return the System.nanotime() value of date
     if (date instanceof SentryNanotimeDate) {
       return date.diff(EMPTY_NANO_TIME);
     }
 
-    // e.g. SentryLongDate is unix time based - upscaled to nanos,
-    // we need to project it back to System.nanotime() format
-    long nowUnixInNanos = DateUtils.millisToNanos(System.currentTimeMillis());
-    long shiftInNanos = nowUnixInNanos - date.nanoTimestamp();
-    return System.nanoTime() - shiftInNanos;
+    // e.g. SentryLongDate is unix time based - upscaled to nanos, so it has to be projected onto
+    // the frame timeline. That projection needs the offset between the two clocks, and the offset
+    // is only a constant while nothing disturbs either of them: a wall-clock step moves one, and
+    // time spent suspended moves the other, since System.nanoTime() stops in suspend and the wall
+    // clock does not. Reading the offset here, whenever a span happens to finish, would therefore
+    // charge the span for every step and every suspend since it started - an app start span can
+    // be projected hours away from the frames it actually overlapped. Hold the offset from
+    // construction instead, so a span lands where it did when the SDK started.
+    return tickAnchorNanos + (date.nanoTimestamp() - wallAnchorNanos);
   }
 
   private static class Frame implements Comparable<Frame> {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SpanFrameMetricsCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SpanFrameMetricsCollectorTest.kt
@@ -4,10 +4,15 @@ import io.sentry.ISpan
 import io.sentry.ITransaction
 import io.sentry.NoOpSpan
 import io.sentry.NoOpTransaction
+import io.sentry.SentryLongDate
 import io.sentry.SentryNanotimeDate
 import io.sentry.SpanContext
+import io.sentry.SpanDataConvention
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector
 import io.sentry.protocol.MeasurementValue
+import io.sentry.time.EpochClock
+import io.sentry.time.TestMonotonicTicker
+import io.sentry.time.Timestamp
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
@@ -83,6 +88,44 @@ class SpanFrameMetricsCollectorTest {
   }
 
   private val fixture = Fixture()
+
+  @Test
+  fun `a wall-clock span is placed on the frame timeline using the anchor taken at construction`() {
+    // app start spans are SentryLongDates, stamped on the wall clock rather than on nanoTime
+    val anchorEpochNanos = TimeUnit.SECONDS.toNanos(1_600_000_000)
+    val frameTicker = TestMonotonicTicker()
+
+    whenever(fixture.frameMetricsCollector.startCollection(any()))
+      .thenReturn(UUID.randomUUID().toString())
+    whenever(fixture.frameMetricsCollector.getLastKnownFrameStartTimeNanos()).thenReturn(-1)
+    fixture.options.frameMetricsCollector = fixture.frameMetricsCollector
+    fixture.options.isEnableFramesTracking = true
+    fixture.options.isEnablePerformanceV2 = true
+
+    val sut =
+      SpanFrameMetricsCollector(
+        fixture.options,
+        fixture.frameMetricsCollector,
+        EpochClock { Timestamp.ofEpochNanos(anchorEpochNanos) },
+        frameTicker,
+      )
+
+    val span = mock<ISpan>()
+    whenever(span.spanContext).thenReturn(SpanContext("op.fake"))
+    whenever(span.startDate).thenReturn(SentryLongDate(anchorEpochNanos + 1_000))
+    whenever(span.finishDate).thenReturn(SentryLongDate(anchorEpochNanos + 100_000_000))
+
+    sut.onSpanStarted(span)
+    // one slow frame, on the frame timeline, fully inside the span
+    sut.onFrameMetricCollected(2_000, 50_000_000, 49_998_000, 30_000_000, true, false, 60.0f)
+
+    // the device spends an hour suspended before the span finishes, so the offset between the
+    // wall clock and the frame timeline is no longer what it was when the span started
+    frameTicker.advance(1, TimeUnit.HOURS)
+    sut.onSpanFinished(span)
+
+    verify(span).setData(SpanDataConvention.FRAMES_SLOW, 1)
+  }
 
   @Test
   fun `When AndroidSlowFrozenFrameCollector is initialized, it doesn't register any listener`() {


### PR DESCRIPTION
## :scroll: Description

`SpanFrameMetricsCollector` matches spans against frames, and the frame timeline is stamped by `Choreographer` on `System.nanoTime()`. A span carrying a `SentryNanotimeDate` is already on that timeline and needs no conversion. A wall-stamped span — an app start span built from `TimeSpan`, which is a `SentryLongDate` — has to be projected onto it, and `toNanoTime` did that by reading the offset between the wall clock and `System.nanoTime()` at the moment the span finished:

```java
long nowUnixInNanos = DateUtils.millisToNanos(System.currentTimeMillis());
long shiftInNanos = nowUnixInNanos - date.nanoTimestamp();
return System.nanoTime() - shiftInNanos;
```

That offset is not a constant. A wall-clock step (NTP, carrier, user) moves one clock, and time spent suspended moves the other, because `System.nanoTime()` stops in suspend on Android while the wall clock keeps going. Reading it at finish time therefore charged the span for every step and every suspend that happened since it started, placing it — and the `frames_slow` / `frames_frozen` / `frames_delay` data derived from it — away from the frames it actually overlapped. An app start span that outlives a doze is off by the length of the doze.

This takes one wall reading and one tick at construction and projects through that fixed anchor instead, so a span lands where it did when the SDK started rather than where the accumulated drift puts it.

Note the anchor deliberately uses `JavaMonotonicTicker` (`System.nanoTime()`) rather than `options.getMonotonicTicker()`, which is `elapsedRealtimeNanos()` on Android. The frame timeline is `nanoTime`, so the anchor has to be on the same base; there is a comment saying so at the call site.

## :bulb: Motivation and Context

Audit finding §C5 from the clock-usage audit.

* resolves: JAVA-579 (partially — §C5 only)
* part of: #5582

## :green_heart: How did you test it?

A unit test in `SpanFrameMetricsCollectorTest` drives a wall-stamped (`SentryLongDate`) span with one slow frame inside it, advances the frame ticker by an hour between the span starting and finishing, and asserts the frame is still attributed to the span. Verified that this test fails against the old `toNanoTime` body and passes with the anchor. The existing 16 tests in the class are unchanged and still pass — they all use `SentryNanotimeDate` spans, which take the untouched fast path.

The projection is now injectable (a package-private constructor taking an `EpochClock` and a `MonotonicTicker`), which is what makes the drift testable at all — previously both clock reads were static calls inside the method.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :link: Relationship to #6055

#6055 rewrites this same method, so the two will conflict textually — but they fix different branches, and this one is not superseded by it.

#6055 splits `toNanoTime` on whether the span has an anchor. Anchored spans invert the anchor exactly; everything else falls through to the old wall-clock projection, **kept verbatim**, live offset read and all. Its own comment names "an app-start projection" as a case that lands in that fallback, which is precisely the `SentryLongDate`-from-`TimeSpan` span this PR is about. So after #6055 the bug fixed here is still present, on the only path app-start spans take.

The other direction matters too: #6055's anchored branch inverts a tick on `MonotonicTicker`, which is `CLOCK_BOOTTIME` on Android, while frames are `CLOCK_MONOTONIC` — a new timebase mismatch that it documents as an unbridged TODO. This PR avoids that by anchoring on `JavaMonotonicTicker` (`System.nanoTime()`), the same timebase as the frames.

Suggested order: this lands first (targets `main`, changes no serialized value, mergeable now), and #6055 — a DO-NOT-MERGE demonstrator with no `9.x` branch to target yet — carries the frozen anchor into its fallback branch when it rebases.

Worth noting that #6055's TODO argues a span that crossed deep sleep should be *skipped* rather than shifted, since there are no frames during sleep. That is a reasonable position, and a different one from this PR's, which narrows the error rather than eliminating it: the frozen anchor puts the span's start where it belongs, but the projected end of a doze-crossing span still overshoots by the length of the doze. Dropping such launches outright is JAVA-642's call.

## :crystal_ball: Next steps

This does not change any serialized timestamp — only which frames a span is credited with — so it is not gated behind the v9 work. §C4 (`TimeSpan` back-projection), which produces the wall-stamped dates this code has to project, does change serialized app-start timestamps and is v9-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

