### PR TITLE
ref(android): Deprecate AndroidCurrentDateProvider (JAVA-728)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### Internal
 
-- Deprecate `AndroidCurrentDateProvider` in favor of `MonotonicTicker`, which counts time spent in deep sleep and cannot be confused with the epoch-based `CurrentDateProvider` ([#6103](https://github.com/getsentry/sentry-java/pull/6103))
+- Deprecate `AndroidCurrentDateProvider.getInstance()` in favor of `MonotonicTicker`, which counts time spent in deep sleep and cannot be confused with the epoch-based `CurrentDateProvider` ([#6103](https://github.com/getsentry/sentry-java/pull/6103))
 
 ## 8.56.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 - Sentry can now configure Log4j2 automatically for Spring Boot 3 when `sentry-log4j2` is on the classpath and Log4j2 Core is the active logging backend ([#6072](https://github.com/getsentry/sentry-java/pull/6072))
   - Disabled by default for now; enable it and configure levels the same way as described in the Spring Boot 4 entry above (`sentry.logging.enabled=true`)
 
+### Internal
+
+- Deprecate `AndroidCurrentDateProvider.getInstance()` in favor of `MonotonicTicker`, which counts time spent in deep sleep and cannot be confused with the epoch-based `CurrentDateProvider` ([#6103](https://github.com/getsentry/sentry-java/pull/6103))
+
 ## 8.56.0
 
 ### Behavioral Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### Internal
 
-- Deprecate `AndroidCurrentDateProvider.getInstance()` in favor of `MonotonicTicker`, which counts time spent in deep sleep and cannot be confused with the epoch-based `CurrentDateProvider` ([#6103](https://github.com/getsentry/sentry-java/pull/6103))
+- Deprecate `AndroidCurrentDateProvider` in favor of `MonotonicTicker`, which counts time spent in deep sleep and cannot be confused with the epoch-based `CurrentDateProvider` ([#6103](https://github.com/getsentry/sentry-java/pull/6103))
 
 ## 8.56.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -12,6 +12,7 @@ import io.sentry.IScopes;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.android.core.internal.util.DeviceOrientations;
 import io.sentry.protocol.Device;
@@ -36,10 +37,7 @@ public final class AppComponentsBreadcrumbsIntegration
   // TODO: JAVA-729
   @SuppressWarnings("deprecation")
   private final @NotNull Debouncer trimMemoryDebouncer =
-      new Debouncer(
-          io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
-          DEBOUNCE_WAIT_TIME_MS,
-          0);
+      new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
 
   public AppComponentsBreadcrumbsIntegration(final @NotNull Context context) {
     this.context =

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -34,6 +34,8 @@ public final class AppComponentsBreadcrumbsIntegration
   private @Nullable IScopes scopes;
   private @Nullable SentryAndroidOptions options;
 
+  // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+  @SuppressWarnings("deprecation")
   private final @NotNull Debouncer trimMemoryDebouncer =
       new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -12,7 +12,6 @@ import io.sentry.IScopes;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
-import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.android.core.internal.util.DeviceOrientations;
 import io.sentry.protocol.Device;
@@ -34,10 +33,13 @@ public final class AppComponentsBreadcrumbsIntegration
   private @Nullable IScopes scopes;
   private @Nullable SentryAndroidOptions options;
 
-  // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+  // TODO: JAVA-729
   @SuppressWarnings("deprecation")
   private final @NotNull Debouncer trimMemoryDebouncer =
-      new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
+      new Debouncer(
+          io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
+          DEBOUNCE_WAIT_TIME_MS,
+          0);
 
   public AppComponentsBreadcrumbsIntegration(final @NotNull Context context) {
     this.context =

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -47,6 +47,8 @@ public final class ScreenshotEventProcessor implements EventProcessor {
   private final boolean isReplayAvailable;
   private final AtomicBoolean isReplayModuleAbsenceLogged = new AtomicBoolean(false);
 
+  // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+  @SuppressWarnings("deprecation")
   public ScreenshotEventProcessor(
       final @NotNull SentryAndroidOptions options,
       final @NotNull BuildInfoProvider buildInfoProvider,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -12,7 +12,6 @@ import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
-import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.android.core.internal.util.ScreenshotUtils;
 import io.sentry.android.replay.util.MaskRenderer;
@@ -47,7 +46,7 @@ public final class ScreenshotEventProcessor implements EventProcessor {
   private final boolean isReplayAvailable;
   private final AtomicBoolean isReplayModuleAbsenceLogged = new AtomicBoolean(false);
 
-  // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+  // TODO: JAVA-729
   @SuppressWarnings("deprecation")
   public ScreenshotEventProcessor(
       final @NotNull SentryAndroidOptions options,
@@ -58,7 +57,7 @@ public final class ScreenshotEventProcessor implements EventProcessor {
         Objects.requireNonNull(buildInfoProvider, "BuildInfoProvider is required");
     this.debouncer =
         new Debouncer(
-            AndroidCurrentDateProvider.getInstance(),
+            io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
             DEBOUNCE_WAIT_TIME_MS,
             DEBOUNCE_MAX_EXECUTIONS);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -12,6 +12,7 @@ import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
+import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.android.core.internal.util.ScreenshotUtils;
 import io.sentry.android.replay.util.MaskRenderer;
@@ -57,7 +58,7 @@ public final class ScreenshotEventProcessor implements EventProcessor {
         Objects.requireNonNull(buildInfoProvider, "BuildInfoProvider is required");
     this.debouncer =
         new Debouncer(
-            io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
+            AndroidCurrentDateProvider.getInstance(),
             DEBOUNCE_WAIT_TIME_MS,
             DEBOUNCE_MAX_EXECUTIONS);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -298,6 +298,9 @@ public final class SystemEventsBreadcrumbsIntegration
     private static final long DEBOUNCE_WAIT_TIME_MS = 60 * 1000;
     private final @NotNull IScopes scopes;
     private final @NotNull SentryAndroidOptions options;
+
+    // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+    @SuppressWarnings("deprecation")
     private final @NotNull Debouncer batteryChangedDebouncer =
         new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -35,6 +35,7 @@ import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
@@ -301,10 +302,7 @@ public final class SystemEventsBreadcrumbsIntegration
     // TODO: JAVA-729
     @SuppressWarnings("deprecation")
     private final @NotNull Debouncer batteryChangedDebouncer =
-        new Debouncer(
-            io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
-            DEBOUNCE_WAIT_TIME_MS,
-            0);
+        new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
 
     SystemEventsBroadcastReceiver(
         final @NotNull IScopes scopes, final @NotNull SentryAndroidOptions options) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -35,7 +35,6 @@ import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
-import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
@@ -299,10 +298,13 @@ public final class SystemEventsBreadcrumbsIntegration
     private final @NotNull IScopes scopes;
     private final @NotNull SentryAndroidOptions options;
 
-    // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+    // TODO: JAVA-729
     @SuppressWarnings("deprecation")
     private final @NotNull Debouncer batteryChangedDebouncer =
-        new Debouncer(AndroidCurrentDateProvider.getInstance(), DEBOUNCE_WAIT_TIME_MS, 0);
+        new Debouncer(
+            io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
+            DEBOUNCE_WAIT_TIME_MS,
+            0);
 
     SystemEventsBroadcastReceiver(
         final @NotNull IScopes scopes, final @NotNull SentryAndroidOptions options) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -14,6 +14,7 @@ import io.sentry.ISerializer;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.gestures.ViewUtils;
+import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.internal.util.ClassUtil;
 import io.sentry.android.core.internal.util.Debouncer;
@@ -51,7 +52,7 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
     this.options = Objects.requireNonNull(options, "SentryAndroidOptions is required");
     this.debouncer =
         new Debouncer(
-            io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
+            AndroidCurrentDateProvider.getInstance(),
             DEBOUNCE_WAIT_TIME_MS,
             DEBOUNCE_MAX_EXECUTIONS);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -46,6 +46,8 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
   private static final long DEBOUNCE_WAIT_TIME_MS = 2000;
   private static final int DEBOUNCE_MAX_EXECUTIONS = 3;
 
+  // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+  @SuppressWarnings("deprecation")
   public ViewHierarchyEventProcessor(final @NotNull SentryAndroidOptions options) {
     this.options = Objects.requireNonNull(options, "SentryAndroidOptions is required");
     this.debouncer =

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -14,7 +14,6 @@ import io.sentry.ISerializer;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.gestures.ViewUtils;
-import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.internal.util.ClassUtil;
 import io.sentry.android.core.internal.util.Debouncer;
@@ -46,13 +45,13 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
   private static final long DEBOUNCE_WAIT_TIME_MS = 2000;
   private static final int DEBOUNCE_MAX_EXECUTIONS = 3;
 
-  // Debouncer measures on the uptime clock; moving it to MonotonicTicker changes behavior.
+  // TODO: JAVA-729
   @SuppressWarnings("deprecation")
   public ViewHierarchyEventProcessor(final @NotNull SentryAndroidOptions options) {
     this.options = Objects.requireNonNull(options, "SentryAndroidOptions is required");
     this.debouncer =
         new Debouncer(
-            AndroidCurrentDateProvider.getInstance(),
+            io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance(),
             DEBOUNCE_WAIT_TIME_MS,
             DEBOUNCE_MAX_EXECUTIONS);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -38,6 +38,9 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
 
   private final @NotNull ICurrentDateProvider currentDateProvider;
 
+  // Pairs with TimeSpan.getStartUptimeMs(), which is SystemClock.uptimeMillis() too, so this
+  // site cannot move to MonotonicTicker on its own without mixing two clock bases.
+  @SuppressWarnings("deprecation")
   public AndroidEnvelopeCache(final @NotNull SentryAndroidOptions options) {
     this(options, AndroidCurrentDateProvider.getInstance());
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -11,7 +11,6 @@ import io.sentry.UncaughtExceptionHandlerIntegration;
 import io.sentry.android.core.AnrV2Integration;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.android.core.TombstoneIntegration;
-import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.cache.EnvelopeCache;
@@ -38,11 +37,10 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
 
   private final @NotNull ICurrentDateProvider currentDateProvider;
 
-  // Pairs with TimeSpan.getStartUptimeMs(), which is SystemClock.uptimeMillis() too, so this
-  // site cannot move to MonotonicTicker on its own without mixing two clock bases.
+  // TODO: JAVA-729
   @SuppressWarnings("deprecation")
   public AndroidEnvelopeCache(final @NotNull SentryAndroidOptions options) {
-    this(options, AndroidCurrentDateProvider.getInstance());
+    this(options, io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance());
   }
 
   AndroidEnvelopeCache(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -11,6 +11,7 @@ import io.sentry.UncaughtExceptionHandlerIntegration;
 import io.sentry.android.core.AnrV2Integration;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.android.core.TombstoneIntegration;
+import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.cache.EnvelopeCache;
@@ -40,7 +41,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
   // TODO: JAVA-729
   @SuppressWarnings("deprecation")
   public AndroidEnvelopeCache(final @NotNull SentryAndroidOptions options) {
-    this(options, io.sentry.android.core.internal.util.AndroidCurrentDateProvider.getInstance());
+    this(options, AndroidCurrentDateProvider.getInstance());
   }
 
   AndroidEnvelopeCache(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
@@ -11,18 +11,15 @@ import org.jetbrains.annotations.ApiStatus;
  * call site declaring the interface accepts either, and the two disagree by however long the device
  * has been suspended.
  *
- * <p>Superseded by {@link io.sentry.time.MonotonicTicker}, which counts deep sleep and says in its
- * name that only differences between its own ticks are meaningful.
+ * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval. It counts deep
+ *     sleep, and says in its name that only differences between its own ticks are meaningful.
  */
+@Deprecated
 @ApiStatus.Internal
 public final class AndroidCurrentDateProvider implements ICurrentDateProvider {
 
   private static final ICurrentDateProvider instance = new AndroidCurrentDateProvider();
 
-  /**
-   * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval.
-   */
-  @Deprecated
   public static ICurrentDateProvider getInstance() {
     return instance;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
@@ -11,15 +11,20 @@ import org.jetbrains.annotations.ApiStatus;
  * call site declaring the interface accepts either, and the two disagree by however long the device
  * has been suspended.
  *
- * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval. It counts deep
- *     sleep, and says in its name that only differences between its own ticks are meaningful.
+ * <p>Superseded by {@link io.sentry.time.MonotonicTicker}, which counts deep sleep and says in its
+ * name that only differences between its own ticks are meaningful. The annotation sits on {@link
+ * #getInstance()}, the only way in, because a deprecated type warns on every import and an import
+ * cannot carry a {@code @SuppressWarnings}.
  */
-@Deprecated
 @ApiStatus.Internal
 public final class AndroidCurrentDateProvider implements ICurrentDateProvider {
 
   private static final ICurrentDateProvider instance = new AndroidCurrentDateProvider();
 
+  /**
+   * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval.
+   */
+  @Deprecated
   public static ICurrentDateProvider getInstance() {
     return instance;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidCurrentDateProvider.java
@@ -4,11 +4,25 @@ import android.os.SystemClock;
 import io.sentry.transport.ICurrentDateProvider;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * An uptime clock: {@link SystemClock#uptimeMillis()} excludes time the device spent in deep sleep,
+ * which neither the name nor the {@link ICurrentDateProvider} type says. {@link
+ * io.sentry.transport.CurrentDateProvider} implements that same type with epoch milliseconds, so a
+ * call site declaring the interface accepts either, and the two disagree by however long the device
+ * has been suspended.
+ *
+ * <p>Superseded by {@link io.sentry.time.MonotonicTicker}, which counts deep sleep and says in its
+ * name that only differences between its own ticks are meaningful.
+ */
 @ApiStatus.Internal
 public final class AndroidCurrentDateProvider implements ICurrentDateProvider {
 
   private static final ICurrentDateProvider instance = new AndroidCurrentDateProvider();
 
+  /**
+   * @deprecated use {@link io.sentry.time.MonotonicTicker} to measure an interval.
+   */
+  @Deprecated
   public static ICurrentDateProvider getInstance() {
     return instance;
   }


### PR DESCRIPTION
## :scroll: Description

Deprecates `AndroidCurrentDateProvider.getInstance()` in favor of `io.sentry.time.MonotonicTicker`, and documents the replacement in the type's javadoc.

JAVA-729 tracks the removal.

### Why the annotation is on `getInstance()` and not on the type

We can't add a `SuppressWarnings` on the imports so I just added it on `getInstance` since it is the only way in to the class.

### Verification

well, it compiles

## :bulb: Motivation and Context



It is super confusing. `ICurrentDateProvider` has two implementation, one which returns `System.currentTimeMillis` - a wall clock - and this one which returns `SystemClock.uptimeMillis()` - a monotonic clock.

* resolves: #6102
* resolves: JAVA-728

## :green_heart: How did you test it?

See "Verification" above.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

JAVA-729 migrates the five call sites off the deprecated provider. The `Debouncer` sites are a behavior change (the debounce interval starts counting deep sleep), and `AndroidEnvelopeCache` is coupled to `TimeSpan`'s uptime base, so it cannot move alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
