### PR TITLE
ref(core): Measure the performance-collection budget on a monotonic ticker (JAVA-579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- Measure the 30 second performance-collection budget on a monotonic ticker, so that a device time change no longer ends collection early or extends it past the budget ([#6101](https://github.com/getsentry/sentry-java/pull/6101))
+
 ## 8.56.0
 
 ### Behavioral Changes

--- a/sentry-test-support/src/main/kotlin/io/sentry/time/TestMonotonicTicker.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/time/TestMonotonicTicker.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
  * nanosecond ticker is off by a factor of a million and still compiles, whereas `advance(1001,
  * MILLISECONDS)` cannot be.
  */
-class TestMonotonicTicker(private var nanos: Long = 0) : MonotonicTicker {
+class TestMonotonicTicker(@Volatile private var nanos: Long = 0) : MonotonicTicker {
   override fun tickNanos(): Long = nanos
 
   fun advance(amount: Long, unit: TimeUnit) {

--- a/sentry/src/main/java/io/sentry/DefaultCompositePerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultCompositePerformanceCollector.java
@@ -1,5 +1,7 @@
 package io.sentry;
 
+import io.sentry.time.Deadline;
+import io.sentry.time.MonotonicTicker;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
@@ -26,10 +28,19 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
   private final boolean hasNoCollectors;
 
   private final @NotNull SentryOptions options;
+  private final @NotNull MonotonicTicker ticker;
   private final @NotNull AtomicBoolean isStarted = new AtomicBoolean(false);
 
   public DefaultCompositePerformanceCollector(final @NotNull SentryOptions options) {
+    this(
+        Objects.requireNonNull(options, "The options object is required."),
+        options.getMonotonicTicker());
+  }
+
+  DefaultCompositePerformanceCollector(
+      final @NotNull SentryOptions options, final @NotNull MonotonicTicker ticker) {
     this.options = Objects.requireNonNull(options, "The options object is required.");
+    this.ticker = Objects.requireNonNull(ticker, "The ticker is required.");
     this.snapshotCollectors = new ArrayList<>();
     this.continuousCollectors = new ArrayList<>();
 
@@ -124,7 +135,7 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
                 // Add the enriched tempData to all transactions/profiles/objects that collect data.
                 // Then Check if that object timed out.
                 for (CompositeData data : compositeDataMap.values()) {
-                  if (data.addDataAndCheckTimeout(tempData, tempData.getNanoTimestamp())) {
+                  if (data.addDataAndCheckTimeout(tempData)) {
                     // timed out
                     if (data.transaction != null) {
                       timedOutTransactions.add(data.transaction);
@@ -212,33 +223,30 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
   private class CompositeData {
     private final @NotNull List<PerformanceCollectionData> dataList;
     private final @Nullable ITransaction transaction;
-    private final long startTimestamp;
+    private final @NotNull Deadline collectUntil;
 
     private CompositeData(final @Nullable ITransaction transaction) {
       this.dataList = new ArrayList<>();
       this.transaction = transaction;
-      this.startTimestamp = options.getDateProvider().now().nanoTimestamp();
+      // On a ticker rather than the date provider: this is how long we have been collecting, and
+      // a device time change must not end a collection early or keep a finished one going.
+      this.collectUntil =
+          Deadline.after(ticker, TRANSACTION_COLLECTION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     /**
      * Adds the data to the internal list of PerformanceCollectionData. Then it checks if data
      * collection timed out (for transactions only).
      *
-     * @param nowNanos the timestamp of the current collection, passed in so a single clock reading
-     *     is shared by every transaction in this collection round.
      * @return true if data collection timed out (for transactions only).
      */
-    boolean addDataAndCheckTimeout(
-        final @NotNull PerformanceCollectionData data, final long nowNanos) {
+    boolean addDataAndCheckTimeout(final @NotNull PerformanceCollectionData data) {
       // stop() hands dataList out while this timer thread may still be writing to it, so consumers
       // synchronize on the list while iterating. We must hold the same monitor here.
       synchronized (dataList) {
         dataList.add(data);
       }
-      return transaction != null
-          && nowNanos
-              > startTimestamp
-                  + TimeUnit.MILLISECONDS.toNanos(TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
+      return transaction != null && collectUntil.hasPassed();
     }
   }
 }

--- a/sentry/src/test/java/io/sentry/DefaultCompositePerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/DefaultCompositePerformanceCollectorTest.kt
@@ -3,6 +3,7 @@ package io.sentry
 import io.sentry.test.getCtor
 import io.sentry.test.getProperty
 import io.sentry.test.injectForField
+import io.sentry.time.TestMonotonicTicker
 import io.sentry.util.thread.ThreadChecker
 import java.util.Timer
 import java.util.concurrent.TimeUnit
@@ -34,6 +35,7 @@ class DefaultCompositePerformanceCollectorTest {
     val id1 = "id1"
     val scopes: IScopes = mock()
     val options = SentryOptions()
+    val ticker = TestMonotonicTicker()
     var mockTimer: Timer? = null
 
     val mockCpuCollector: IPerformanceSnapshotCollector =
@@ -65,7 +67,7 @@ class DefaultCompositePerformanceCollectorTest {
       optionsConfiguration.configure(options)
       transaction1 = SentryTracer(TransactionContext("", ""), scopes)
       transaction2 = SentryTracer(TransactionContext("", ""), scopes)
-      val collector = DefaultCompositePerformanceCollector(options)
+      val collector = DefaultCompositePerformanceCollector(options, ticker)
       val timer: Timer = collector.getProperty("timer") ?: Timer(true)
       mockTimer = spy(timer)
       collector.injectForField("timer", mockTimer)
@@ -183,26 +185,19 @@ class DefaultCompositePerformanceCollectorTest {
 
   @Test
   fun `collector times out after 30 seconds`() {
-    val mockDateProvider = mock<SentryDateProvider>()
     val mockCollector = mock<IPerformanceContinuousCollector>()
-    val dates =
-      listOf(
-        SentryNanotimeDate(TimeUnit.SECONDS.toMillis(100), TimeUnit.SECONDS.toNanos(100)),
-        SentryNanotimeDate(TimeUnit.SECONDS.toMillis(131), TimeUnit.SECONDS.toNanos(131)),
-      )
-    whenever(mockDateProvider.now()).thenReturn(dates[0], dates[0], dates[0], dates[1])
-    val collector = fixture.getSut {
-      it.dateProvider = mockDateProvider
-      it.addPerformanceCollector(mockCollector)
-    }
+    val collector = fixture.getSut { it.addPerformanceCollector(mockCollector) }
     collector.start(fixture.transaction1)
     verify(fixture.mockTimer, never())!!.cancel()
+
+    // 31 seconds of collecting have gone by
+    fixture.ticker.advance(31, TimeUnit.SECONDS)
 
     // Let's sleep to make the collector get values
     Thread.sleep(300)
 
-    // When the collector gets the values, it checks the current date, set 31 seconds after the
-    // begin. This means it should stop itself
+    // When the collector gets the values, it checks how long it has been collecting for, which is
+    // now past the 30 second budget. This means it should stop itself
     verify(fixture.mockTimer)!!.cancel()
 
     // When the collector times out, the data collection for spans is stopped, too
@@ -214,23 +209,18 @@ class DefaultCompositePerformanceCollectorTest {
   }
 
   @Test
-  fun `collector collects for 30 seconds`() {
-    val mockDateProvider = mock<SentryDateProvider>()
-    val dates =
-      listOf(
-        SentryNanotimeDate(TimeUnit.SECONDS.toMillis(100), TimeUnit.SECONDS.toNanos(100)),
-        SentryNanotimeDate(TimeUnit.SECONDS.toMillis(130), TimeUnit.SECONDS.toNanos(130)),
-      )
-    whenever(mockDateProvider.now()).thenReturn(dates[0], dates[0], dates[0], dates[1])
-    val collector = fixture.getSut { it.dateProvider = mockDateProvider }
+  fun `collector keeps collecting while inside the 30 second budget`() {
+    val collector = fixture.getSut()
     collector.start(fixture.transaction1)
     verify(fixture.mockTimer, never())!!.cancel()
+
+    // 29 seconds of collecting have gone by
+    fixture.ticker.advance(29, TimeUnit.SECONDS)
 
     // Let's sleep to make the collector get values
     Thread.sleep(300)
 
-    // When the collector gets the values, it checks the current date, set 30 seconds after the
-    // begin. This means it should continue without being cancelled
+    // Still inside the 30 second budget, so it should continue without being cancelled
     verify(fixture.mockTimer, never())!!.cancel()
 
     // Data is deleted after the collector times out


### PR DESCRIPTION
## :scroll: Description

`DefaultCompositePerformanceCollector` decided a transaction had been collecting for 30 seconds by subtracting two `options.getDateProvider()` readings:

```java
this.startTimestamp = options.getDateProvider().now().nanoTimestamp();
// ...
return transaction != null
    && nowNanos > startTimestamp + TimeUnit.MILLISECONDS.toNanos(TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
```

Those readings are wall-clock on every platform, including Android. It looks like it might be monotonic because `SentryNanotimeDate` carries a `System.nanoTime()` component, but `nanoTimestamp()` returns `DateUtils.millisToNanos(unixDateMillis)` — the nanoTime component is only used by `diff()`, which this code does not call. So the extra precision that type exists for never entered this comparison, and a device time change either ended collection early or kept it running well past the budget.

Each `CompositeData` now holds a `Deadline` on a `MonotonicTicker`. The budget is not a serialized value — it only decides when the collector stops — so this is not gated behind the v9 work.

Note the sample timestamps themselves (`new PerformanceCollectionData(options.getDateProvider().now().nanoTimestamp())`) are deliberately untouched: those *are* serialized into profile measurements, and re-anchoring them is §C1 / JAVA-578.

## :bulb: Motivation and Context

Audit finding §C6 from the clock-usage audit, which lists four wall-clock TTL/cleanup sites. This is one of them. See "Next steps" for where the other three went.

* resolves: JAVA-579 (partially — the performance-collection budget only)
* part of: #5582

## :green_heart: How did you test it?

The two existing 30 second tests in `DefaultCompositePerformanceCollectorTest` now advance a ticker instead of stubbing `dateProvider.now()` with a positional sequence of four return values:

```kotlin
whenever(mockDateProvider.now()).thenReturn(dates[0], dates[0], dates[0], dates[1])
```

That was brittle against any change in how often the date provider gets called, and it is what let the wall-clock dependency sit here unnoticed. All 20 tests in the class pass.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

Three details worth a reviewer's eye:

1. The 30 second boundary is now **inclusive** — `Deadline.hasPassed()` is `>=`, where the old comparison was a strict `>`. A sample landing exactly on 30.000s now ends collection instead of being kept.
2. `addDataAndCheckTimeout` no longer takes a shared `nowNanos`. That parameter existed so one clock reading was shared across every transaction in a collection round; with a per-transaction `Deadline` there is nothing to share, and the nanosecond spread across one loop cannot matter to a 30 second budget. Say the word if you would rather keep the shared reading.
3. `TestMonotonicTicker`'s backing field is now `@Volatile`, because the collector's timer thread reads a ticker that the test thread advances. (The companion `HostnameCache` PR does not need this — `executorService.submit` gives that path a happens-before edge.)

## :crystal_ball: Next steps

§C6 also mentions the 100ms sampling loop in this same class running on `java.util.Timer`, whose deadlines are wall-clock and whose `Object.wait()` does not progress in Android deep sleep. Deliberately not in this PR: it is a scheduling change rather than a TTL one, it needs either a periodic API on `ISentryExecutorService` or a self-rescheduling task, and six tests in this class assert directly against an injected mock `Timer`. It deserves its own review.

The other two §C6 sites — profiling-trace cleanup in `Sentry.java` and envelope rotation in `CacheStrategy` — both compare against `File.lastModified()`, which is inherently a wall-clock value written by another process; there is no monotonic quantity to compare it against, so they are not fixable as stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
